### PR TITLE
fix setups after traumatic reboot

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+export DJANGO_SETTINGS_MODULE='paying_for_college.config.settings.standalone'

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The app is set up to run as a component of CFPB's website, [consumerfinance.gov]
 ### Running tests
 You can run python tests from the project root with this command:
 ```bash
-. pytest.sh
+./pytest.sh
 ```
 
 <!-- INCLUDE IN setup.sh

--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ setvirtualenvproject
 ```bash
 ./local_setup.sh
 ```
-- Move to the `paying_for_college` directory and fire up a local server:
+- Fire up a local server:
 ```bash
-cd 'paying_for_college'
 python manage.py runserver
 ```
 

--- a/local_setup.sh
+++ b/local_setup.sh
@@ -9,7 +9,7 @@ set -e
 # Install project dependencies.
 install(){
   echo 'Installing project dependencies...'
-  pip install -r requirements/base.txt
+  pip install -r requirements/testing.txt
   # npm install
   # grunt build
 
@@ -17,12 +17,12 @@ install(){
 
 # Setup local data store in sqlite3
 dbsetup(){
+  source .env
   echo 'Loading college data into local test database'
   python manage.py makemigrations
   python manage.py migrate
-  python manage.py loaddata colleges.json
-  python manage.py collectstatic --noinput
-#  python manage.py rebuild_index
+  python manage.py loaddata collegedata.json
+  # python manage.py rebuild_index
 }
 
 install

--- a/paying_for_college/.env
+++ b/paying_for_college/.env
@@ -1,1 +1,0 @@
-export DJANGO_SETTINGS_MODULE='config.settings.standalone'

--- a/paying_for_college/config/settings/base.py
+++ b/paying_for_college/config/settings/base.py
@@ -70,7 +70,7 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = 'config.wsgi.application'
+WSGI_APPLICATION = 'paying_for_college.config.wsgi.application'
 
 LANGUAGE_CODE = 'en-us'
 
@@ -83,9 +83,5 @@ USE_L10N = True
 USE_TZ = True
 
 STATIC_URL = '/static/'
-STATIC_ROOT = PROJECT_ROOT.child('static')
+# STATIC_ROOT = PROJECT_ROOT.child('static')
 MEDIA_URL = "http://files.consumerfinance.gov/f/theme/"
-
-STATICFILES_DIRS = (
-    PROJECT_ROOT.child('static_built'),
-)

--- a/paying_for_college/config/urls.py
+++ b/paying_for_college/config/urls.py
@@ -2,20 +2,35 @@ from django.conf.urls import url, include
 from django.conf import settings
 from paying_for_college.views import LandingView
 from django.contrib import admin
-# from django.conf.urls.static import static
+from django.conf import settings
+try:
+    STANDALONE = settings.STANDALONE
+except AttributeError:  # pragma: no cover
+    STANDALONE = False
 
 urlpatterns = [
     # url(r'^admin/', include(admin.site.urls)),
     url(r'^$',
         LandingView.as_view(), name='pfc-landing'),
     url(r'^compare-financial-aid-and-college-cost/',
-        include('paying_for_college.disclosures.urls', namespace='disclosures')),
+        include('paying_for_college.disclosures.urls',
+                namespace='disclosures')),
     url(r'^repay-student-debt/',
         include('paying_for_college.debt.urls', namespace='debt')),
     url(r'^guides/',
         include('paying_for_college.guides.urls', namespace='guides')),
 ]
 
-# if settings.DEBUG:
-#     urlpatterns += static(settings.STATIC_URL,
-#                           document_root=settings.STATIC_ROOT)
+if STANDALONE:
+    urlpatterns += [
+    url(r'^paying-for-college/$',
+        LandingView.as_view(), name='standalone:pfc-landing'),
+    url(r'^paying-for-college/compare-financial-aid-and-college-cost/',
+        include('paying_for_college.disclosures.urls',
+                namespace='standalone-disclosures')),
+    url(r'^paying-for-college/repay-student-debt/',
+        include('paying_for_college.debt.urls', namespace='standalone-debt')),
+    url(r'^paying-for-college/guides/',
+        include('paying_for_college.guides.urls', namespace='standalone-guides')),
+
+    ]

--- a/paying_for_college/config/wsgi.py
+++ b/paying_for_college/config/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.test")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "paying_for_college.config.settings.test")
 
 application = get_wsgi_application()


### PR DESCRIPTION
This should set the standalone version on its feet again after the layout reboot. 
## Changes
- config and script adjustments to match new site layout
## Review
- @ascott1 @marteki
