### PR TITLE
Remove container h1 from logo markup

### DIFF
--- a/paying_for_college/templates/standalone/base_update.html
+++ b/paying_for_college/templates/standalone/base_update.html
@@ -149,25 +149,23 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               <div role="banner">
                 {% block responsive_nav %}
                 {% endblock %}
-                <h1>
-                    <a href="/">
+                <a href="/" class="logo">
+                    <img id="logo"
+                         class="logo__js"
+                         src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.svg"
+                         onerror="this.src='http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png';"
+                         alt="Consumer Financial Protection Bureau"
+                         width="262"
+                         height="66">
+                    <noscript>
                         <img id="logo"
-                             class="logo__js"
-                             src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.svg"
-                             onerror="this.src='http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png';"
+                             class="logo__no-js"
+                             src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png"
                              alt="Consumer Financial Protection Bureau"
                              width="262"
                              height="66">
-                        <noscript>
-                            <img id="logo"
-                                 class="logo__no-js"
-                                 src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png"
-                                 alt="Consumer Financial Protection Bureau"
-                                 width="262"
-                                 height="66">
-                        </noscript>
-                    </a>
-                  </h1>
+                    </noscript>
+                </a>
                   <p class="lang"><span class="tel"><a href="tel:+18554112372">Contact us&nbsp;&nbsp;<strong>(855) 411-2372</strong></a></span></p>
                   <form accept-charset="UTF-8" action="http://search.consumerfinance.gov/search" class="single" id="search_form" method="get">
                                       <input name="utf8" type="hidden" value="&#x2713;" />

--- a/src/disclosures/css/nemo-shim.less
+++ b/src/disclosures/css/nemo-shim.less
@@ -77,6 +77,7 @@ strong {
 @media screen and (max-width: 660px) {
 
   // Scale the logo a bit
+  #header .logo,
   #header h1 {
     margin-left: 60px;
   }


### PR DESCRIPTION
This removes the need for a container `h1` tag around the logo markup to match the common CFPB Django templates.

If you're really interested in _why_ (and I know you are), [this](http://csswizardry.com/2010/10/your-logo-is-an-image-not-a-h1/) dives into why we shouldn't wrap image logos in `h1` tags.
## Review

@niqjohnson @marteki @higs4281 
