### PR TITLE
Add evaluate offer section

### DIFF
--- a/paying_for_college/templates/just-a-demo.html
+++ b/paying_for_college/templates/just-a-demo.html
@@ -424,6 +424,80 @@
                 </div>
             </div>
         </section>
+        <section class="step evaluate">
+            <h2 class="step_heading">Step 2. Evaluating your offer</h2>
+            <p>Asking yourself these questions will help you understand how accepting this offer can impact your ability to pay back your student debt and impact your financial future.</p>
+            <section class="criteria">
+                <h3 class="criteria_heading">Am I about to take out too many loans?</h3>
+                <p>There are two factors that make up your debt burden—your loan payment and your salary. The general rule of thumb is that your student loan payment shouldn’t be more than 14% of your monthly income.</p>
+                <p>If your debt burden is too high, it increases the chances of defaulting on your loan or not being able to pay for other necessities, like health insurance. Since it’s difficult to predict or actively increase your future salary, the best way to lower your debt burden is to reduce the amount of student loans you take out.</p>
+                <section class="metric debt-burden">
+                    <h4 class="metric_heading">Your estimated debt burden</h4>
+                    <p class="metric_explanation">We calculate your debt burden by dividing your monthly loan payment by the average salary for students who graduate from your program (provided by your school).</p>
+                    <div class="debt-burden_projection">
+                        <div class="debt-burden_projection-name">
+                            Projected salary
+                        </div>
+                        <div class="debt-burden_projection-value">
+                            $30,000 / yr.<br>
+                            $2,500 / mo.
+                        </div>
+                    </div>
+                    <div class="debt-burden_projection">
+                        <div class="debt-burden_projection-name">
+                            Your projected loan payment
+                        </div>
+                        <div class="debt-burden_projection-value">
+                            $550 / mo.
+                        </div>
+                    </div>
+                    <div class="debt-equation u-clearfix">
+                        <div class="debt-equation_part debt-equation_part__loan">
+                            <div class="debt-equation_number">$550</div>
+                            <div class="debt-equation_label">loan payment</div>
+                        </div>
+                        <div class="debt-equation_symbol">
+                            /
+                        </div>
+                        <div class="debt-equation_part debt-equation_part__income">
+                            <div class="debt-equation_number">$2,500</div>
+                            <div class="debt-equation_label">monthly income</div>
+                        </div>
+                        <div class="debt-equation_symbol">
+                            =
+                        </div>
+                        <div class="debt-equation_part debt-equation_part__percent">
+                            <div class="debt-equation_number">22%</div>
+                            <div class="debt-equation_label">of your income</div>
+                        </div>
+                    </div>
+                </section>
+                <section class="metric total-debt-after-graduation">
+                    <h4 class="metric_heading">Total debt after graduation</h4>
+                    <p class="metric_explanation">Average total debt (for the length of your program) that students studying Medical billing at Oak College or similar programs had after graduation.</p>
+                    <div class="bar-graph">
+                        <div class="bar-graph_bar"></div>
+                        <div class="bar-graph_point bar-graph_point__you u-clearfix">
+                            <div class="bar-graph_label">[School Name]</div>
+                            <div class="bar-graph_value">
+                                <div class="bar-graph_line"></div>
+                                <div class="bar-graph_number">$38,000</div>
+                            </div>
+                        </div>
+                        <div class="bar-graph_point bar-graph_point__average u-clearfix">
+                            <div class="bar-graph_label">National average</div>
+                            <div class="bar-graph_value">
+                                <div class="bar-graph_line"></div>
+                                <div class="bar-graph_number">$28,000</div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </section>
+            <section class="criteria">
+                <h3 class="criteria_heading">Will I graduate?</h3>
+                <p>Graduation is not a guarantee. And if you don’t graduate, you’ll still have to repay federal and private loans (and possibly even some grants), but you won’t have the added benefit of your degree to help earn more money.</p>
+        </section>
     </section>
 </main>
 <div class="financial-inputs">

--- a/paying_for_college/templates/just-a-demo.html
+++ b/paying_for_college/templates/just-a-demo.html
@@ -471,6 +471,13 @@
                             <div class="debt-equation_label">of your income</div>
                         </div>
                     </div>
+                    <div class="cf-notification cf-notification__error">
+                        <span class="cf-notification_icon cf-notification_icon__error cf-icon cf-icon-error-round"></span>
+                        <p class="cf-notification_text">
+                            Higher than recommended
+                            <span class="short-desc">Recommended not to exceed 14%</span>
+                        </p>
+                    </div>
                 </section>
                 <section class="metric total-debt-after-graduation">
                     <h4 class="metric_heading">Total debt after graduation</h4>
@@ -478,25 +485,235 @@
                     <div class="bar-graph">
                         <div class="bar-graph_bar"></div>
                         <div class="bar-graph_point bar-graph_point__you u-clearfix">
-                            <div class="bar-graph_label">[School Name]</div>
-                            <div class="bar-graph_value">
-                                <div class="bar-graph_line"></div>
-                                <div class="bar-graph_number">$38,000</div>
+                            <div class="bar-graph_row">
+                                <div class="bar-graph_label">[School Name]</div>
+                                <div class="bar-graph_value">
+                                    <div class="bar-graph_line"></div>
+                                    <div class="bar-graph_number">$38,000</div>
+                                </div>
                             </div>
                         </div>
                         <div class="bar-graph_point bar-graph_point__average u-clearfix">
-                            <div class="bar-graph_label">National average</div>
-                            <div class="bar-graph_value">
-                                <div class="bar-graph_line"></div>
-                                <div class="bar-graph_number">$28,000</div>
+                            <div class="bar-graph_row">
+                                <div class="bar-graph_label">National average</div>
+                                <div class="bar-graph_value">
+                                    <div class="bar-graph_line"></div>
+                                    <div class="bar-graph_number">$28,000</div>
+                                </div>
                             </div>
                         </div>
+                    </div>
+                    <div class="cf-notification cf-notification__error">
+                        <span class="cf-notification_icon cf-notification_icon__error cf-icon cf-icon-error-round"></span>
+                        <p class="cf-notification_text">
+                            Higher debt than national average
+                        </p>
                     </div>
                 </section>
             </section>
             <section class="criteria">
                 <h3 class="criteria_heading">Will I graduate?</h3>
                 <p>Graduation is not a guarantee. And if you don’t graduate, you’ll still have to repay federal and private loans (and possibly even some grants), but you won’t have the added benefit of your degree to help earn more money.</p>
+                <section class="metric graduation-rate">
+                    <h4 class="metric_heading">Graduation rate</h4>
+                    <p class="metric_explanation">Percentage of full-time students who graduate from a college or university</p>
+                    <div class="bar-graph">
+                        <div class="bar-graph_bar"></div>
+                        <div class="bar-graph_point bar-graph_point__you u-clearfix">
+                            <div class="bar-graph_row">
+                                <div class="bar-graph_label">[School Name]</div>
+                                <div class="bar-graph_value">
+                                    <div class="bar-graph_line"></div>
+                                    <div class="bar-graph_number">12%</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="bar-graph_point bar-graph_point__average u-clearfix">
+                            <div class="bar-graph_row">
+                                <div class="bar-graph_label">National average</div>
+                                <div class="bar-graph_value">
+                                    <div class="bar-graph_line"></div>
+                                    <div class="bar-graph_number">86%</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="cf-notification cf-notification__error">
+                        <span class="cf-notification_icon cf-notification_icon__error cf-icon cf-icon-error-round"></span>
+                        <p class="cf-notification_text">
+                            Lower graduation rate than national average
+                        </p>
+                    </div>
+                </section>
+            </section>
+            <section class="criteria">
+                <h3 class="criteria_heading">How will I afford my loan payment?</h3>
+                <p>Take into consideration how much money you can expect to make if you graduate, and then evaluate how much of that will be living expenses and loan payments.</p>
+                <section class="metric average-salary">
+                    <h4 class="metric_heading">Average salary</h4>
+                    <p class="metric_explanation">Expected first-year salary after graduating from your program</p>
+                    <div class="bar-graph">
+                        <div class="bar-graph_bar"></div>
+                        <div class="bar-graph_point bar-graph_point__you u-clearfix">
+                            <div class="bar-graph_row">
+                                <div class="bar-graph_label">[School Name]</div>
+                                <div class="bar-graph_value">
+                                    <div class="bar-graph_line"></div>
+                                    <div class="bar-graph_number">$26,000</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="bar-graph_point bar-graph_point__average u-clearfix">
+                            <div class="bar-graph_row">
+                                <div class="bar-graph_label">National average</div>
+                                <div class="bar-graph_value">
+                                    <div class="bar-graph_line"></div>
+                                    <div class="bar-graph_number">$34,000</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="cf-notification cf-notification__error">
+                        <span class="cf-notification_icon cf-notification_icon__error cf-icon cf-icon-error-round"></span>
+                        <p class="cf-notification_text">
+                            Lower average salary than national average
+                        </p>
+                    </div>
+                </section>
+                <section class="metric estimated-expenses">
+                    <h4 class="metric_heading">Estimated expenses</h4>
+                    <p class="metric_explanation">Monthly cost of necessities for single person based on national averages</p>
+                    <form class="offer-part estimated-expenses_form" action="#">
+                        <div class="form-group_item offer-part_currency">
+                            <label class="form-label__wrapped">
+                                <span class="form-label_text-wrapper">Rent</span>
+                                <span class="offer-part_unit">$</span>
+                                <input class="offer-part_input" type="text" data-expense="monthlyRent" autocorrect="off">
+                            </label>
+                        </div>
+                        <div class="form-group_item offer-part_currency">
+                            <label class="form-label__wrapped">
+                                <span class="form-label_text-wrapper">Student loan payment</span>
+                                <span class="offer-part_unit">$</span>
+                                <input class="offer-part_input" type="text" data-expense="monthlyLoanPayment" autocorrect="off">
+                            </label>
+                        </div>
+                        <div class="form-group_item offer-part_currency">
+                            <label class="form-label__wrapped">
+                                <span class="form-label_text-wrapper">Food</span>
+                                <span class="offer-part_unit">$</span>
+                                <input class="offer-part_input" type="text" data-expense="monthlyFood" autocorrect="off">
+                            </label>
+                        </div>
+                        <div class="form-group_item offer-part_currency">
+                            <label class="form-label__wrapped">
+                                <span class="form-label_text-wrapper">Transportation</span>
+                                <span class="offer-part_unit">$</span>
+                                <input class="offer-part_input" type="text" data-expense="monthlyTransportation" autocorrect="off">
+                            </label>
+                        </div>
+                        <div class="form-group_item offer-part_currency">
+                            <label class="form-label__wrapped">
+                                <span class="form-label_text-wrapper">Health insurance</span>
+                                <span class="offer-part_unit">$</span>
+                                <input class="offer-part_input" type="text" data-expense="monthlyHealthInsurance" autocorrect="off">
+                            </label>
+                        </div>
+                        <div class="form-group_item offer-part_currency">
+                            <label class="form-label__wrapped">
+                                <span class="form-label_text-wrapper">Savings and retirement</span>
+                                <span class="offer-part_unit">$</span>
+                                <input class="offer-part_input" type="text" data-expense="monthlySavings" autocorrect="off">
+                            </label>
+                        </div>
+                        <div class="form-group_item offer-part_currency">
+                            <label class="form-label__wrapped">
+                                <span class="form-label_text-wrapper">Other</span>
+                                <span class="offer-part_unit">$</span>
+                                <input class="offer-part_input" type="text" data-expense="monthlyOther" autocorrect="off">
+                            </label>
+                        </div>
+                        <div class="content_line"></div>
+                        <div class="line-item">
+                            <div class="line-item_title">
+                                Total monthly expenses
+                            </div>
+                            <div class="line-item_value">
+                                <span class="line-item_currency">$</span>
+                                <span class="line-item_amount" data-expense="totalMonthlyExpenses"></span>
+                            </div>
+                        </div>
+                    </form>
+                    <div class="estimated-expenses_summary">
+                        <h5 class="estimated-expenses_heading">Grand total</h5>
+                        <div class="line-item">
+                            <div class="line-item_title">
+                                Average monthly salary
+                                <span class="estimated-expenses_explanation">Before taxes</span>
+                            </div>
+                            <div class="line-item_value">
+                                <span class="line-item_currency">$</span>
+                                <span class="line-item_amount" data-expense="monthlySalary"></span>
+                            </div>
+                        </div>
+                        <div class="line-item">
+                            <div class="line-item_title">
+                                Total monthly expenses
+                            </div>
+                            <div class="line-item_value">
+                                <span class="line-item_sign">( &minus; )</span>
+                                <span class="line-item_currency">$</span>
+                                <span class="line-item_amount" data-expense="totalMonthlyExpenses"></span>
+                            </div>
+                        </div>
+                        <div class="content_line"></div>
+                        <div class="line-item line-item__total">
+                            <div class="line-item_title">
+                                What you have leftover
+                            </div>
+                            <div class="line-item_value">
+                                <span class="line-item_currency">$</span>
+                                <span class="line-item_amount" data-expense="monthlyLeftover"></span>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </section>
+            <section class="criteria">
+                <h3 class="criteria_heading">What if I can’t afford my student loan payments?</h3>
+                <p>If you stop paying your loan, you could go into default. Defaulting on a loan can have serious negative affects on your financial future by lowering your credit score and making it very difficult to get a car or home loan.</p>
+                <section class="metric loan-default-rates">
+                    <h4 class="metric_heading">Loan default rates</h4>
+                    <p class="metric_explanation">Percentage of students who default on loans after entering repayment</p>
+                    <div class="bar-graph">
+                        <div class="bar-graph_bar"></div>
+                        <div class="bar-graph_point bar-graph_point__you u-clearfix">
+                            <div class="bar-graph_row">
+                                <div class="bar-graph_label">[School Name]</div>
+                                <div class="bar-graph_value">
+                                    <div class="bar-graph_line"></div>
+                                    <div class="bar-graph_number">72%</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="bar-graph_point bar-graph_point__average u-clearfix">
+                            <div class="bar-graph_row">
+                                <div class="bar-graph_label">National average</div>
+                                <div class="bar-graph_value">
+                                    <div class="bar-graph_line"></div>
+                                    <div class="bar-graph_number">32%</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="cf-notification cf-notification__error">
+                        <span class="cf-notification_icon cf-notification_icon__error cf-icon cf-icon-error-round"></span>
+                        <p class="cf-notification_text">
+                            Higher default rate than national average
+                        </p>
+                    </div>
+                </section>
+            </section>
         </section>
     </section>
 </main>

--- a/src/disclosures/css/cf-enhancements.less
+++ b/src/disclosures/css/cf-enhancements.less
@@ -59,3 +59,67 @@
   .webfont-medium();
   font-size: 1.125em;
 }
+
+/* ==========================================================================
+   Capital Framework Notification Styling
+   from https://github.com/cfpb/cfgov-refresh/blob/2c62c966880afba0d634df7062876abec3393661/cfgov/unprocessed/css/cf-notifications.less
+   ========================================================================== */
+
+.cf-notification {
+  @notification-padding__px: 11px;
+
+  position: relative;
+
+  padding: @notification-padding__px;
+  padding-left: 40px;
+  margin-bottom: @notification-padding__px + 4px;
+
+  background: @gray-20;
+  border: 1px solid @gray;
+
+  &__error {
+    background: @redorange-20;
+    border-color: @input-error;
+  }
+
+  &__success {
+    background: @green-tint;
+    border-color: @input-success;
+  }
+
+  &__warning {
+    background: @gold-20;
+    border-color: @input-warning;
+  }
+
+  &_icon {
+    position: absolute;
+    top: @notification-padding__px + 2px;
+    left: @notification-padding__px + 4px;
+
+    color: @gray-20;
+    font-size: unit( 18px / @base-font-size-px, em );
+
+    &__error {
+      color: #d14327;
+    }
+
+    &__success {
+      color: #2cb34a;
+    }
+
+    &__warning {
+      color: #ff931b;
+    }
+  }
+
+  &_text {
+    .h4();
+    margin: 0;
+
+    .short-desc {
+      display: block;
+      font-size: @base-font-size-px;
+    }
+  }
+}

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -272,7 +272,7 @@
 .metric {
   padding-top: unit(10px / @base-font-size-px, em);
   border-top: 1px solid @gray-50;
-  margin-top: unit(45px / @base-font-size-px, em);
+  margin-top: unit(30px / @base-font-size-px, em);
 }
 
 .metric_heading {
@@ -344,11 +344,16 @@
   @bar-graph-line-width:  51px;
 
   height: @bar-graph-height;
+  margin-bottom: unit(10px / @base-font-size-px, em);
   position: relative;
 
   &_point {
+    width: 100%;
+    position: absolute;
+  }
+
+  &_row {
     .grid_nested-col-group();
-    position: relative;
   }
 
   &_label,
@@ -398,6 +403,35 @@
   .bar-graph_line {
     border-top-color: @darkgray;
     border-top-style: dotted;
+  }
+}
+
+.estimated-expenses {
+  @expense-summary-font-size: 18px;
+
+  &_form {
+    margin-top: 0;
+  }
+
+  &_summary {
+    margin-top: unit(30px / @base-font-size-px, em);
+  }
+
+  &_heading {
+    padding-bottom: unit(5px / @expense-summary-font-size, em);
+    border-bottom: 1px solid @black;
+    margin-bottom: unit(10px / @expense-summary-font-size, em);
+  }
+
+  &_explanation {
+    display: block;
+    margin-top: unit(5px / @expense-summary-font-size, em);
+    .webfont-regular();
+    font-size: unit(14px / @expense-summary-font-size, em);
+  }
+
+  .content_line {
+    margin-bottom: unit(5px / @expense-summary-font-size, em);
   }
 }
 

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -254,6 +254,154 @@
 }
 
 /* ==========================================================================
+   Evaluating your offer
+   ========================================================================== */
+
+.criteria + .criteria {
+  margin-top: unit(45px / @base-font-size-px, em);
+}
+
+.criteria_heading {
+  .heading-3();
+
+  .respond-to-min(@bp-sm-min, {
+    .heading-2();
+  });
+}
+
+.metric {
+  padding-top: unit(10px / @base-font-size-px, em);
+  border-top: 1px solid @gray-50;
+  margin-top: unit(45px / @base-font-size-px, em);
+}
+
+.metric_heading {
+  .heading-4();
+
+  .respond-to-min(@bp-sm-min, {
+    .heading-3();
+  });
+}
+
+.metric_explanation {
+  margin-bottom: unit(15px / 14px, em);
+  font-size: unit(14px / @base-font-size-px, em);
+}
+
+.debt-burden_projection {
+  .grid_nested-col-group();
+  margin-bottom: unit(20px / @base-font-size-px, em);
+}
+
+.debt-burden_projection-name {
+  .grid_column(7);
+}
+
+.debt-burden_projection-value {
+  .grid_column(5);
+}
+
+.debt-equation {
+  padding-top: unit(10px / @base-font-size-px, em);
+  margin-bottom: unit(30px / @base-font-size-px, em);
+}
+
+.debt-equation_part {
+  float: left;
+}
+
+.debt-equation_part__loan {
+  width: 25%;
+}
+
+.debt-equation_part__income {
+  width: 25%;
+}
+
+.debt-equation_part__percent {
+  width: 20%;
+}
+
+.debt-equation_symbol {
+  @symbol-font-size-px: 36px;
+  margin-top: unit(3px / @symbol-font-size-px, em);
+  width: 15%;
+  float: left;
+  .webfont-medium();
+  font-size: @symbol-font-size-px;
+  text-align: center;
+}
+
+.debt-equation_number {
+  .webfont-medium();
+  font-size: unit(18px / @base-font-size-px, em);
+}
+
+// Needs to be nested to keep variables scoped
+.bar-graph {
+  @bar-graph-width:       45px;
+  @bar-graph-height:      130px;
+  @bar-graph-line-width:  51px;
+
+  height: @bar-graph-height;
+  position: relative;
+
+  &_point {
+    .grid_nested-col-group();
+    position: relative;
+  }
+
+  &_label,
+  &_value {
+    .grid_column(6);
+  }
+
+  &_line {
+    display: inline-block;
+    width: @bar-graph-line-width;
+    border-top-width: 3px;
+    margin-bottom: 5px;
+    margin-right: 5px;
+  }
+
+  &_number {
+    display: inline-block;
+  }
+
+  &_bar {
+    width: @bar-graph-width;
+    height: @bar-graph-height;
+    margin-left: unit( (@grid_gutter-width / 2) + (@bar-graph-line-width - @bar-graph-width) / 2, px);
+    position: absolute;
+    top: 0;
+    left: 50%;
+    background-color: @gray-20;
+  }
+}
+
+.bar-graph_point__you {
+
+  .bar-graph_number{
+    .webfont-medium();
+    font-size: unit(18px / @base-font-size-px, em);
+  }
+
+  .bar-graph_line {
+    border-top-color: @black;
+    border-top-style: solid;
+  }
+}
+
+.bar-graph_point__average {
+  color: @darkgray;
+
+  .bar-graph_line {
+    border-top-color: @darkgray;
+    border-top-style: dotted;
+  }
+}
+
+/* ==========================================================================
    Student debt calculator demo
    ========================================================================== */
 

--- a/src/disclosures/js/index.js
+++ b/src/disclosures/js/index.js
@@ -79,7 +79,23 @@ $( document ).ready( function() {
   $( '[data-financial="totalProgramDebt"]' ).text( '20,000' );
   $( '[data-financial="totalRepayment"]' ).text( '36,450' );
   $( '.total-debt-after-graduation .bar-graph_point__you').css('top', '20px');
-  $( '.total-debt-after-graduation .bar-graph_point__average').css('top', '60px');
+  $( '.total-debt-after-graduation .bar-graph_point__average').css('top', '80px');
+  $( '.graduation-rate .bar-graph_point__you').css('top', '100px');
+  $( '.graduation-rate .bar-graph_point__average').css('top', '20px');
+  $( '.average-salary .bar-graph_point__you').css('top', '90px');
+  $( '.average-salary .bar-graph_point__average').css('top', '40px');
+  $( '.loan-default-rates .bar-graph_point__you').css('top', '25px');
+  $( '.loan-default-rates .bar-graph_point__average').css('top', '70px');
+  $( '[data-expense="monthlyRent"]' ).val( '800' );
+  $( '[data-expense="monthlyLoanPayment"]' ).val( '550' );
+  $( '[data-expense="monthlyFood"]' ).val( '300' );
+  $( '[data-expense="monthlyTransportation"]' ).val( '200' );
+  $( '[data-expense="monthlyHealthInsurance"]' ).val( '100' );
+  $( '[data-expense="monthlySavings"]' ).val( '50' );
+  $( '[data-expense="monthlyOther"]' ).val( '50' );
+  $( '[data-expense="totalMonthlyExpenses"]' ).text( '2,050' );
+  $( '[data-expense="monthlySalary"]' ).text( '2,166' );
+  $( '[data-expense="monthlyLeftover"]' ).text( '116' );
 
   // End demo code
 

--- a/src/disclosures/js/index.js
+++ b/src/disclosures/js/index.js
@@ -78,6 +78,8 @@ $( document ).ready( function() {
   $( '[data-financial="remainingCost"]' ).text( '1,000' );
   $( '[data-financial="totalProgramDebt"]' ).text( '20,000' );
   $( '[data-financial="totalRepayment"]' ).text( '36,450' );
+  $( '.total-debt-after-graduation .bar-graph_point__you').css('top', '20px');
+  $( '.total-debt-after-graduation .bar-graph_point__average').css('top', '60px');
 
   // End demo code
 


### PR DESCRIPTION
Add the "evaluating your offer" section
## Additions
- Evaluate section HTML
- Evaluate section CSS/LESS
- New Capital Framework notification LESS
- Demo JS to populate evaluate section fields
## Testing
- This will only look right at small screen sizes. To test, pull in the `evaluate-offer` branch, run `gulp`, then run `./manage.py runserver` from your virtual environment. The page will be at `http://localhost:8000/paying-for-college/demo/`. Fire up Chrome's device emulator (or shrink your browser) and check it out on a phone-sized screen.
## Review
- @ascott1
- @marteki 
## Screenshots

![evaluate-offer](https://cloud.githubusercontent.com/assets/1862695/11596476/43d3f93a-9a83-11e5-9127-a6f1db9ca178.png)
## Todos
- Remove the demo JS when the real JS is working
## Checklist
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [X] Passes all existing automated tests
- [X] Placeholder code is flagged
- [X] Visually tested in supported browsers and devices
