### PR TITLE
Add responsive header and footer to standalone Django template

### DIFF
--- a/paying_for_college/config/urls.py
+++ b/paying_for_college/config/urls.py
@@ -24,6 +24,9 @@ urlpatterns = [
     url(r'^managing-college-money/$',
         StandAloneView.as_view(template_name='manage_your_money.html'),
         name='pfc-manage'),
+    url(r'^demo/$',
+        StandAloneView.as_view(template_name='just-a-demo.html'),
+        name='pfc-demo'),
 ]
 
 if STANDALONE:
@@ -43,4 +46,7 @@ if STANDALONE:
     url(r'^paying-for-college/managing-college-money/$',
         StandAloneView.as_view(template_name='manage_your_money.html'),
         name='standalone-pfc-manage'),
+    url(r'^paying-for-college/demo/$',
+        StandAloneView.as_view(template_name='just-a-demo.html'),
+        name='standalone-pfc-demo'),
     ]

--- a/paying_for_college/templates/just-a-demo.html
+++ b/paying_for_college/templates/just-a-demo.html
@@ -1,0 +1,86 @@
+{% extends base_template %}
+{% load staticfiles %}
+{% block title %}ust a demo!{% endblock %}
+{% block app_css %}
+  <link rel="stylesheet" type="text/css" href="{% static "paying_for_college/disclosures/static/css/main.min.css" %}">
+{% endblock %}
+{% block content %}
+<h1>Paying for College</h1>
+<h2>Student Debt Calculator Demo</h2>
+<button id="add-random">Add random demo values!</button>
+<div class="financial-inputs">
+  <!-- Costs of Attendance -->
+  <label for="costs__tuition">Tuition
+    <input type="text" name="costs__tuition" data-financial="tuitionFees">
+  </label>
+  <label for="costs__room-and-board">Room and Board
+    <input type="text" name="costs__room-and-board" data-financial="roomBoard">
+  </label>
+  <label for="costs__books">Books
+    <input type="text" name="costs__books" data-financial="books">
+  </label>
+  <label for="costs__other">Other
+    <input type="text" name="costs__other" data-financial="otherExpenses">
+  </label>
+  <label for="costs__transportation">Transportation
+    <input type="text" name="costs__transportation" data-financial="transportation">
+  </label>
+
+  <!-- Grants & Scholarships -->
+  <label for="grants__pell">Federal Pell Grant
+    <input type="text" name="grants__pell" data-financial="pell">
+  </label>
+  <label for="grants__scholarships">Scholarships
+    <input type="text" name="grants__scholarships" data-financial="scholarships">
+  </label>
+
+  <!-- Contributions -->
+  <label for="contrib__savings">Personal Savings
+    <input type="text" name="contrib__savings" data-financial="savings">
+  </label>
+  <label for="contrib__family">Family Contributions
+    <input type="text" name="contrib__family" data-financial="family">
+  </label>
+  <label for="contrib__state529plan">Parent Loans (529 Plan)
+    <input type="text" name="contrib__state529plan" data-financial="state529plan">
+  </label>
+  <label for="contrib__workstudy">Work Study
+    <input type="text" name="contrib__workstudy" data-financial="workstudy">
+  </label>
+
+  <!-- Contributions -->
+  <label for="contrib__perkins">Perkins
+    <input type="text" name="contrib__perkins" data-financial="perkins">
+  </label>
+  <label for="contrib__staffsubsidized">Subsidized loan 
+    <input type="text" name="contrib__subsidized" data-financial="staffSubsidized">
+  </label>
+  <label for="contrib__staffunsubsidized">Unsubsidized loan 
+    <input type="text" name="contrib__unsubsidized" data-financial="staffUnsubsidized">
+  </label>
+  <label for="contrib__institutionalloan">Institutional Loan
+    <input type="text" name="contrib__perkins" data-financial="institutionalLoan">
+  </label>
+  <label for="contrib__privateloan">Private Loan
+    <input type="text" name="contrib__perkins" data-financial="privateLoan">
+  </label>
+  <button id="calculate-debt">Run Calculations</button>
+  <table class="outputs">
+    <tr>
+      <td>Total Debt at Graduation:</td>
+      <td data-financial="totalDebt"></td>
+    </tr>
+    <tr>
+      <td>Monthly Loan Payment:</td>
+      <td data-financial="loanMonthly"></td>
+    </tr>
+    <tr>
+      <td>Amount Left to Pay:</td>
+      <td data-financial="gap"></td>
+    </tr>
+  </table>
+</div>
+{% endblock %}
+{% block app_js %}
+  <script type="text/javascript" src="{% static "paying_for_college/disclosures/static/js/main.js" %}"></script>
+{% endblock %}

--- a/paying_for_college/templates/just-a-demo.html
+++ b/paying_for_college/templates/just-a-demo.html
@@ -87,6 +87,9 @@
 </div>
 {% endblock %}
 
+{% block share_box %}
+{% endblock %}
+
 {% block nemo_js %}
 {% endblock %}
 

--- a/paying_for_college/templates/just-a-demo.html
+++ b/paying_for_college/templates/just-a-demo.html
@@ -1,6 +1,9 @@
 {% extends base_template %}
 {% load staticfiles %}
 {% block title %}Just a demo!{% endblock %}
+{% block page_viewport %}
+<meta name="viewport" content="width=device-width, initial-scale=1">
+{% endblock %}
 {% block nemo_styles %}
 {% endblock %}
 {% block app_css %}

--- a/paying_for_college/templates/just-a-demo.html
+++ b/paying_for_college/templates/just-a-demo.html
@@ -1,8 +1,13 @@
 {% extends base_template %}
 {% load staticfiles %}
-{% block title %}ust a demo!{% endblock %}
+{% block title %}Just a demo!{% endblock %}
+{% block nemo_styles %}
+{% endblock %}
 {% block app_css %}
   <link rel="stylesheet" type="text/css" href="{% static "paying_for_college/disclosures/static/css/main.min.css" %}">
+{% endblock %}
+{% block responsive_nav %}
+<a class="toggle-menu" href="#"><i class="cf-icon cf-icon-menu"></i><span class="u-visually-hidden">Menu</span></a>
 {% endblock %}
 {% block content %}
 <h1>Paying for College</h1>
@@ -52,10 +57,10 @@
   <label for="contrib__perkins">Perkins
     <input type="text" name="contrib__perkins" data-financial="perkins">
   </label>
-  <label for="contrib__staffsubsidized">Subsidized loan 
+  <label for="contrib__staffsubsidized">Subsidized loan
     <input type="text" name="contrib__subsidized" data-financial="staffSubsidized">
   </label>
-  <label for="contrib__staffunsubsidized">Unsubsidized loan 
+  <label for="contrib__staffunsubsidized">Unsubsidized loan
     <input type="text" name="contrib__unsubsidized" data-financial="staffUnsubsidized">
   </label>
   <label for="contrib__institutionalloan">Institutional Loan
@@ -81,6 +86,10 @@
   </table>
 </div>
 {% endblock %}
+
+{% block nemo_js %}
+{% endblock %}
+
 {% block app_js %}
   <script type="text/javascript" src="{% static "paying_for_college/disclosures/static/js/main.js" %}"></script>
 {% endblock %}

--- a/paying_for_college/templates/standalone/base_update.html
+++ b/paying_for_college/templates/standalone/base_update.html
@@ -5,9 +5,9 @@ Hey! If you're viewing this, you should probably come work on our Technology
 & Innovation team. We're always looking for a few great designers, developers, data
 scientists, and network, infrastructure, privacy and security pros. Keep
 an eye on our job opportunities at: http://www.consumerfinance.gov/jobs/
- 
+
 Also, you can see more of our code at https://github.com/cfpb
- 
+
 And by the way, there’s another hidden message somewhere on the following page: http://www.consumerfinance.gov/jobs/technology-innovation-fellows/. See if you can find it! Hint: picture yourself embedded in our work.
 -->
 
@@ -40,7 +40,7 @@ And by the way, there’s another hidden message somewhere on the following page
     <meta property="og:url" content="{{ request.build_absolute_uri }}">
     {% endblock %}
 
-    {% block page_viewport %}   
+    {% block page_viewport %}
     <meta name="viewport" content="width=1016">
     {% endblock %}
 
@@ -50,12 +50,12 @@ And by the way, there’s another hidden message somewhere on the following page
     <link rel="apple-touch-icon" size="114x114" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/apple-touch-icon-114x114-precomposed.png">
     <link rel="apple-touch-icon" size="144x144" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/apple-touch-icon-144x144-precomposed.png">
 
-
     <script src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/js/jquery-1.9.1.min.js"></script>
     <!--[if lt IE 9]>
     <script src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/js/html5shim.js"></script>
     <![endif]-->
 
+    {% block nemo_styles %}
     <!-- Styles -->
 
     <!--[if gt IE 8]><!-->
@@ -66,6 +66,7 @@ And by the way, there’s another hidden message somewhere on the following page
     <![endif]-->
     <link rel="stylesheet" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/c/styles.css">
     <link rel='stylesheet' id='cfpb_icon_font-css'  href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/cfpb-icon-font/css/icons.css?ver=all" type="text/css" media="all">
+    {% endblock %}
 
     {% block app_css %}
     {% endblock %}
@@ -91,7 +92,7 @@ And by the way, there’s another hidden message somewhere on the following page
       (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
       g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
       s.parentNode.insertBefore(g,s)}(document,'script'));
-    </script>    
+    </script>
 
     {% endblock %}
 </head>
@@ -123,67 +124,71 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <div id="page">
         {% block app_notification %}
         {% endblock %}
-        <div class="wrapper-banner">
-            <div class="wrapper-container">
-                <span class="split">
-                    <span class="official-website">An official website of the United States Government</span>
-                    <div class="split-right">
-                      <a href="/es/" hreflang="es" class="espanol-link">Español</a>
-                      {% if IS_REMIT %}
-                      <a href="/lang/#zh" hreflang="zh">中文</a>
-                      <a href="/lang/#vi" hreflang="vi">Tiếng Việt</a>
-                      <a href="/lang/#ko" hreflang="ko">한국어</a>
-                      <a href="/lang/#tl" hreflang="tl">Tagalog</a>
-                      <a href="/lang/#ru" hreflang="ru">Pусский</a>
-                      <a href="/lang/#ar" hreflang="ar">العربية</a>
-                      <a href="/lang/#ht" hreflang="ht">Kreyòl Ayisyen</a>
-                      {% endif %}
-                  </div>
-                </span>
-            </div>
-        </div><!-- .wrapper-banner -->
+        <div class="nemo">
+          <div class="wrapper-banner">
+              <div class="wrapper-container">
+                  <span class="split">
+                      <span class="official-website">An official website of the United States Government</span>
+                      <div class="split-right">
+                        <a href="/es/" hreflang="es" class="espanol-link">Español</a>
+                        {% if IS_REMIT %}
+                        <a href="/lang/#zh" hreflang="zh">中文</a>
+                        <a href="/lang/#vi" hreflang="vi">Tiếng Việt</a>
+                        <a href="/lang/#ko" hreflang="ko">한국어</a>
+                        <a href="/lang/#tl" hreflang="tl">Tagalog</a>
+                        <a href="/lang/#ru" hreflang="ru">Pусский</a>
+                        <a href="/lang/#ar" hreflang="ar">العربية</a>
+                        <a href="/lang/#ht" hreflang="ht">Kreyòl Ayisyen</a>
+                        {% endif %}
+                    </div>
+                  </span>
+              </div>
+          </div><!-- .wrapper-banner -->
 
-        <header id="header">
-            <div>
-                <a href="/">
-                    <img id="logo"
-                         class="logo__js"
-                         src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.svg"
-                         onerror="this.src='http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png';"
-                         alt="Consumer Financial Protection Bureau"
-                         width="262"
-                         height="66">
-                    <noscript>
-                        <img id="logo"
-                             class="logo__no-js"
-                             src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png"
-                             alt="Consumer Financial Protection Bureau"
-                             width="262"
-                             height="66">
-                    </noscript>
-                </a>
-                <p class="lang"><span class="tel"><a href="tel:+18554112372">Contact us&nbsp;&nbsp;<strong>(855) 411-2372</strong></a></span></p>
-                <form accept-charset="UTF-8" action="http://search.consumerfinance.gov/search" class="single" id="search_form" method="get">
-                                    <input name="utf8" type="hidden" value="&#x2713;" />
-                                    <input id="affiliate" name="affiliate" type="hidden" value="cfpb" />
-                                    <div class='inf'>
-                                        <label for="query">Search</label>
-                                        <input id="query" name="query" type="text" />
-                                    </div>
-                                    <button>Go</button>
-                                </form>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="/">Home</a></li>
-                    <li><a href="#inside">Inside the CFPB</a></li>
-                    <li><a href="#assistance">Get assistance</a></li>
-                    <li><a href="#participate">Participate</a></li>
-                    <li><a href="#regulation">Law &amp; Regulation</a></li>
-                    <li><a href="#alert" class="complaint">Submit a complaint</a></li>
-                </ul>
-            </nav>
-        </header>
+          <header id="header">
+              <div role="banner">
+                {% block responsive_nav %}
+                {% endblock %}
+                  <a href="/">
+                      <img id="logo"
+                           class="logo__js"
+                           src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.svg"
+                           onerror="this.src='http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png';"
+                           alt="Consumer Financial Protection Bureau"
+                           width="262"
+                           height="66">
+                      <noscript>
+                          <img id="logo"
+                               class="logo__no-js"
+                               src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png"
+                               alt="Consumer Financial Protection Bureau"
+                               width="262"
+                               height="66">
+                      </noscript>
+                  </a>
+                  <p class="lang"><span class="tel"><a href="tel:+18554112372">Contact us&nbsp;&nbsp;<strong>(855) 411-2372</strong></a></span></p>
+                  <form accept-charset="UTF-8" action="http://search.consumerfinance.gov/search" class="single" id="search_form" method="get">
+                                      <input name="utf8" type="hidden" value="&#x2713;" />
+                                      <input id="affiliate" name="affiliate" type="hidden" value="cfpb" />
+                                      <div class='inf'>
+                                          <label for="query">Search</label>
+                                          <input id="query" name="query" type="text" />
+                                      </div>
+                                      <button>Go</button>
+                                  </form>
+              </div>
+              <nav class="main" role="navigation">
+                  <ul>
+                      <li><a href="/">Home</a></li>
+                      <li><a href="#inside">Inside the CFPB</a></li>
+                      <li><a href="#assistance">Get assistance</a></li>
+                      <li><a href="#participate">Participate</a></li>
+                      <li><a href="#regulation">Law &amp; Regulation</a></li>
+                      <li><a href="#alert" class="complaint">Submit a complaint</a></li>
+                  </ul>
+              </nav>
+          </header>
+        </div>
 
         <div id="wrapper">
         <section id="maincontent">
@@ -199,148 +204,152 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </section><!--/main_content-->
         </div><!-- /wrapper -->
 
-        <section id="subnav">
-        <nav id="inside">
-            <h4>Inside the CFPB</h4>
-            <ul>
-                <li><h5><a href="/the-bureau/">About us</a></h5></li>
-                <li><h5><a href="/jobs/">Jobs</a></h5></li>
-                <li><h5><a href="/contact-us/">Contact us</a></h5></li>
-                <li><h5><a href="/newsroom/">Newsroom</a></h5></li>
-                <li><h5><a href="/reports/">Reports</a></h5></li>
-                <li><h5><a href="/budget/">Budget and performance</a></h5></li>
-                <li><h5><a href="/strategic-plan/">Strategic plan</a></h5></li>
-                <li><h5><a href="/blog/">Blog</a></h5></li>
-                <li><h5><a href="/advisory-groups/">Advisory groups</a></h5></li>
-                <li><h5><a href="/doing-business-with-us/">Doing business with us</a></h5></li>
-        </ul>
-        </nav>
-        <nav id="assistance">
-            <h4>Get assistance</h4>
-            <ul>
-                <li><h5><a href="/askcfpb/">Ask CFPB</a></h5>
-                  <p>Get answers to your financial questions.</p></li>
-                <li><h5><a href="/paying-for-college/">Paying for College</a></h5></li>
-                <li><h5><a href="/owning-a-home/">Owning a Home</a></h5></li>
-                <li><h5><a href="/mortgagehelp/">Trouble paying your mortgage?</a></h5></li>
-                <li><h5><a href="https://help.consumerfinance.gov/app/account/complaints/list">Check the status of a complaint</a></h5></li>
-                <li><h5><a href="/fair-lending/">Protections against credit discrimination</a></h5></li>
-                <li>
-                    <h5>Information for:</h5>
-                    <ul>
-                        <li><a href="/students/">Students</a></li>
-                        <li><a href="/older-americans/">Older Americans</a></li>
-                        <li><a href="/servicemembers/">Servicemembers and Veterans</a></li>
-                        <li><a href="/small-financial-services-providers/">Community Banks &amp; Credit Unions</a></li>
-                        <li><a href="/empowerment/">Economically Vulnerable Consumers</a></li>
-                    </ul>
-                </li>
-            </ul>
-        </nav>
-        <nav id="participate">
-            <h4>Participate</h4>
-            <ul>
-                <li>
-                    <h5>Know Before You Owe</h5>
-                    <p>Making costs and risks clear.</p>
-                    <ul>
-                        <li><a href="/credit-cards/knowbeforeyouowe/">Credit cards</a></li>
-                        <li><a href="/knowbeforeyouowe/">Mortgages</a></li>
-                        <li><a href="/students/knowbeforeyouowe/">Student loans</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <h5><a href="/your-story/">Tell Your Story</a></h5>
-                    <p>Help inform how we protect consumers &amp; create a fairer marketplace.</p>
-                </li>
-                <li>
-                    <h5><a href="/complaintdatabase">Consumer Complaint Database</a></h5>
-                </li>
-                <li>
-                    <h5><a href="/hmda">Home Mortgage Disclosure Act Database</a></h5>
-                </li>       
-                <li>
-                    <h5><a href="/open/">Open government</a></h5>
-                    <ul>
-                        <li><a href="/leadership-calendar/">Leadership calendar</a></li>
-                        <li><a href="/foia/">FOIA</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <h5><a href="/notice-and-comment/">Notice and comment</a></h5>
-                    <p>Weigh in on current rulemakings.</p>
-                </li>
-            </ul>
-        </nav>
-        <nav id="regulation">
-            <h4>Regulation</h4>
-            <ul>
-                <li><h5><a href="/guidance/supervision/manual/">Examination manual</a></h5></li>
-                <li><h5><a href="/guidance/">Guidance</a></h5></li>
-                <li><h5><a href="/notice-and-comment/">Notice and comment</a></h5></li>
-                <li><h5><a href="/regulations/">Regulations</a></h5></li>
-                <li><h5><a href="/regulatory-implementation/">Regulatory implementation</a></h5></li>
-                <li><h5><a href="/administrativeadjudication/">Administrative adjudication</a></h5></li>
-                <li><h5><a href="/amicus/">Amicus program</a></h5></li>
-            </ul>
-        </nav>
-        <nav id="alert">
-            <h4>Submit a complaint</h4>
-            <ul>
-                <li>
-                    <h5><a href="/complaint">Submit a complaint</a></h5>
-                </li>
-                <li><h5><a href="https://help.consumerfinance.gov/app/account/complaints/list">Check the status of your complaint</a></h5></li>
-                <li>
-                    <h5><a href="/the-cfpb-wants-you-to-blow-the-whistle-on-lawbreakers/">Whistleblowers</a></h5>
-                    <p>Confidentially report any wrongdoing you have observed.</p>
-                </li>
-            </ul>
-        </nav>
-        </section>
+        <div class="nemo">
+          <section id="subnav">
+          <nav id="inside">
+              <h4>Inside the CFPB</h4>
+              <ul>
+                  <li><h5><a href="/the-bureau/">About us</a></h5></li>
+                  <li><h5><a href="/jobs/">Jobs</a></h5></li>
+                  <li><h5><a href="/contact-us/">Contact us</a></h5></li>
+                  <li><h5><a href="/newsroom/">Newsroom</a></h5></li>
+                  <li><h5><a href="/reports/">Reports</a></h5></li>
+                  <li><h5><a href="/budget/">Budget and performance</a></h5></li>
+                  <li><h5><a href="/strategic-plan/">Strategic plan</a></h5></li>
+                  <li><h5><a href="/blog/">Blog</a></h5></li>
+                  <li><h5><a href="/advisory-groups/">Advisory groups</a></h5></li>
+                  <li><h5><a href="/doing-business-with-us/">Doing business with us</a></h5></li>
+          </ul>
+          </nav>
+          <nav id="assistance">
+              <h4>Get assistance</h4>
+              <ul>
+                  <li><h5><a href="/askcfpb/">Ask CFPB</a></h5>
+                    <p>Get answers to your financial questions.</p></li>
+                  <li><h5><a href="/paying-for-college/">Paying for College</a></h5></li>
+                  <li><h5><a href="/owning-a-home/">Owning a Home</a></h5></li>
+                  <li><h5><a href="/mortgagehelp/">Trouble paying your mortgage?</a></h5></li>
+                  <li><h5><a href="https://help.consumerfinance.gov/app/account/complaints/list">Check the status of a complaint</a></h5></li>
+                  <li><h5><a href="/fair-lending/">Protections against credit discrimination</a></h5></li>
+                  <li>
+                      <h5>Information for:</h5>
+                      <ul>
+                          <li><a href="/students/">Students</a></li>
+                          <li><a href="/older-americans/">Older Americans</a></li>
+                          <li><a href="/servicemembers/">Servicemembers and Veterans</a></li>
+                          <li><a href="/small-financial-services-providers/">Community Banks &amp; Credit Unions</a></li>
+                          <li><a href="/empowerment/">Economically Vulnerable Consumers</a></li>
+                      </ul>
+                  </li>
+              </ul>
+          </nav>
+          <nav id="participate">
+              <h4>Participate</h4>
+              <ul>
+                  <li>
+                      <h5>Know Before You Owe</h5>
+                      <p>Making costs and risks clear.</p>
+                      <ul>
+                          <li><a href="/credit-cards/knowbeforeyouowe/">Credit cards</a></li>
+                          <li><a href="/knowbeforeyouowe/">Mortgages</a></li>
+                          <li><a href="/students/knowbeforeyouowe/">Student loans</a></li>
+                      </ul>
+                  </li>
+                  <li>
+                      <h5><a href="/your-story/">Tell Your Story</a></h5>
+                      <p>Help inform how we protect consumers &amp; create a fairer marketplace.</p>
+                  </li>
+                  <li>
+                      <h5><a href="/complaintdatabase">Consumer Complaint Database</a></h5>
+                  </li>
+                  <li>
+                      <h5><a href="/hmda">Home Mortgage Disclosure Act Database</a></h5>
+                  </li>
+                  <li>
+                      <h5><a href="/open/">Open government</a></h5>
+                      <ul>
+                          <li><a href="/leadership-calendar/">Leadership calendar</a></li>
+                          <li><a href="/foia/">FOIA</a></li>
+                      </ul>
+                  </li>
+                  <li>
+                      <h5><a href="/notice-and-comment/">Notice and comment</a></h5>
+                      <p>Weigh in on current rulemakings.</p>
+                  </li>
+              </ul>
+          </nav>
+          <nav id="regulation">
+              <h4>Regulation</h4>
+              <ul>
+                  <li><h5><a href="/guidance/supervision/manual/">Examination manual</a></h5></li>
+                  <li><h5><a href="/guidance/">Guidance</a></h5></li>
+                  <li><h5><a href="/notice-and-comment/">Notice and comment</a></h5></li>
+                  <li><h5><a href="/regulations/">Regulations</a></h5></li>
+                  <li><h5><a href="/regulatory-implementation/">Regulatory implementation</a></h5></li>
+                  <li><h5><a href="/administrativeadjudication/">Administrative adjudication</a></h5></li>
+                  <li><h5><a href="/amicus/">Amicus program</a></h5></li>
+              </ul>
+          </nav>
+          <nav id="alert">
+              <h4>Submit a complaint</h4>
+              <ul>
+                  <li>
+                      <h5><a href="/complaint">Submit a complaint</a></h5>
+                  </li>
+                  <li><h5><a href="https://help.consumerfinance.gov/app/account/complaints/list">Check the status of your complaint</a></h5></li>
+                  <li>
+                      <h5><a href="/the-cfpb-wants-you-to-blow-the-whistle-on-lawbreakers/">Whistleblowers</a></h5>
+                      <p>Confidentially report any wrongdoing you have observed.</p>
+                  </li>
+              </ul>
+          </nav>
+          </section>
+        </div>
 
-        <footer id="footer">
-            <div>
-                <a href="/"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo-vert.png" alt="Consumer Financial Protection Bureau" title="CFPB"></a>
-                <nav>
-                    <ul>
-                        <li><a href="/privacy-policy/">Privacy policy and legal notices</a></li>
-                        <li><a href="/accessibility/">Accessibility</a></li>
-                        <li><a href="/plain-writing/">Plain writing</a></li>
-                        <li><a href="/no-fear-act/">No FEAR Act</a></li>
-                        <li><a href="/foia/">FOIA</a></li>
-                        <li><a href="/equal-employment-opportunity/whistleblowers/">Whistleblower Act</a></li>
-                    </ul>
-                </nav>
-                <nav>
-                    <ul>
-                        <li><a href="http://usa.gov/">USA.gov</a></li>
-                        <li><a href="http://oig.federalreserve.gov/">Office of Inspector General</a></li>
-                        <li><a href="/ombudsman/">Ombudsman</a></li>
-                    </ul>
-                </nav>
-                <nav>
-                    <ul>
-                        <li class="horizontal-list-item"><a href="http://facebook.com/cfpb" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/fb_footer_icon.png" alt="Visit us on Facebook"></a>&nbsp;&nbsp;</li>
-                        <li class="horizontal-list-item"><a href="http://twitter.com/cfpb" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/twitter_footer_icon.png" alt="Visit us on Twitter"></a>&nbsp;&nbsp;</li>
-                        <li class="horizontal-list-item"><a href="http://youtube.com/CFPB" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/youtube_footer_icon.png" alt="Visit us on Youtube"></a>&nbsp;&nbsp;</li>
-                        <li class="horizontal-list-item"><a href="http://flickr.com/cfpbphotos" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/flickr_footer_icon.png" alt="Visit us on Flickr"></a>&nbsp;&nbsp;</li>
-                        <li class="horizontal-list-item"><a href="/feed/" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/rss_footer_icon.png" alt="Subscribe to updates with RSS"></a></li>
-                    </ul>
-                    <p>Visite nuestro sitio web 
-                    en español</p>
-                    <p><a class="link-button espanol-link" href="/es/" hreflang="es">Español</a></p>
-                </nav>
-            </div>
-            <nav class="bottom">
-                <ul>
-                    <li><a href="/contact-us/">Contact us</a></li>
-                    <li><a href="/newsroom/">Newsroom</a></li>
-                    <li><a href="/jobs/">Jobs</a></li>
-                    <li><a href="/open/">Open government</a></li>
-                </ul>
-            </nav>
-        </footer>
+        <div class="nemo">
+          <footer id="footer">
+              <div>
+                  <a href="/"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo-vert.png" alt="Consumer Financial Protection Bureau" title="CFPB"></a>
+                  <nav>
+                      <ul>
+                          <li><a href="/privacy-policy/">Privacy policy and legal notices</a></li>
+                          <li><a href="/accessibility/">Accessibility</a></li>
+                          <li><a href="/plain-writing/">Plain writing</a></li>
+                          <li><a href="/no-fear-act/">No FEAR Act</a></li>
+                          <li><a href="/foia/">FOIA</a></li>
+                          <li><a href="/equal-employment-opportunity/whistleblowers/">Whistleblower Act</a></li>
+                      </ul>
+                  </nav>
+                  <nav>
+                      <ul>
+                          <li><a href="http://usa.gov/">USA.gov</a></li>
+                          <li><a href="http://oig.federalreserve.gov/">Office of Inspector General</a></li>
+                          <li><a href="/ombudsman/">Ombudsman</a></li>
+                      </ul>
+                  </nav>
+                  <nav>
+                      <ul>
+                          <li class="horizontal-list-item"><a href="http://facebook.com/cfpb" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/fb_footer_icon.png" alt="Visit us on Facebook"></a>&nbsp;&nbsp;</li>
+                          <li class="horizontal-list-item"><a href="http://twitter.com/cfpb" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/twitter_footer_icon.png" alt="Visit us on Twitter"></a>&nbsp;&nbsp;</li>
+                          <li class="horizontal-list-item"><a href="http://youtube.com/CFPB" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/youtube_footer_icon.png" alt="Visit us on Youtube"></a>&nbsp;&nbsp;</li>
+                          <li class="horizontal-list-item"><a href="http://flickr.com/cfpbphotos" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/flickr_footer_icon.png" alt="Visit us on Flickr"></a>&nbsp;&nbsp;</li>
+                          <li class="horizontal-list-item"><a href="/feed/" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/rss_footer_icon.png" alt="Subscribe to updates with RSS"></a></li>
+                      </ul>
+                      <p>Visite nuestro sitio web
+                      en español</p>
+                      <p><a class="link-button espanol-link" href="/es/" hreflang="es">Español</a></p>
+                  </nav>
+              </div>
+              <nav class="bottom">
+                  <ul>
+                      <li><a href="/contact-us/">Contact us</a></li>
+                      <li><a href="/newsroom/">Newsroom</a></li>
+                      <li><a href="/jobs/">Jobs</a></li>
+                      <li><a href="/open/">Open government</a></li>
+                  </ul>
+              </nav>
+          </footer>
+        </div>
 
         <div class="shareavatar">
             <img alt="" class="shareavatar" height=0 width=0 src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/facebookshareavatar.png" />
@@ -350,10 +359,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     {% block app_modal %}
     {% endblock %}
 
-
+{% block nemo_js %}
 <script src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/js/functions.js"></script>
 <script type="text/javascript" src="http://www.consumerfinance.gov/static/agreements/js/chosen.jquery.js"></script>
-
+{% endblock %}
 
 {% block app_js %}
 {% endblock %}
@@ -374,7 +383,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 <script type="text/javascript">
     // If there are no breadcrumbs on this page, remove the ul tag so that screen
-    // readers don't read it (since the ul has nothing in it).  
+    // readers don't read it (since the ul has nothing in it).
     $(function(){
         var numBreadCrumbs = $("ul.bread").children("li").length;
         if(numBreadCrumbs == 0){

--- a/paying_for_college/templates/standalone/base_update.html
+++ b/paying_for_college/templates/standalone/base_update.html
@@ -149,23 +149,25 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               <div role="banner">
                 {% block responsive_nav %}
                 {% endblock %}
-                  <a href="/">
-                      <img id="logo"
-                           class="logo__js"
-                           src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.svg"
-                           onerror="this.src='http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png';"
-                           alt="Consumer Financial Protection Bureau"
-                           width="262"
-                           height="66">
-                      <noscript>
-                          <img id="logo"
-                               class="logo__no-js"
-                               src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png"
-                               alt="Consumer Financial Protection Bureau"
-                               width="262"
-                               height="66">
-                      </noscript>
-                  </a>
+                <h1>
+                    <a href="/">
+                        <img id="logo"
+                             class="logo__js"
+                             src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.svg"
+                             onerror="this.src='http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png';"
+                             alt="Consumer Financial Protection Bureau"
+                             width="262"
+                             height="66">
+                        <noscript>
+                            <img id="logo"
+                                 class="logo__no-js"
+                                 src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png"
+                                 alt="Consumer Financial Protection Bureau"
+                                 width="262"
+                                 height="66">
+                        </noscript>
+                    </a>
+                  </h1>
                   <p class="lang"><span class="tel"><a href="tel:+18554112372">Contact us&nbsp;&nbsp;<strong>(855) 411-2372</strong></a></span></p>
                   <form accept-charset="UTF-8" action="http://search.consumerfinance.gov/search" class="single" id="search_form" method="get">
                                       <input name="utf8" type="hidden" value="&#x2713;" />

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -1,15 +1,18 @@
-body {
-  margin: 2em;  
-}
+#maincontent {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding-top: 30px;
 
-label {
-  line-height: 3;
-  max-width: 40%;
-  padding-bottom: 0.5em;
-  text-align: right;
-  & > input[type="text"] {
-    display: block;
-    float: right;
-    margin-left: 1em;
+  label {
+    line-height: 3;
+    max-width: 40%;
+    padding-bottom: 0.5em;
+    text-align: right;
+    & > input[type="text"] {
+      display: block;
+      float: right;
+      margin-left: 1em;
+    }
   }
+
 }

--- a/src/disclosures/css/main.less
+++ b/src/disclosures/css/main.less
@@ -22,6 +22,13 @@
 // Import the Capital Framework enhancements
 @import (less) "cf-enhancements.less";
 
+// import CFPB nemo theme header and footer styles
+.nemo {
+  @import "nemo.less";
+  // and a shim to override some things
+  @import "nemo-shim.less";
+}
+
 // We've generated some sample rules for you. They're used with the index.html file.
 // Please delete them before starting your project.
 

--- a/src/disclosures/css/nemo-shim.less
+++ b/src/disclosures/css/nemo-shim.less
@@ -1,0 +1,164 @@
+// Style our hamburger icon
+.toggle-menu {
+  display: none;
+  position: absolute;
+  left: 10px;
+  top: 20px;
+  font-size: 18px;
+  height: 40px;
+  width: 40px;
+  line-height: 40px;
+  text-align: center;
+}
+
+#subnav {
+  padding: 0;
+}
+
+#subnav nav h5 {
+  text-transform: none;
+}
+
+#header nav a {
+  .webfont-medium();
+}
+
+#subnav nav h5,
+strong {
+  .webfont-demi();
+}
+
+#header {
+  border-bottom: 5px solid #333;
+}
+
+#header nav {
+  margin: 10px 0 0;
+}
+
+@media screen and (min-width: 865px) {
+  .horizontal-list-item {
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media screen and (max-width: 1060px) {
+
+  // Shrink font size of menu if viewport isn't huge
+  #header nav {
+    font-size: 80%;
+  }
+
+}
+
+@media screen and (max-width: 865px) {
+
+  // The nav items are crazy ugly when bumped to two lines
+  // Aligning them to the left helps a little
+  #header nav ul li a {
+    text-align: left;
+  }
+
+}
+
+@media screen and (max-width: 1100px) {
+
+  .wrapper-container,
+  .split {
+    max-width: 100%;
+  }
+  // Hide the multi-language banner
+  .wrapper-container .language-banner {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 660px) {
+
+  // Scale the logo a bit
+  #header h1 {
+    margin-left: 60px;
+  }
+
+  // Show the menu icon
+  .toggle-menu {
+    display: block;
+  }
+
+  #header {
+    .toggle-menu,
+    .toggle-menu:link,
+    .toggle-menu:visited {
+      color: #75787B;
+    }
+
+    .toggle-menu:hover,
+    .toggle-menu:active,
+    .toggle-menu:focus {
+        color: #75787B;
+        background: #E3E4E4;
+      }
+    }
+
+  // Reset font size
+  #header nav {
+    font-size: 100%;
+  }
+
+  // Simplify subnav styles for mobiles
+  #subnav nav {
+    border: 0;
+    width: 100%;
+    ul {
+      margin: 0;
+      width: auto;
+    }
+  }
+
+  // Move the nav items into a vertical list
+  #header nav ul {
+    display: none;
+    &.vis {
+      display: block;
+    }
+    li {
+      display: block;
+    }
+  }
+
+  // Reset the phone number and search form positioning
+  p.lang,
+  #search_form {
+    display: none; // hide until we make a search toggle
+    position: relative;
+    top: 0;
+    right: 0;
+    width: 100%;
+    text-align: center;
+  }
+
+  // remove us flag
+  .official-website {
+    padding-right: 0;
+    background: none;
+  }
+
+  // Reset the footer navs
+  #footer > div {
+    > a,
+    > nav {
+      width: auto;
+      display: block;
+      min-height: 0;
+    }
+  }
+
+  .split-right {
+    position: static;
+    margin-right: 0;
+    margin-left: 10px;
+    text-align: right;
+  }
+
+}

--- a/src/disclosures/css/nemo.less
+++ b/src/disclosures/css/nemo.less
@@ -1,0 +1,703 @@
+article, aside, figure, footer, header, hgroup, nav, section {display: block;}
+
+img,object, embed {max-width: 100%;}
+
+html {overflow-y: scroll;}
+/*ul {list-style: none;}*/
+blockquote, q {quotes:
+ none;}
+
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: ''; content: none;
+}
+
+a {margin: 0; padding: 0; font-size: 100%; vertical-align: baseline; background: transparent;}
+
+del {text-decoration: line-through;}
+
+abbr[title], dfn[title] {border-bottom: 1px dotted #000; cursor: help;}
+
+/* tables still need cellspacing="0" in the markup */
+table {border-collapse: collapse; border-spacing: 0;}
+th {font-weight: bold; vertical-align: bottom;}
+td {font-weight: normal; vertical-align: top;}
+
+hr {display: block; height: 1px; border: 0; border-top: 1px solid #ccc; margin: 1em 0; padding: 0;}
+
+input, select {vertical-align: middle;}
+
+pre {
+  white-space: pre; /* CSS2 */
+  white-space: pre-wrap; /* CSS 2.1 */
+  white-space: pre-line; /* CSS 3 (and 2.1 as well, actually) */
+  word-wrap: break-word; /* IE */
+}
+
+input[type="radio"] {vertical-align: text-bottom;}
+input[type="checkbox"] {vertical-align: bottom; *vertical-align: baseline;}
+.ie6 input {vertical-align: text-bottom;}
+
+select, input, textarea {font: 99% sans-serif;}
+
+table {font-size: inherit; font: 100%;}
+
+/* Accessible focus treatment
+  people.opera.com/patrickl/experiments/keyboard/test */
+a:hover, a:active {outline: none;}
+
+small {font-size: 85%;}
+
+strong, th {font-weight: bold;}
+
+td, td img {vertical-align: top;}
+
+/* Make sure sup and sub don't screw with your line-heights
+  gist.github.com/413930 */
+sub, sup {font-size: 75%; line-height: 0; position: relative;}
+sup {top: -0.5em;}
+sub {bottom: -0.25em;}
+
+/* standardize any monospaced elements */
+pre, code, kbd, samp {font-family: monospace, sans-serif;}
+
+/* hand cursor on clickable elements */
+.clickable,
+label,
+input[type=button],
+input[type=submit],
+button {cursor: pointer;}
+
+/* Webkit browsers add a 2px margin outside the chrome of form elements */
+button, input, select, textarea {margin: 0;}
+
+/* make buttons play nice in IE */
+button {width: auto; overflow: visible;}
+
+
+/***** BASE STYLES *****/
+
+p {
+  margin: 1em 0;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: "Avenir Next", Verdana, sans-serif;
+}
+
+.lt-ie9 h1, .lt-ie9 h2, .lt-ie9 h3, .lt-ie9 h4, .lt-ie9 h5, .lt-ie9 h6 {
+  font-family: "Avenir Next Demi", Verdana, sans-serif;
+}
+
+.lt-ie9 h1 em, .lt-ie9 h1 i, .lt-ie9 h2 em, .lt-ie9 h2 i, .lt-ie9 h3 em, .lt-ie9 h3 i, .lt-ie9 h4 em, .lt-ie9 h4 i, .lt-ie9 h5 em, .lt-ie9 h5 i, .lt-ie9 h6 em, .lt-ie9 h6 i {
+  font-family: "Avenir Next Demi Italic", Verdana, sans-serif;
+}
+
+h1 {
+  font-size: 2em;
+  font-weight: 600;
+  line-height: 1.375;
+}
+
+h2 {
+  font-size: 1.25em;
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+h3 {
+  font-size: 1.25em;
+  font-weight: 600;
+  line-height: 1.2em;
+}
+
+h4 {
+  font-size: 1.0em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+h5 {
+  font-size: 1em;
+  font-weight: 600;
+}
+
+h6 {
+  font-size: 1em;
+  font-weight: 600;
+}
+
+a {
+  text-decoration: none;
+  color: #4d819a;
+  padding-bottom: 0.1em;
+  border-bottom: 1px dotted #4d819a;
+}
+
+blockquote {
+  background-color: #e5dfd6;
+  padding: 1em 3.0em 0.5em;
+  font-family: "Avenir Next", Verdana, sans-serif;
+  margin-bottom: 1em;
+  border-left: 5px solid #beb099;
+}
+
+input {
+  font-size: 1em;
+  border: 1px inset #afafb3;
+  border-radius: 0.25em;
+  box-shadow: inset 2px 1px 2px -3px #aaa;
+  padding: .25em .5em;
+  background-color: #fff;
+}
+
+input[type='radio'],
+input[type='checkbox'] {
+  border: none;
+  padding: none;
+}
+
+textarea {
+  font-size: 1em;
+  border: 1px inset #afafb3;
+  box-shadow: inset 2px 1px 2px -3px #aaa;
+  padding: .25em .5em;
+}
+
+button {
+  color: #fff;
+  background-color: #50a748;
+  font-family: "Avenir Next", Verdana, sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  border-radius: 0.35em;
+  font-size: .875em;
+  border: 1px outset #afafb3;
+  position: relative;
+  top: -1px;
+  padding: .45em .75em;
+  -webkit-transition: all 700ms ease;
+  -moz-transition: all 700ms ease;
+  transition: all 700ms ease;
+}
+
+button:disabled {
+  background-color: #a9dc93;
+}
+
+select {
+  font-size: 1em;
+}
+
+fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+legend {
+  padding: 0;
+  max-width: 100%;
+}
+/***** LAYOUT *****/
+
+#header {
+  background-color: #fff;
+  padding: 1em 0 0;
+  border-bottom: 1px solid #333;
+}
+
+  #header a {
+    padding: 0;
+    border: none;
+    color: #333;
+    background-color: #fff;
+  }
+
+  #header #logo {
+    margin-top: 0.5em;
+  }
+
+#header > div {
+  max-width: 976px;
+  height: auto;
+  margin: 0 auto;
+  position: relative;
+}
+
+#header h1 {
+  margin: 0;
+  padding: 0;
+  font-size: 1em;
+}
+
+#header nav {
+  border-top: 1px solid #333;
+  margin: 1em 0 0;
+}
+
+#header nav ul {
+  list-style-type: none;
+  padding: 0;
+  margin: 0 auto;
+  max-width: 1060px;
+  display: table;
+}
+
+#header nav ul li {
+  font-family: "Avenir Next", Verdana, sans-serif;
+  font-weight: 500;
+  text-transform: uppercase;
+  font-size: 1em;
+  display: table-cell;
+  width: auto;
+  letter-spacing: 0.08em;
+  margin: 0;
+}
+
+.lt-ie8 #header nav ul li {
+  display: inline-block;
+  *display: inline;
+  *zoom: 1;
+}
+
+.lt-ie9 #header nav ul li {
+  font-family: "Avenir Next Demi", Verdana, sans-serif;
+}
+
+#header nav ul li a {
+  -webkit-transition: background-color ease 1000ms;
+  -moz-transition: background-color ease 1000ms;
+  transition: background-color ease 1000ms;
+  display: block;
+  width: auto;
+  height: auto;
+  padding: 0.5em 0.85em 0.25em 0.85em;
+  color: #333;
+  text-align: center;
+  background-color: #fff;
+}
+
+#header nav ul li a:visited {
+  color: #333;
+}
+
+#header nav ul li a:hover {
+  background-color: #dbe6eb;
+  color: #333;
+}
+
+#header nav ul li a:focus {
+  background-color: #fff;
+}
+
+#header nav ul li a.active {
+  background-color: #dbe6eb;
+}
+
+#header nav ul li a.complaint {
+  color: #50a748;
+}
+
+#subnav {
+  max-width: 976px;
+  margin: 0 auto;
+  padding: 1em 20px;
+  background-color: #fff;
+}
+
+.js #subnav {
+  width: auto;
+  padding: 0;
+  background-color: transparent;
+}
+
+#subnav nav {
+  display: inline-block;
+    /* IE7 hack to mimic inline-block on block elements */
+  *display: inline;
+  *zoom: 1;
+  vertical-align: top;
+  border: 1px solid #333;
+  padding: 0 1em;
+  background-color: #dbe6eb;
+  z-index: 100;
+}
+
+  #subnav nav a {
+    color: #333;
+    border: none;
+  }
+
+  #subnav nav h4 {
+    display: none;
+  }
+
+  #subnav nav ul {
+    margin: 1em 0;
+    width: 13em;
+    padding: 0;
+    list-style-type: none;
+  }
+
+  #subnav nav {
+    position: absolute;
+    top: 10.25em;
+    display: none;
+    border-top: none;
+  }
+
+    #subnav nav ul li {
+      border-bottom: 1px solid #afafb3;
+      padding: 0.5em;
+      -webkit-column-break-inside: avoid;
+      -moz-column-break-inside: avoid;
+      column-break-inside: avoid;
+    }
+
+    #subnav nav ul li:last-child {
+      border-bottom: none;
+    }
+
+    #subnav nav ul li h5 {
+      margin: 0;
+    }
+
+    #subnav nav ul li p {
+      margin: 0;
+      font-size: 0.8333em;
+      color: #626263;
+    }
+
+    #subnav nav ul li ul li {
+      border-bottom: none;
+      padding: 0;
+      margin-top: 0.5em;
+      font-family: "Avenir Next", Verdana, sans-serif;
+      word-wrap: normal;
+    }
+
+    #subnav .close {
+      font-size: 0.625em;
+      font-family: "Avenir Next", Verdana, sans-serif;
+      display: block;
+      text-align: right;
+      padding-bottom: 1em;
+    }
+
+    #subnav a:hover,
+    #subnav a:focus {
+      background-color: inherit;
+    }
+
+#footer {
+  font-size: 0.833333333em;
+  padding: 2em 0;
+  background-color: #fff;
+  border-top: 1px solid #333;
+}
+
+  #footer > div > a {
+    display: inline-block;
+    /* IE7 hack to mimic inline-block on block elements */
+  *display: inline;
+  *zoom: 1;
+    margin: 1em 1.9685% 0 1.9685%;
+    width: 22.53937%;
+  }
+
+  #footer > div > nav {
+    border-left: 1px solid #afafb3;
+    display: inline-block;
+    /* IE7 hack to mimic inline-block on block elements */
+  *display: inline;
+  *zoom: 1;
+    width: 18.50393%;
+    padding: 0 1.5%;
+    margin-left: 1.9685%;
+    vertical-align: top;
+    min-height: 12.5em;
+  }
+
+  #footer > div {
+    max-width: 1060px;
+    padding: 0;
+    margin: 0 auto;
+  }
+
+  #footer > div > a:link {
+    padding: 0;
+    border: none;
+  }
+
+  #footer > div > nav > ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  #footer > div > nav > ul li {
+    margin: 0.75em 0 0;
+  }
+
+
+#search_form {
+  position: absolute;
+  top: 2.35em;
+  right: 0;
+  text-align: right;
+  width: 40%;
+}
+
+  #search_form button {
+    background: #50b948 url(http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/search_bg.png) no-repeat center left;
+    text-indent: -9999px;
+    width: 3em;
+  }
+
+  .single .inf {
+    display: inline-block;
+    /* IE7 hack to mimic inline-block on block elements */
+      *display: inline;
+      *zoom: 1;
+  }
+
+  .single input {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+    font-size: 1em;
+  }
+
+  .single button {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+    display: inline-block;
+    /* IE7 hack to mimic inline-block on block elements */
+      *display: inline;
+      *zoom: 1;
+    line-height: 1.95;
+    padding: 0 0.5em;
+    position: relative;
+      top: 1px;
+      left: -3px;
+  }
+
+  .lt-ie8 .single button {
+    line-height: 1.6;
+    top: 4px;
+  }
+
+.inf {
+  position: relative;
+}
+
+  .inf > label {
+    position: absolute;
+    padding: 0 0.5em;
+    top: 0.25em;
+    z-index: 10;
+    background-color: #fff;
+    color: #444;
+    font-family: "Avenir Next", Verdana, sans-serif;
+  }
+
+  .inf > input {
+    position: relative;
+    z-index: 20;
+    background: transparent;
+    background: rgba(255,255,255,0.25);
+    -webkit-transition: background 700ms ease;
+    -moz-transition: background 700ms ease;
+    transition: background 700ms ease;
+    width: 210px;
+
+  }
+
+  .inf .filled {
+    background: #fff;
+  }
+
+.lang {
+  color: #626263;
+  font-family: "Avenir Next", Verdana, sans-serif;
+  font-size: 13px;
+  position: absolute;
+  top: 16px;
+  right: 0;
+  margin: 0;
+}
+
+.govt {
+  color: #626263;
+  font-family: "Avenir Next", Verdana, sans-serif;
+  font-size: 0.83333333em;
+  position: absolute;
+  top: 0px;
+  right: 2em;
+  margin: 0;
+  background: transparent url("../img/us_flag_small.png") right center no-repeat;
+  padding-right: 24px;
+}
+
+#footer aside { display: inline-block; }
+#footer button a { color: white; border-bottom: none;}
+#footer button a:hover { background: transparent; }
+#footer > div > nav > div > p { padding-top: 1em; }
+
+.check ul {
+  list-style-type: none;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.bottom {
+  display: block;
+  max-width: 976px;
+  border: none;
+  margin: 0 auto;
+  padding: 0;
+  position: relative;
+}
+
+.bottom > ul {
+  list-style-type: none;
+  margin: 1em 0;
+  padding: 1em 1.9685%;
+  border-top: 1px solid #afafb3;
+}
+
+.bottom > ul > li {
+  display: inline-block;
+    /* IE7 hack to mimic inline-block on block elements */
+  *display: inline;
+  *zoom: 1;
+  margin-right: 1em;
+}
+
+.bottom > ul > li + li {
+  border-left: 1px solid #afafb3;
+  padding-left: 1em;
+}
+
+.bottom img {
+  position: absolute;
+  right: 1.9685%;
+  top: 0.75em;
+}
+
+.lt-ie9 .bottom img {
+  top: 2.75em;
+}
+
+
+/***** STATES *****/
+
+a:hover,
+a:focus {
+  background-color: #dbe6eb;
+  border-bottom-style: solid;
+}
+
+  footer > div > a:hover,
+  header > div > a:hover {
+    background-color: transparent;
+  }
+
+  .share a:hover,
+  .share a:focus {
+    background-color: transparent;
+    border: none;
+  }
+
+    .share a:hover img,
+    .share a:focus img {
+      -webkit-transform: scale(1.1);
+      -moz-transform: scale(1.1);
+      -ms-transform: scale(1.1);
+      transform: scale(1.1);
+    }
+
+input:focus {
+  border: 1px solid #50a748;
+}
+
+  .inf input:focus {
+    background: #fff;
+    background: rgba(255,255,255,0.85);
+  }
+
+button:hover,
+button:focus {
+  cursor: pointer;
+  outline: 2px;
+}
+
+button:disabled:hover,
+button:disabled:focus {
+  cursor: default;
+}
+
+
+.wrapper-banner, .wrapper-header {
+  color: #101820;
+  font-family: "Avenir Next", Arial, sans-serif;
+  font-size: 75%;
+  font-weight: 400;
+}
+
+.wrapper-banner {
+    background-color: #f7f5f4;
+    padding: 4px 0;
+    text-align: center;
+    width: 100%;
+}
+
+.wrapper-banner a {
+  background: none;
+  border-bottom: none;
+  margin: 0 6px;
+  padding-bottom: none;
+}
+
+.wrapper-container {
+  font-size: 93%;
+  line-height: 1.25em;
+  margin: 0 auto;
+  text-align: left;
+  width: 1016px;
+}
+
+.small {
+  font-size: 0.625em;
+}
+
+.split {
+  display: block;
+  line-height: 1.25;
+  overflow: hidden;
+  width: 1016px;
+}
+
+.split-right {
+  float: right;
+  margin-right: 1.9685%;
+  text-align: right;
+}
+
+.official-website {
+  background: transparent url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/us_flag_small.png") left center no-repeat;
+  float: left;
+  margin-left: 1.9685%;
+  padding-left: 24px;
+}
+
+.noStyles, a.noStyles:hover {
+color: #333;
+border: none;
+padding: 0;
+background: none;
+}

--- a/src/disclosures/js/index.js
+++ b/src/disclosures/js/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-// var $ = require( 'jquery' ),
 var FinancialModel = require( './lib/financial-data.js' ),
     financials = new FinancialModel(),
     View = require( './lib/school-view.js' ),

--- a/src/disclosures/js/index.js
+++ b/src/disclosures/js/index.js
@@ -1,11 +1,15 @@
 'use strict';
 
-var $ = require( 'jquery' ),
-    FinancialModel = require( './lib/financial-data.js' ),
+// var $ = require( 'jquery' ),
+var FinancialModel = require( './lib/financial-data.js' ),
     financials = new FinancialModel(),
     View = require( './lib/school-view.js' ),
     schoolView = new View(),
     queryHandler = require( './lib/query-handler.js' );
+
+require('./nemo');
+require('./nemo-shim');
+
 
 function init() {
   // Set the financials.values property with defaults
@@ -51,4 +55,3 @@ $( document ).ready( function() {
 
 
 });
-

--- a/src/disclosures/js/lib/school-view.js
+++ b/src/disclosures/js/lib/school-view.js
@@ -6,8 +6,8 @@
 
 'use strict';
 
-var $ = require( 'jquery' ),
-    stringToNum = require( './handle-string-input.js'),
+//var $ = require( 'jquery' ),
+var stringToNum = require( './handle-string-input.js'),
     formatUSD = require( 'format-usd' );
 
 var SchoolView = function() {

--- a/src/disclosures/js/nemo-shim.js
+++ b/src/disclosures/js/nemo-shim.js
@@ -1,5 +1,3 @@
-// var $ = require('jquery');
-
 // To play nicer with nemo, add js class to body element
 var bodyTag = document.getElementsByTagName("body")[0];
 bodyTag.className += " js";
@@ -8,6 +6,3 @@ $('.toggle-menu').on('click', function(e){
     e.preventDefault();
     $('nav.main ul').toggleClass('vis');
 });
-
-// window.$ = $;
-// window.jQuery = $;

--- a/src/disclosures/js/nemo-shim.js
+++ b/src/disclosures/js/nemo-shim.js
@@ -1,0 +1,13 @@
+// var $ = require('jquery');
+
+// To play nicer with nemo, add js class to body element
+var bodyTag = document.getElementsByTagName("body")[0];
+bodyTag.className += " js";
+
+$('.toggle-menu').on('click', function(e){
+    e.preventDefault();
+    $('nav.main ul').toggleClass('vis');
+});
+
+// window.$ = $;
+// window.jQuery = $;

--- a/src/disclosures/js/nemo.js
+++ b/src/disclosures/js/nemo.js
@@ -1,5 +1,3 @@
-//var $ = require('jquery');
-
 var linkElement, hidemenu, dropdown, dropping;
 
 function escHandler(e) {

--- a/src/disclosures/js/nemo.js
+++ b/src/disclosures/js/nemo.js
@@ -1,0 +1,216 @@
+//var $ = require('jquery');
+
+var linkElement, hidemenu, dropdown, dropping;
+
+function escHandler(e) {
+    if(e.keyCode == 27) {
+        window.clearTimeout(countdown);
+        var target = $("#interScreen p:first a").attr("href");
+        $("#interScreen").remove();
+        $('a[href="'+target+'"]').get(0).focus();
+        $("body").unbind("keydown",escHandler);
+        return false;
+    }
+    return true;
+}
+
+function dropMenu() {
+  dropping = 1;
+  $("#closeMenu").remove();
+  var menuItem = $(linkElement);
+  var target = menuItem.attr("href");
+  var position = menuItem.offset().left - 1;
+  $(target).css("left",position + "px");
+  var position = menuItem.offset().top + menuItem.outerHeight();
+  $(target).css("top",position + "px");
+  $(target).append("<a id='closeMenu' class='close' href='#'>close menu</a>");
+  $("a#closeMenu").click(function(e) {
+    e.preventDefault();
+    var myParent = $(this).parent().attr("id");
+    hideMenu();
+    $('a[href="#'+myParent+'"]').removeClass("active");
+    $('a[href="#'+myParent+'"]').get(0).focus();
+    $('a[href="#'+myParent+'"]').css("outline","none");
+  });
+  var height = $(target).show().height();
+  $(target).hide().css('height', 0);
+  $(target).show().animate({height: height}, 400, function() {
+    dropping = 0;
+  });
+  $(target+" a:first").get(0).focus();
+  $(target+" a:first").css("outline","none");
+  menuItem.addClass("active");
+  dropdown = 0;
+}
+
+function hideMenu() {
+    $(".active").removeClass("active");
+    $("#closeMenu").remove();
+    $("#subnav nav").slideUp();
+}
+
+/* trigger when page is ready */
+$(document).ready(function (){
+    skipNav();
+    $("#header nav a").mouseenter(function() {
+        window.clearTimeout(hidemenu);
+        var target = $(this).attr("href");
+        if (($(target).css("display") == "none") || (target == "/")) {
+            hideMenu();
+            linkElement = this;
+            dropdown = window.setTimeout(dropMenu, 500);
+        }
+        else {
+
+        }
+        return false;
+    }).mouseleave(function() {
+        hidemenu = window.setTimeout(hideMenu, 500);
+        window.clearTimeout(dropdown);
+        dropdown = 0;
+    }).click(function(e) {
+        if(dropping) {
+            return false;
+        }
+        var clicked = $(this);
+        var target = clicked.attr("href");
+        if(target == "/") {
+            return true;
+        }
+        if ( $(target).css("display") == "none") {
+            if(!dropdown && !dropping) {
+                hideMenu();
+                linkElement = this;
+                dropMenu();
+            }
+        }
+        else {
+            if(!dropping) {
+                hideMenu();
+            }
+        }
+        return false;
+    });
+    $("#subnav nav").mouseenter(function() {
+        window.clearTimeout(hidemenu);
+        window.clearTimeout(dropdown);
+        var hovering = "#" + $(this).attr("id");
+    }).mouseleave(function() {
+        var hovering = "";
+        hidemenu = window.setTimeout(hideMenu,500);
+    });
+    $(".inf input").keyup(function() {
+      if ($(this).val()) {
+        $(this).addClass("filled");
+      }
+      else {
+        $(this).removeClass("filled");
+      }
+    });
+    $(".inf textarea").keyup(function() {
+      if ($(this).val()) {
+        $(this).addClass("filled");
+      }
+      else {
+        $(this).removeClass("filled");
+      }
+    });
+    $(".signup,.signup2").submit(function() {
+        var form = $(this);
+        form.children("fieldset").children("p:last-child").children("button").attr("disabled","disabled");
+
+        $.ajax({
+            type: "POST",
+            url: $(this).attr("action"),
+            data: form.serialize(),
+            complete: function(req, status_msg) {
+                if(status_msg){
+                    form.children("fieldset").hide();
+                    var thanks;
+                    if(form.attr("data-thanks")) {
+                        thanks = form.attr("data-thanks");
+                    }
+                    else {
+                        thanks = "Thanks, we'll be in touch.";
+                    }
+                    form.html("<p>"+thanks+"</p>");
+                } else {
+                    form.children("fieldset").hide();
+                    form.append("<p>Something went wrong. Please try again later.</p>");
+                }
+            }
+        });
+        return false;
+    });
+    $("a > img").each(function() {
+        $(this).parent().addClass("noStyles");
+    });
+    $(".mini a").mouseup(function(){
+        var link = $(this).attr("href");
+        link = link.replace("http://","/");
+        link = link.replace("http://","/");
+        var tracker = "/v/topshare"+link;
+        _gaq.push(['_trackPageview',tracker]); });
+    $(".botshare a").mouseup(function(){
+        var link = $(this).attr("href");
+        link = link.replace("http://","/");
+        link = link.replace("http://","/");
+        var tracker = "/v/botshare"+link;
+        _gaq.push(['_trackPageview',tracker]);
+    });
+    $('iframe').each(function() {
+        var url = $(this).attr("src")
+        $(this).attr("src",url+"?wmode=transparent")
+    });
+    $('a[href$="pdf"]').each(function() {
+        $(this).addClass("pdf");
+    });
+});
+
+/* Skip nav to primary content link */
+
+function skipNav() {
+    var $skipLink = $('#skip-link');
+    $skipLink.click(function() {
+        $('#primary-content').focus();
+    });
+}
+
+
+/* SEARCH BOX */
+$(function(){
+
+    // on page-load, determin the right placeholder color
+    var searchLabelNd = $('#search_form label');
+    if($('#search_form #query').val())
+        searchLabelNd.fadeOut(50);
+    else
+        searchLabelNd.fadeIn(50);
+
+
+    // placeholder text Behavior on focus and blur
+    $('#search_form #query').focus(function(){
+        if($(this).val())
+            searchLabelNd.fadeOut(50);
+        else
+            searchLabelNd.fadeIn(50);
+    });
+
+    $('#search_form #query').keyup(function(){
+        if($('#search_form #query').val())
+            searchLabelNd.fadeOut(50);
+        else
+            searchLabelNd.fadeIn(50);
+    });
+
+    $('#search_form #query').blur(function(){
+        if($(this).val() == ''){
+            searchLabelNd.fadeIn(50);
+        }else{
+            searchLabelNd.fadeOut(50);
+        }
+    });
+
+});
+
+/* END SEARCH BOX */


### PR DESCRIPTION
This adds a responsive version of the nemo header and footer (ala Owning a Home) when running the app in standalone mode.

Feel free to :-1: if we don't want to merge the demo template into `master`.
## Screenshot

![screen shot 2015-11-24 at 12 39 11 pm](https://cloud.githubusercontent.com/assets/212533/11375347/ce66c812-92a8-11e5-8367-3b1c8f5d861f.png)
## Review
- @niqjohnson 
- @higs4281 
