### PR TITLE
Api

### DIFF
--- a/paying_for_college/config/settings/base.py
+++ b/paying_for_college/config/settings/base.py
@@ -14,7 +14,7 @@ DEBUG = False
 
 ALLOWED_HOSTS = []
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -25,7 +25,7 @@ INSTALLED_APPS = (
     'paying_for_college',
     'south',
     'haystack',
-)
+]
 
 HAYSTACK_CONNECTIONS = {
     'default': {

--- a/paying_for_college/config/settings/no_haystack.py
+++ b/paying_for_college/config/settings/no_haystack.py
@@ -1,0 +1,3 @@
+from .standalone import *
+
+INSTALLED_APPS.remove('haystack')

--- a/paying_for_college/disclosures/scripts/api_utils.py
+++ b/paying_for_college/disclosures/scripts/api_utils.py
@@ -35,14 +35,14 @@ try:
 except:  # pragma: no cover
     API_KEY = '0123456789' * 4
 API_ROOT = "https://api.data.gov/ed/collegescorecard/v1"
-SCHOOLS_ROOT = "{}/schools".format(API_ROOT)
-# SCHEMA_ROOT = "{}/data.json".format(API_ROOT)
+SCHOOLS_ROOT = "{0}/schools".format(API_ROOT)
+# SCHEMA_ROOT = "{0}/data.json".format(API_ROOT)
 PAGE_MAX = 100  # the max page size allowed as of 2015-09-14
 
 MODEL_MAP = {
     'ope6_id': 'ope6_id',
     'ope8_id': 'ope8_id',
-    '{}.student.size'.format(LATEST_YEAR): 'enrollment',
+    '{0}.student.size'.format(LATEST_YEAR): 'enrollment',
     'school.accreditor': 'accreditor',
     'school.school_url': 'url',
     'school.degrees_awarded.predominant': 'degrees_predominant',  # data guide says this is INDICATORGROUP
@@ -57,12 +57,12 @@ MODEL_MAP = {
 }
 
 JSON_MAP = {
-    '{}.student.retention_rate.four_year.full_time'.format(LATEST_YEAR): 'RETENTRATE',
-    '{}.student.retention_rate.lt_four_year.full_time'.format(LATEST_YEAR): 'RETENTRATELT4',  # NEW
-    '{}.repayment.repayment_cohort.3_year_declining_balance'.format(LATEST_YEAR): 'REPAY3YR',  # NEW
-    '{}.repayment.3_yr_default_rate'.format(LATEST_YEAR): 'DEFAULTRATE',
-    '{}.aid.median_debt_suppressed.overall'.format(LATEST_YEAR): 'AVGSTULOANDEBT',
-    '{}.aid.median_debt_suppressed.completers.monthly_payments'.format(LATEST_YEAR): 'MEDIANDEBTCOMPLETER',  # NEW
+    '{0}.student.retention_rate.four_year.full_time'.format(LATEST_YEAR): 'RETENTRATE',
+    '{0}.student.retention_rate.lt_four_year.full_time'.format(LATEST_YEAR): 'RETENTRATELT4',  # NEW
+    '{0}.repayment.repayment_cohort.3_year_declining_balance'.format(LATEST_YEAR): 'REPAY3YR',  # NEW
+    '{0}.repayment.3_yr_default_rate'.format(LATEST_YEAR): 'DEFAULTRATE',
+    '{0}.aid.median_debt_suppressed.overall'.format(LATEST_YEAR): 'AVGSTULOANDEBT',
+    '{0}.aid.median_debt_suppressed.completers.monthly_payments'.format(LATEST_YEAR): 'MEDIANDEBTCOMPLETER',  # NEW
 }
 
 BASE_FIELDS = [
@@ -155,7 +155,7 @@ YEAR_FIELDS = [
 
 def build_field_string(YEAR=LATEST_YEAR):
     """assemble fields for an api query for an analysis csv"""
-    fields = BASE_FIELDS + ['{}.{}'.format(YEAR, field)
+    fields = BASE_FIELDS + ['{0}.{1}'.format(YEAR, field)
                             for field in YEAR_FIELDS]
     field_string = ",".join([field for field in fields])
     return field_string
@@ -164,7 +164,7 @@ def build_field_string(YEAR=LATEST_YEAR):
 # def get_schools_by_page(year, page=0):
 #     """get a page of schools for a single year as dict"""
 #     field_string = build_fields_string(year)
-#     url = "{}?api_key={}&page={}&per_page={}&fields={}".format(SCHOOLS_ROOT,
+#     url = "{0}?api_key={1}&page={2}&per_page={3}&fields={4}".format(SCHOOLS_ROOT,
 #                                                            API_KEY,
 #                                                            page,
 #                                                            PAGE_MAX,
@@ -176,7 +176,7 @@ def build_field_string(YEAR=LATEST_YEAR):
 def search_by_school_name(name):
     """search api by school name, return school name, id, city, state"""
     fields = "id,school.name,school.city,school.state"
-    url = "{}?api_key={}&school.name={}&fields={}".format(SCHOOLS_ROOT,
+    url = "{0}?api_key={1}&school.name={2}&fields={3}".format(SCHOOLS_ROOT,
                                                           API_KEY,
                                                           name,
                                                           fields)
@@ -186,10 +186,10 @@ def search_by_school_name(name):
 
 # def get_all_school_ids():
 #     """traverse pages, assemble all school ids and names and output as json."""
-#     collector = {}
-#     url = '{}?api_key={}&fields=id,school.name'.format(SCHOOLS_ROOT, API_KEY)
+#     collector = {0}
+#     url = '{0}?api_key={1}&fields=id,school.name'.format(SCHOOLS_ROOT, API_KEY)
 #     for page in range(1, 391):
-#         next_url = "{}&page={}".format(url, page)
+#         next_url = "{0}&page={1}".format(url, page)
 #         nextdata = json.loads(requests.get(next_url).text)
 #         for entry in nextdata['results']:
 #             collector[entry['id']] = entry['school.name']
@@ -206,7 +206,7 @@ def export_spreadsheet(year):
     container = {}
     for key in headings:
         container[key] = ''
-    url = '{}?api_key={}&per_page={}&fields={}'.format(SCHOOLS_ROOT,
+    url = '{0}?api_key={1}&per_page={2}&fields={3}'.format(SCHOOLS_ROOT,
                                                    API_KEY,
                                                    PAGE_MAX,
                                                    fields)
@@ -223,8 +223,8 @@ def export_spreadsheet(year):
     more_data = True
     #  harvest rest of pages
     while more_data:
-        print("getting page {}".format(next_page))
-        next_url = "{}&page={}".format(url, next_page)
+        print("getting page {0}".format(next_page))
+        next_url = "{0}&page={1}".format(url, next_page)
         try:
             nextdata = json.loads(requests.get(next_url).text)
         except:
@@ -238,7 +238,7 @@ def export_spreadsheet(year):
                 for key, value in school.iteritems():
                     collector[school['id']][key.replace('.', '_')] = value
             next_page = nextdata['metadata']['page'] + 1
-    with open('schools_{}.csv'.format(year), 'w') as f:
+    with open('schools_{0}.csv'.format(year), 'w') as f:
         writer = csv.writer(f)
         writer.writerow(headings)
         for school_id in collector:
@@ -246,8 +246,8 @@ def export_spreadsheet(year):
                              collector[school_id][field]
                              for field in headings
                              ])
-    print("export_spreadsheet took {} to process schools\
-    for the year {}".format((datetime.datetime.now()-starter), year))
+    print("export_spreadsheet took {0} to process schools\
+    for the year {1}".format((datetime.datetime.now()-starter), year))
     return data
 
 if __name__ == '__main__':  # pragma: no cover
@@ -298,28 +298,28 @@ def calculate_group_percent(group1, group2):
 # USF = 137351
 def get_repayment_data(school_id, year):
     """return metric on student debt repayment"""
-    school_id = "{}".format(school_id)
+    school_id = "{0}".format(school_id)
     entrylist = [
-        '{}.repayment.3_yr_repayment_suppressed.overall',
-        '{}.repayment.repayment_cohort.1_year_declining_balance',
-        '{}.repayment.1_yr_repayment.completers',
-        '{}.repayment.1_yr_repayment.noncompleters',
-        '{}.repayment.repayment_cohort.3_year_declining_balance',
-        '{}.repayment.3_yr_repayment.completers',
-        '{}.repayment.3_yr_repayment.noncompleters',
-        '{}.repayment.repayment_cohort.5_year_declining_balance',
-        '{}.repayment.5_yr_repayment.completers',
-        '{}.repayment.5_yr_repayment.noncompleters',
-        '{}.repayment.repayment_cohort.7_year_declining_balance',
-        '{}.repayment.7_yr_repayment.completers',
-        '{}.repayment.7_yr_repayment.noncompleters']
+        '{0}.repayment.3_yr_repayment_suppressed.overall',
+        '{0}.repayment.repayment_cohort.1_year_declining_balance',
+        '{0}.repayment.1_yr_repayment.completers',
+        '{0}.repayment.1_yr_repayment.noncompleters',
+        '{0}.repayment.repayment_cohort.3_year_declining_balance',
+        '{0}.repayment.3_yr_repayment.completers',
+        '{0}.repayment.3_yr_repayment.noncompleters',
+        '{0}.repayment.repayment_cohort.5_year_declining_balance',
+        '{0}.repayment.5_yr_repayment.completers',
+        '{0}.repayment.5_yr_repayment.noncompleters',
+        '{0}.repayment.repayment_cohort.7_year_declining_balance',
+        '{0}.repayment.7_yr_repayment.completers',
+        '{0}.repayment.7_yr_repayment.noncompleters']
     fields = ",".join([entry.format(year) for entry in entrylist])
-    url = "{}?id={}&api_key={}&fields={}".format(SCHOOLS_ROOT,
+    url = "{0}?id={1}&api_key={2}&fields={3}".format(SCHOOLS_ROOT,
                                              school_id,
                                              API_KEY,
                                              fields)
     data = requests.get(url).json()['results'][0]
-    repay_completers = data['{}.repayment.5_yr_repayment.completers'.format(year)]
-    repay_non = data['{}.repayment.5_yr_repayment.noncompleters'.format(year)]
+    repay_completers = data['{0}.repayment.5_yr_repayment.completers'.format(year)]
+    repay_non = data['{0}.repayment.5_yr_repayment.noncompleters'.format(year)]
     data['completer_repayment_rate_after_5_yrs'] = calculate_group_percent(repay_completers, repay_non)
     return data

--- a/paying_for_college/disclosures/scripts/api_utils.py
+++ b/paying_for_college/disclosures/scripts/api_utils.py
@@ -52,6 +52,7 @@ MODEL_MAP = {
     'school.online_only': 'online_only',
     'school.operating': 'operating',
     'school.under_investigation': 'under_investigation',
+    'school.zip': 'zip5',
 }
 
 JSON_MAP = {

--- a/paying_for_college/disclosures/scripts/update_colleges.py
+++ b/paying_for_college/disclosures/scripts/update_colleges.py
@@ -45,7 +45,7 @@ def update():
     bad_json_count = 0
     id_url = "{}&id={}&fields={}"
     for school in School.objects.all():
-    # for school in School.objects.all()[5:10]:
+        # print("{}".format(school))
         processed += 1
         sys.stdout.write('.')
         sys.stdout.flush()
@@ -79,6 +79,8 @@ def update():
                             if key in data.keys():
                                 data_dict[JSON_MAP[key]] = data[key]
                                 updated = True
+                            else:
+                                data_dict[JSON_MAP[key]] = None
                     else:
                         BAD_JSON.append(school)
                         print("second json parsing attempt failed for {}".format(school))

--- a/paying_for_college/disclosures/scripts/update_colleges.py
+++ b/paying_for_college/disclosures/scripts/update_colleges.py
@@ -21,9 +21,9 @@ from paying_for_college.models import School
 
 DATESTAMP = datetime.datetime.now().strftime("%Y-%m-%d")
 HOME = os.path.expanduser("~")
-NO_DATA_FILE = "{}/no_data_{}.json".format(HOME, DATESTAMP)
+NO_DATA_FILE = "{0}/no_data_{1}.json".format(HOME, DATESTAMP)
 SCRIPTNAME = os.path.basename(__file__)
-ID_BASE = "{}?api_key={}".format(api_utils.SCHOOLS_ROOT, api_utils.API_KEY)
+ID_BASE = "{0}?api_key={1}".format(api_utils.SCHOOLS_ROOT, api_utils.API_KEY)
 FIELDS = sorted(MODEL_MAP.keys() + JSON_MAP.keys())
 FIELDSTRING = ",".join(FIELDS)
 
@@ -48,14 +48,14 @@ def update():
     processed = 0
     update_count = 0
     bad_json_count = 0
-    id_url = "{}&id={}&fields={}"
+    id_url = "{0}&id={1}&fields={2}"
     for school in School.objects.filter(operating=True)[:20]:
-        # print("{}".format(school))
+        # print("{0}".format(school))
         processed += 1
         sys.stdout.write('.')
         sys.stdout.flush()
         if processed % 500 == 0:  # pragma: no cover
-            print("\n{}\n".format(processed))
+            print("\n{0}\n".format(processed))
         if processed % 5 == 0:
             time.sleep(1)
         url = id_url.format(ID_BASE, school.school_id, FIELDSTRING)
@@ -78,7 +78,7 @@ def update():
                         data_dict = json.loads(school.data_json)
                     except ValueError:
                         bad_json_count += 1
-                        # print("data_json wouldn't load on first try for {}".format(school))
+                        # print("data_json wouldn't load on first try for {0}".format(school))
                         data_dict = fix_json(school.data_json)
                     if data_dict:
                         for key in JSON_MAP:
@@ -89,7 +89,7 @@ def update():
                                 data_dict[JSON_MAP[key]] = None
                     else:
                         BAD_JSON.append(school)
-                        # print("second json parsing attempt failed for {}".format(school))
+                        # print("second json parsing attempt failed for {0}".format(school))
                     if updated is True:
                         update_count += 1
                         school.data_json = json.dumps(data_dict)
@@ -99,21 +99,21 @@ def update():
                     sys.stdout.flush()
                     NO_DATA.append(school)
             else:
-                print("request not OK, returned {}".format(resp.reason))
+                print("request not OK, returned {0}".format(resp.reason))
                 FAILED.append(school)
                 if resp.status_code == 429:
                     print("API limit reached")
                     print(resp.content)
                     break
                 else:
-                    print("request for {} returned {}".format(school,
+                    print("request for {0} returned {1}".format(school,
                                                               resp.status_code))
                     continue
-    endmsg = "\nTried to get new data for {} schools:\n\
-    updated {} and found no data for {}\n\
-    API response failures: {}\n\
-    {} schools had malformed data_json; {} of those couldn't be fixed.\n\
-    \n{} took {} to run".format(processed,
+    endmsg = "\nTried to get new data for {0} schools:\n\
+    updated {1} and found no data for {2}\n\
+    API response failures: {3}\n\
+    {4} schools had malformed data_json; {5} of those couldn't be fixed.\n\
+    \n{6} took {7} to run".format(processed,
                                 update_count,
                                 len(NO_DATA),
                                 len(FAILED),
@@ -122,7 +122,7 @@ def update():
                                 SCRIPTNAME,
                                 (datetime.datetime.now()-starter))
     if NO_DATA:
-        endmsg += "\nA list of schools that had no API data was saved to {}".format(NO_DATA_FILE)
+        endmsg += "\nA list of schools that had no API data was saved to {0}".format(NO_DATA_FILE)
         no_data_dict = {}
         for school in NO_DATA:
             no_data_dict[school.pk] = school.primary_alias

--- a/paying_for_college/disclosures/scripts/update_colleges.py
+++ b/paying_for_college/disclosures/scripts/update_colleges.py
@@ -21,9 +21,6 @@ from paying_for_college.models import School
 
 SCRIPTNAME = os.path.basename(__file__)
 ID_BASE = "{}?api_key={}".format(api_utils.SCHOOLS_ROOT, api_utils.API_KEY)
-FAILED = []  # failed to get a good API response
-NO_DATA = []  # API responded with no data
-BAD_JSON = []  # our School object had misformed data_json
 FIELDS = sorted(MODEL_MAP.keys() + JSON_MAP.keys())
 FIELDSTRING = ",".join(FIELDS)
 
@@ -38,13 +35,17 @@ def fix_json(jstring):
 
 def update():
     """update college-level data for current year"""
+    FAILED = []  # failed to get a good API response
+    NO_DATA = []  # API responded with no data
+    BAD_JSON = []  # our School object had misformed data_json
     updated = False
     starter = datetime.datetime.now()
     processed = 0
     update_count = 0
     bad_json_count = 0
     id_url = "{}&id={}&fields={}"
-    for school in School.objects.all()[5:10]:
+    for school in School.objects.all():
+    # for school in School.objects.all()[5:10]:
         processed += 1
         sys.stdout.write('.')
         sys.stdout.flush()
@@ -59,7 +60,7 @@ def update():
             continue
         else:
             time.sleep(1)
-            if resp.ok:
+            if resp.ok is True:
                 raw_data = resp.json()
                 if raw_data and raw_data['results']:
                     data = raw_data['results'][0]
@@ -90,7 +91,7 @@ def update():
                     print("API returned no data for {}".format(school))
                     NO_DATA.append(school)
             else:
-                print("request returned {}".format(resp.reason))
+                print("request not OK, returned {}".format(resp.reason))
                 FAILED.append(school)
                 if resp.status_code == 429:
                     print("API limit reached")
@@ -105,12 +106,12 @@ def update():
     API response failures: {}\n\
     {} schools had malformed data_json; {} of those couldn't be fixed.\n\
     \n{} took {} to run".format(processed,
-                              update_count,
-                              len(NO_DATA),
-                              len(FAILED),
-                              bad_json_count,
-                              len(BAD_JSON),
-                              SCRIPTNAME,
-                              (datetime.datetime.now()-starter))
+                                update_count,
+                                len(NO_DATA),
+                                len(FAILED),
+                                bad_json_count,
+                                len(BAD_JSON),
+                                SCRIPTNAME,
+                                (datetime.datetime.now()-starter))
     print(endmsg)
     return (FAILED, NO_DATA, BAD_JSON, endmsg)

--- a/paying_for_college/disclosures/scripts/update_colleges.py
+++ b/paying_for_college/disclosures/scripts/update_colleges.py
@@ -3,77 +3,114 @@
 We store broad, slow-changing values on the School model.
 More specific and changeable values are stored in the model's data_json field
 """
+from __future__ import print_function
 import os
+import ast
 import sys
 import time
+import json
 import datetime
 # import pprint
 # PP = pprint.PrettyPrinter(indent=4)
+
+import requests
 
 from paying_for_college.disclosures.scripts import api_utils
 from paying_for_college.disclosures.scripts.api_utils import MODEL_MAP, JSON_MAP
 from paying_for_college.models import School
 
 SCRIPTNAME = os.path.basename(__file__)
-ID_BASE = "%s?api_key=%s" % (api_utils.SCHOOLS_ROOT, api_utils.API_KEY)
-FAILED = []
-NO_DATA = []
+ID_BASE = "{}?api_key={}".format(api_utils.SCHOOLS_ROOT, api_utils.API_KEY)
+FAILED = []  # failed to get a good API response
+NO_DATA = []  # API responded with no data
+BAD_JSON = []  # our School object had misformed data_json
 FIELDS = sorted(MODEL_MAP.keys() + JSON_MAP.keys())
+FIELDSTRING = ",".join(FIELDS)
+
+
+def fix_json(jstring):
+    """attempt to fix a misquoted data_json string"""
+    try:
+        return ast.literal_eval(jstring)
+    except:
+        return {}
 
 
 def update():
     """update college-level data for current year"""
+    updated = False
     starter = datetime.datetime.now()
-    school_count = 0
-    updated = 0
-    ope6_count = 0
-    ope8_count = 0
-    id_url = "%s&id=%s&fields=%s"
-    for school in School.objects.all():
-        school_count += 1
+    processed = 0
+    update_count = 0
+    bad_json_count = 0
+    id_url = "{}&id={}&fields={}"
+    for school in School.objects.all()[5:10]:
+        processed += 1
         sys.stdout.write('.')
         sys.stdout.flush()
-        if school_count % 500 == 0:  # pragma: no cover
-            print(school_count)
-        url = id_url % (ID_BASE, school.school_id, FIELDS)
+        if processed % 500 == 0:  # pragma: no cover
+            print(processed)
+        url = id_url.format(ID_BASE, school.school_id, FIELDSTRING)
+        # print(url)
         try:
             resp = requests.get(url)
         except:
             FAILED.append(school)
             continue
         else:
+            time.sleep(1)
             if resp.ok:
-                time.sleep(1)
-                data = resp.json()
-                if data:
-                    updated += 1
+                raw_data = resp.json()
+                if raw_data and raw_data['results']:
+                    data = raw_data['results'][0]
                     for key in MODEL_MAP:
-                        setattr(school, MODEL_MAP[key], data[key])
-                    sjson = json.loads(school.data_json)
-                    for key in JSON_MAP:
-                        sjson[JSON_MAP[key]] = data[key]
-                        school.data_json = sjson
+                        if key in data.keys():
+                            setattr(school, MODEL_MAP[key], data[key])
+                            updated = True
+                    try:
+                        data_dict = json.loads(school.data_json)
+                    except ValueError:
+                        bad_json_count += 1
+                        print("data_json wouldn't load on first try for {}".format(school))
+                        data_dict = fix_json(school.data_json)
+                    if data_dict:
+                        for key in JSON_MAP:
+                            if key in data.keys():
+                                data_dict[JSON_MAP[key]] = data[key]
+                                updated = True
+                    else:
+                        BAD_JSON.append(school)
+                        print("second json parsing attempt failed for {}".format(school))
+                        continue
+                    if updated is True:
+                        update_count += 1
+                        school.data_json = json.dumps(data_dict)
                         school.save()
                 else:
+                    print("API returned no data for {}".format(school))
                     NO_DATA.append(school)
             else:
+                print("request returned {}".format(resp.reason))
                 FAILED.append(school)
                 if resp.status_code == 429:
                     print("API limit reached")
                     print(resp.content)
                     break
                 else:
-                    print("request for %s returned %s" % (school,
-                                                          resp.status_code))
+                    print("request for {} returned {}".format(school,
+                                                              resp.status_code))
                     continue
-    endmsg = "checked %s schools\n\
-    updated %s and found no data for %s\n\
-    failed to update %s\n\
-    %s took %s to run" % (school_count,
-                          updated,
-                          len(NO_DATA),
-                          len(FAILED),
-                          SCRIPTNAME,
-                          (datetime.datetime.now()-starter))
+    endmsg = "\nTried to get new data for {} schools:\n\
+    updated {} and found no data for {}\n\
+    API response failures: {}\n\
+    {} schools had malformed data_json; {} of those couldn't be fixed.\n\
+    \n{} took {} to run".format(processed,
+                              update_count,
+                              len(NO_DATA),
+                              len(FAILED),
+                              bad_json_count,
+                              len(BAD_JSON),
+                              SCRIPTNAME,
+                              (datetime.datetime.now()-starter))
     print(endmsg)
-    return (FAILED, NO_DATA, endmsg)
+    return (FAILED, NO_DATA, BAD_JSON, endmsg)

--- a/paying_for_college/migrations/0007_auto__add_field_program_campus__add_field_program_median_student_loan_.py
+++ b/paying_for_college/migrations/0007_auto__add_field_program_campus__add_field_program_median_student_loan_.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Program.campus'
+        db.add_column(u'paying_for_college_program', 'campus',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=255, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Program.median_student_loan_completers'
+        db.add_column(u'paying_for_college_program', 'median_student_loan_completers',
+                      self.gf('django.db.models.fields.IntegerField')(null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Program.job_note'
+        db.add_column(u'paying_for_college_program', 'job_note',
+                      self.gf('django.db.models.fields.TextField')(default='', blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Program.campus'
+        db.delete_column(u'paying_for_college_program', 'campus')
+
+        # Deleting field 'Program.median_student_loan_completers'
+        db.delete_column(u'paying_for_college_program', 'median_student_loan_completers')
+
+        # Deleting field 'Program.job_note'
+        db.delete_column(u'paying_for_college_program', 'job_note')
+
+
+    models = {
+        u'paying_for_college.alias': {
+            'Meta': {'object_name': 'Alias'},
+            'alias': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'is_primary': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'paying_for_college.bahrate': {
+            'Meta': {'object_name': 'BAHRate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'value': ('django.db.models.fields.IntegerField', [], {}),
+            'zip5': ('django.db.models.fields.CharField', [], {'max_length': '5'})
+        },
+        u'paying_for_college.constantcap': {
+            'Meta': {'ordering': "['name']", 'object_name': 'ConstantCap'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'value': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'paying_for_college.constantrate': {
+            'Meta': {'ordering': "['slug']", 'object_name': 'ConstantRate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'value': ('django.db.models.fields.DecimalField', [], {'max_digits': '6', 'decimal_places': '5'})
+        },
+        u'paying_for_college.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'contact': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'paying_for_college.disclosure': {
+            'Meta': {'object_name': 'Disclosure'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'paying_for_college.feedback': {
+            'Meta': {'object_name': 'Feedback'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {})
+        },
+        u'paying_for_college.nickname': {
+            'Meta': {'ordering': "['nickname']", 'object_name': 'Nickname'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'is_female': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'nickname': ('django.db.models.fields.TextField', [], {})
+        },
+        u'paying_for_college.program': {
+            'Meta': {'object_name': 'Program'},
+            'accreditor': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'books': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'campus': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'cip_code': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'completion_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'default_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'fees': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'housing': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'job_note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'job_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'level': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'median_student_loan_completers': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'other_costs': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'program_code': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'program_length': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'program_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'salary': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'soc_codes': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'time_to_complete': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'total_cost': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'transportation': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'tuition': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'paying_for_college.school': {
+            'KBYOSS': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'Meta': {'object_name': 'School'},
+            'accreditor': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'control': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'data_json': ('django.db.models.fields.TextField', [], {}),
+            'degrees_highest': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'degrees_predominant': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'enrollment': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'main_campus': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'online_only': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'ope6_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'ope8_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'operating': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'ownership': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'school_id': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'url': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'paying_for_college.worksheet': {
+            'Meta': {'object_name': 'Worksheet'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'guid': ('django.db.models.fields.CharField', [], {'max_length': '64', 'primary_key': 'True'}),
+            'saved_data': ('django.db.models.fields.TextField', [], {}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['paying_for_college']

--- a/paying_for_college/migrations/0008_auto__add_field_program_titleiv_debt__add_field_program_private_debt__.py
+++ b/paying_for_college/migrations/0008_auto__add_field_program_titleiv_debt__add_field_program_private_debt__.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Program.titleiv_debt'
+        db.add_column(u'paying_for_college_program', 'titleiv_debt',
+                      self.gf('django.db.models.fields.IntegerField')(null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Program.private_debt'
+        db.add_column(u'paying_for_college_program', 'private_debt',
+                      self.gf('django.db.models.fields.IntegerField')(null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Program.institutional_debt'
+        db.add_column(u'paying_for_college_program', 'institutional_debt',
+                      self.gf('django.db.models.fields.IntegerField')(null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Program.mean_student_loan_completers'
+        db.add_column(u'paying_for_college_program', 'mean_student_loan_completers',
+                      self.gf('django.db.models.fields.IntegerField')(null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'School.zip5'
+        db.add_column(u'paying_for_college_school', 'zip5',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=5, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Program.titleiv_debt'
+        db.delete_column(u'paying_for_college_program', 'titleiv_debt')
+
+        # Deleting field 'Program.private_debt'
+        db.delete_column(u'paying_for_college_program', 'private_debt')
+
+        # Deleting field 'Program.institutional_debt'
+        db.delete_column(u'paying_for_college_program', 'institutional_debt')
+
+        # Deleting field 'Program.mean_student_loan_completers'
+        db.delete_column(u'paying_for_college_program', 'mean_student_loan_completers')
+
+        # Deleting field 'School.zip5'
+        db.delete_column(u'paying_for_college_school', 'zip5')
+
+
+    models = {
+        u'paying_for_college.alias': {
+            'Meta': {'object_name': 'Alias'},
+            'alias': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'is_primary': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'paying_for_college.bahrate': {
+            'Meta': {'object_name': 'BAHRate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'value': ('django.db.models.fields.IntegerField', [], {}),
+            'zip5': ('django.db.models.fields.CharField', [], {'max_length': '5'})
+        },
+        u'paying_for_college.constantcap': {
+            'Meta': {'ordering': "['name']", 'object_name': 'ConstantCap'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'value': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'paying_for_college.constantrate': {
+            'Meta': {'ordering': "['slug']", 'object_name': 'ConstantRate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'value': ('django.db.models.fields.DecimalField', [], {'max_digits': '6', 'decimal_places': '5'})
+        },
+        u'paying_for_college.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'contact': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'paying_for_college.disclosure': {
+            'Meta': {'object_name': 'Disclosure'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'paying_for_college.feedback': {
+            'Meta': {'object_name': 'Feedback'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {})
+        },
+        u'paying_for_college.nickname': {
+            'Meta': {'ordering': "['nickname']", 'object_name': 'Nickname'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'is_female': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'nickname': ('django.db.models.fields.TextField', [], {})
+        },
+        u'paying_for_college.program': {
+            'Meta': {'object_name': 'Program'},
+            'accreditor': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'books': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'campus': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'cip_code': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'completion_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'default_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'fees': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'housing': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'institutional_debt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'job_note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'job_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'level': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'mean_student_loan_completers': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'median_student_loan_completers': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'other_costs': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'private_debt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'program_code': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'program_length': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'program_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'salary': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'soc_codes': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'time_to_complete': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'titleiv_debt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'total_cost': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'transportation': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'tuition': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'paying_for_college.school': {
+            'KBYOSS': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'Meta': {'object_name': 'School'},
+            'accreditor': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'control': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'data_json': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'degrees_highest': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'degrees_predominant': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'enrollment': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'main_campus': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'online_only': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'ope6_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'ope8_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'operating': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'ownership': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'school_id': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '2', 'blank': 'True'}),
+            'url': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'zip5': ('django.db.models.fields.CharField', [], {'max_length': '5', 'blank': 'True'})
+        },
+        u'paying_for_college.worksheet': {
+            'Meta': {'object_name': 'Worksheet'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'guid': ('django.db.models.fields.CharField', [], {'max_length': '64', 'primary_key': 'True'}),
+            'saved_data': ('django.db.models.fields.TextField', [], {}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['paying_for_college']

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -51,6 +51,7 @@ class ConstantCap(models.Model):
 # GRADRATERANK
 # INDICATORGROUP
 # KBYOSS (now school.KBYOSS)
+# MEDIANDEBTCOMPLETER # new in 2015
 # NETPRICE110K
 # NETPRICE3OK
 # NETPRICE48K
@@ -66,6 +67,8 @@ class ConstantCap(models.Model):
 # OTHERONCAMPUS
 # OTHERWFAMILY
 # RETENTRATE
+# RETENTRATELT4 # new in 2015
+# REPAY3YR # new in 2015
 # ROOMBRDOFFCAMPUS
 # ROOMBRDONCAMPUS
 # SCHOOL (now school.primary_alias)
@@ -103,7 +106,6 @@ class School(models.Model):
     main_campus = models.NullBooleanField()
     online_only = models.NullBooleanField()
     operating = models.BooleanField(default=True)
-
     KBYOSS = models.BooleanField(default=False)  # shopping-sheet participant
 
     def __unicode__(self):

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -165,9 +165,11 @@ class Program(models.Model):
     accreditor = models.CharField(max_length=255, blank=True)
     level = models.CharField(max_length=255, blank=True)
     program_code = models.CharField(max_length=255, blank=True)
+    campus = models.CharField(max_length=255, blank=True)
     cip_code = models.CharField(max_length=255, blank=True)
     soc_codes = models.CharField(max_length=255, blank=True)
-    total_cost = models.IntegerField(blank=True, null=True)
+    total_cost = models.IntegerField(blank=True, null=True,
+                                     help_text="COMPUTED")
     time_to_complete = models.IntegerField(blank=True,
                                            null=True,
                                            help_text="IN MONTHS")
@@ -175,15 +177,13 @@ class Program(models.Model):
                                           null=True,
                                           max_digits=5,
                                           decimal_places=2)
+    median_student_loan_completers = models.IntegerField(blank=True,
+                                                         null=True,
+                                                         help_text="TITLEIV_DEBT + PRIVATE_DEBT + INSTITUTIONAL_DEBT")
     default_rate = models.DecimalField(blank=True,
                                        null=True,
                                        max_digits=5,
                                        decimal_places=2)
-    job_rate = models.DecimalField(blank=True,
-                                   null=True,
-                                   max_digits=5,
-                                   decimal_places=2,
-                                   help_text="COMPLETERS WHO GET RELATED JOB")
     salary = models.IntegerField(blank=True, null=True)
     program_length = models.IntegerField(blank=True,
                                          null=True,
@@ -201,6 +201,13 @@ class Program(models.Model):
     transportation = models.IntegerField(blank=True, null=True)
     other_costs = models.IntegerField(blank=True,
                                       null=True)
+    job_rate = models.DecimalField(blank=True,
+                                   null=True,
+                                   max_digits=5,
+                                   decimal_places=2,
+                                   help_text="COMPLETERS WHO GET RELATED JOB")
+    job_note = models.TextField(blank=True,
+                                      help_text="EXPLANATION FROM SCHOOL")
 
     def __unicode__(self):
         return u"%s (%s)" % (self.program_name, unicode(self.institution))

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -37,47 +37,47 @@ class ConstantCap(models.Model):
 
 
 # data_json fields:
-# ALIAS
+# ALIAS (not needed)
 # AVGMONTHLYPAY
 # AVGSTULOANDEBT
 # AVGSTULOANDEBTRANK
-# BADALIAS
-# BAH 1356
+# BADALIAS (not needed)
+# BAH 1356 (no longer needed)
 # BOOKS
-# CITY Pittsburgh
-# CONTROL For Profit
+# CITY (now school.city)
+# CONTROL (now school.control)
 # DEFAULTRATE
 # GRADRATE
 # GRADRATERANK
 # INDICATORGROUP
-# KBYOSS
+# KBYOSS (now school.KBYOSS)
 # NETPRICE110K
 # NETPRICE3OK
 # NETPRICE48K
 # NETPRICE75K
 # NETPRICEGENERAL
 # NETPRICEOK
-# OFFERAA Yes
-# OFFERBA Yes
-# OFFERGRAD Yes
-# ONCAMPUSAVAIL No
-# ONLINE No
+# OFFERAA
+# OFFERBA
+# OFFERGRAD
+# ONCAMPUSAVAIL
+# ONLINE (now school.online)
 # OTHEROFFCAMPUS
 # OTHERONCAMPUS
 # OTHERWFAMILY
 # RETENTRATE
 # ROOMBRDOFFCAMPUS
 # ROOMBRDONCAMPUS
-# SCHOOL EDMC Central Administrative Office
-# SCHOOL_ID 483090
-# STATE PA
+# SCHOOL (now school.primary_alias)
+# SCHOOL_ID (now school.pk)
+# STATE (now school.state)
 # TUITIONGRADINDIS
 # TUITIONGRADINS
 # TUITIONGRADOSS
 # TUITIONUNDERINDIS
 # TUITIONUNDERINS
 # TUITIONUNDEROSS
-# ZIP 15222
+# ZIP (now school.zip5)
 
 
 class School(models.Model):
@@ -87,9 +87,10 @@ class School(models.Model):
     school_id = models.IntegerField(primary_key=True)
     ope6_id = models.IntegerField(blank=True, null=True)
     ope8_id = models.IntegerField(blank=True, null=True)
-    data_json = models.TextField()
-    city = models.CharField(max_length=50)
-    state = models.CharField(max_length=2)
+    data_json = models.TextField(blank=True)
+    city = models.CharField(max_length=50, blank=True)
+    state = models.CharField(max_length=2, blank=True)
+    zip5 = models.CharField(max_length=5, blank=True)
     enrollment = models.IntegerField(blank=True, null=True)
     accreditor = models.CharField(max_length=255, blank=True)
     ownership = models.CharField(max_length=255, blank=True)
@@ -177,6 +178,12 @@ class Program(models.Model):
                                           null=True,
                                           max_digits=5,
                                           decimal_places=2)
+    titleiv_debt = models.IntegerField(blank=True, null=True)
+    private_debt = models.IntegerField(blank=True, null=True)
+    institutional_debt = models.IntegerField(blank=True, null=True)
+    mean_student_loan_completers = models.IntegerField(blank=True,
+                                                         null=True,
+                                                         help_text="TITLEIV_DEBT + PRIVATE_DEBT + INSTITUTIONAL_DEBT")
     median_student_loan_completers = models.IntegerField(blank=True,
                                                          null=True,
                                                          help_text="TITLEIV_DEBT + PRIVATE_DEBT + INSTITUTIONAL_DEBT")

--- a/paying_for_college/search_indexes.py
+++ b/paying_for_college/search_indexes.py
@@ -13,7 +13,7 @@ class SchoolIndex(indexes.SearchIndex, indexes.Indexable):
         return School
 
     def index_queryset(self, using=None):
-        return self.get_model().objects.all()
+        return self.get_model().objects.filter(operating=True)
 
     def prepare_autocomplete(self, obj):
         alias_strings = [a.alias for a in obj.alias_set.all()]

--- a/paying_for_college/tests/test_models.py
+++ b/paying_for_college/tests/test_models.py
@@ -2,6 +2,7 @@
 # -*- coding: utf8 -*-
 import json
 
+from paying_for_college.config.settings import no_haystack
 from django.test import TestCase
 from paying_for_college.models import School, Contact, Program, Alias, Nickname
 from paying_for_college.models import ConstantCap, ConstantRate, Disclosure

--- a/paying_for_college/tests/test_models.py
+++ b/paying_for_college/tests/test_models.py
@@ -2,7 +2,6 @@
 # -*- coding: utf8 -*-
 import json
 
-from paying_for_college.config.settings import no_haystack
 from django.test import TestCase
 from paying_for_college.models import School, Contact, Program, Alias, Nickname
 from paying_for_college.models import ConstantCap, ConstantRate, Disclosure

--- a/paying_for_college/tests/test_no_haystack.py
+++ b/paying_for_college/tests/test_no_haystack.py
@@ -3,10 +3,9 @@
 
 from unittest import TestCase
 
-from paying_for_college.config.settings import no_haystack
-
 
 class NoHaystackTest(TestCase):
 
     def test_settings(self):
+        from paying_for_college.config.settings import no_haystack
         self.assertTrue('haystack' not in no_haystack.INSTALLED_APPS)

--- a/paying_for_college/tests/test_no_haystack.py
+++ b/paying_for_college/tests/test_no_haystack.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+
+from unittest import TestCase
+
+from paying_for_college.config.settings import no_haystack
+
+
+class NoHaystackTest(TestCase):
+
+    def test_settings(self):
+        self.assertTrue('haystack' not in no_haystack.INSTALLED_APPS)

--- a/paying_for_college/tests/test_scripts.py
+++ b/paying_for_college/tests/test_scripts.py
@@ -41,10 +41,9 @@ class TestUpdater(django.test.TestCase):
         mock_response.json.return_value = self.mock_dict
         mock_response.ok = True
         mock_requests.return_value = mock_response
-        (FAILED, NO_DATA, BAD_JSON, endmsg) = update_colleges.update()
+        (FAILED, NO_DATA, endmsg) = update_colleges.update()
         self.assertTrue(len(NO_DATA) == 0)
         self.assertTrue(len(FAILED) == 0)
-        self.assertTrue(len(BAD_JSON) == 0)
         self.assertTrue('updated' in endmsg)
 
     @mock.patch('paying_for_college.disclosures.scripts.update_colleges.requests.get')
@@ -52,11 +51,11 @@ class TestUpdater(django.test.TestCase):
         mock_response = mock.Mock()
         mock_response.ok = False
         mock_response.reason = "Testing OK == False"
-        (FAILED, NO_DATA, BAD_JSON, endmsg) = update_colleges.update()
+        (FAILED, NO_DATA, endmsg) = update_colleges.update()
         # print("\n after OK == False, FAILED is %s" % FAILED)
         self.assertTrue(len(FAILED) == 1)
         mock_requests.status_code = 429
-        (FAILED, NO_DATA, BAD_JSON, endmsg) = update_colleges.update()
+        (FAILED, NO_DATA, endmsg) = update_colleges.update()
         # print("after 429 FAILED is %s" % FAILED)
         self.assertTrue(len(FAILED) == 1)
 
@@ -65,7 +64,7 @@ class TestUpdater(django.test.TestCase):
         mock_response = mock.Mock()
         mock_response.ok = True
         mock_response.json.return_value = {'results': []}
-        (FAILED, NO_DATA, BAD_JSON, endmsg) = update_colleges.update()
+        (FAILED, NO_DATA, endmsg) = update_colleges.update()
         # print("after results==[], NO_DATA is %s" % FAILED)
         self.assertTrue('no data' in endmsg)
 

--- a/paying_for_college/tests/test_scripts.py
+++ b/paying_for_college/tests/test_scripts.py
@@ -13,8 +13,8 @@ class TestUpdater(django.test.TestCase):
 
     mock_dict = {'results':
                  [{'id': 155317,
-                   'ope6_id': 'ope6_id',
-                   'ope8_id': 'ope8_id',
+                   'ope6_id': 5555,
+                   'ope8_id': 55500,
                    'enrollment': 10000,
                    'accreditor': "Santa",
                    'url': '',
@@ -35,15 +35,39 @@ class TestUpdater(django.test.TestCase):
                  'metadata': {'page': 0}
                  }
 
-    @mock.patch('paying_for_college.disclosures.scripts.api_utils.requests.get')
+    @mock.patch('paying_for_college.disclosures.scripts.update_colleges.requests.get')
     def test_update_colleges(self, mock_requests):
         mock_response = mock.Mock()
         mock_response.json.return_value = self.mock_dict
-        mock_response.ok.return_value = True
+        mock_response.ok = True
         mock_requests.return_value = mock_response
         (FAILED, NO_DATA, BAD_JSON, endmsg) = update_colleges.update()
         self.assertTrue(len(NO_DATA) == 0)
+        self.assertTrue(len(FAILED) == 0)
+        self.assertTrue(len(BAD_JSON) == 0)
         self.assertTrue('updated' in endmsg)
+
+    @mock.patch('paying_for_college.disclosures.scripts.update_colleges.requests.get')
+    def test_update_colleges_not_OK(self, mock_requests):
+        mock_response = mock.Mock()
+        mock_response.ok = False
+        mock_response.reason = "Testing OK == False"
+        (FAILED, NO_DATA, BAD_JSON, endmsg) = update_colleges.update()
+        # print("\n after OK == False, FAILED is %s" % FAILED)
+        self.assertTrue(len(FAILED) == 1)
+        mock_requests.status_code = 429
+        (FAILED, NO_DATA, BAD_JSON, endmsg) = update_colleges.update()
+        # print("after 429 FAILED is %s" % FAILED)
+        self.assertTrue(len(FAILED) == 1)
+
+    @mock.patch('paying_for_college.disclosures.scripts.update_colleges.requests.get')
+    def test_update_colleges_bad_responses(self, mock_requests):
+        mock_response = mock.Mock()
+        mock_response.ok = True
+        mock_response.json.return_value = {'results': []}
+        (FAILED, NO_DATA, BAD_JSON, endmsg) = update_colleges.update()
+        # print("after results==[], NO_DATA is %s" % FAILED)
+        self.assertTrue('no data' in endmsg)
 
 
 class TestScripts(unittest.TestCase):
@@ -60,7 +84,7 @@ class TestScripts(unittest.TestCase):
         percent = api_utils.calculate_group_percent(0, 0)
         self.assertTrue(percent == 0)
 
-    @mock.patch('paying_for_college.disclosures.scripts.api_utils.requests.get')
+    @mock.patch('paying_for_college.disclosures.scripts.update_colleges.requests.get')
     def test_get_repayment_data(self, mock_requests):
         mock_response = mock.Mock()
         expected_dict = {'results':
@@ -71,7 +95,7 @@ class TestScripts(unittest.TestCase):
         data = api_utils.get_repayment_data(123456, YEAR)
         self.assertTrue(data['completer_repayment_rate_after_5_yrs'] == 10.0)
 
-    @mock.patch('paying_for_college.disclosures.scripts.api_utils.requests.get')
+    @mock.patch('paying_for_college.disclosures.scripts.update_colleges.requests.get')
     def test_export_spreadsheet_no_data(self, mock_requests):
         mock_response = mock.Mock()
         expected_dict = {}
@@ -80,7 +104,7 @@ class TestScripts(unittest.TestCase):
         data = api_utils.export_spreadsheet(YEAR)
         self.assertTrue(data == expected_dict)
 
-    @mock.patch('paying_for_college.disclosures.scripts.api_utils.requests.get')
+    @mock.patch('paying_for_college.disclosures.scripts.update_colleges.requests.get')
     def test_search_by_school_name(self, mock_requests):
         mock_response = mock.Mock()
         mock_response.json.return_value = self.mock_dict
@@ -88,7 +112,7 @@ class TestScripts(unittest.TestCase):
         data = api_utils.search_by_school_name('mockname')
         self.assertTrue(data == self.mock_dict['results'])
 
-    @mock.patch('paying_for_college.disclosures.scripts.api_utils.requests.get')
+    @mock.patch('paying_for_college.disclosures.scripts.update_colleges.requests.get')
     def test_export_spreadsheet(self, mock_requests):
         mock_response = mock.Mock()
         mock_response.text.return_value = json.dumps({'results': []})

--- a/paying_for_college/tests/test_scripts.py
+++ b/paying_for_college/tests/test_scripts.py
@@ -41,9 +41,9 @@ class TestUpdater(django.test.TestCase):
         mock_response.json.return_value = self.mock_dict
         mock_response.ok.return_value = True
         mock_requests.return_value = mock_response
-        (FAILED, NO_DATA, endmsg) = update_colleges.update()
+        (FAILED, NO_DATA, BAD_JSON, endmsg) = update_colleges.update()
         self.assertTrue(len(NO_DATA) == 0)
-        self.assertTrue('checked' in endmsg)
+        self.assertTrue('updated' in endmsg)
 
 
 class TestScripts(unittest.TestCase):

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -48,7 +48,6 @@ class TestViews(django.test.TestCase):
 
     def test_feedback(self):
         response = client.get(reverse('disclosures:pfc-feedback'))
-        print("context keys are %s" % sorted(response.context_data.keys()))
         self.assertTrue(sorted(response.context_data.keys()) ==
                         ['base_template', 'form', 'url_root'])
 

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -30,22 +30,21 @@ if STANDALONE:
     BASE_TEMPLATE = "standalone/base_update.html"
 else:  # pragma: no cover
     BASE_TEMPLATE = "front/base_update.html"
-    # BASE_TEMPLATE = "%s/templates/base_update.html" % BASEDIR
 
 URL_ROOT = 'paying_for_college2'
 
 LEVEL_MAP = {  # Dept. of Ed classification of post-secondary degree levels
-    '1': 'Program of less than 1 academic year',
-    '2': 'Program of at least 1 but less than 2 academic years',
-    '3': 'Associate’s degree - 2 academic years',
-    '4': 'Program of at least 2 but less than 4 academic years',
-    '5': 'Bachelor’s degree',
-    '6': 'Post-baccalaureate certificate',
-    '7': 'Master’s degree',
-    '8': 'Post-master’s certificate',
-    '17': 'Doctor’s degree-research/scholarship',
-    '18': 'Doctor’s degree-professional practice',
-    '19': 'Doctor’s degree-other'
+    '1': "Program of less than 1 academic year",
+    '2': "Program of at least 1 but less than 2 academic years",
+    '3': "Associate's degree",
+    '4': "Program of at least 2 but less than 4 academic years",
+    '5': "Bachelor's degree",
+    '6': "Post-baccalaureate certificate",
+    '7': "Master's degree",
+    '8': "Post-master's certificate",
+    '17': "Doctor's degree-research/scholarship",
+    '18': "Doctor's degree-professional practice",
+    '19': "Doctor's degree-other"
 }
 
 

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -34,6 +34,20 @@ else:  # pragma: no cover
 
 URL_ROOT = 'paying_for_college2'
 
+LEVEL_MAP = {  # Dept. of Ed classification of post-secondary degree levels
+    '1': 'Program of less than 1 academic year',
+    '2': 'Program of at least 1 but less than 2 academic years',
+    '3': 'Associate’s degree - 2 academic years',
+    '4': 'Program of at least 2 but less than 4 academic years',
+    '5': 'Bachelor’s degree',
+    '6': 'Post-baccalaureate certificate',
+    '7': 'Master’s degree',
+    '8': 'Post-master’s certificate',
+    '17': 'Doctor’s degree-research/scholarship',
+    '18': 'Doctor’s degree-professional practice',
+    '19': 'Doctor’s degree-other'
+}
+
 
 class BaseTemplateView(TemplateView):
 


### PR DESCRIPTION
This makes model and api adjustments for our first deployment to build.
## Additions
- no_hastack settings file to allow efficient data loading
- new model fields to handle API data
- fix tests to match API script changes
## Changes
- API scripts updated with new fields and harvesting routine
- switches to python3-compliant print statements, a SAG recommendation
## Testing

After importing, update the database for new model fields with:

``` bash
./manage.py migrate paying_for_college
```

If using UnityBox, this needs to be run from inside the vagrant machine:

``` bash
vagrant ssh
workon cfpb_django
cd /var/www/django/cfpb
./manage.py migrate paying_for_college
sudo service httpd restart
```
## Review

You can ignore the migration files.
- @ascott1 @marteki @niqjohnson 
