### PR TITLE
Add large screen styles for the big question

### DIFF
--- a/paying_for_college/templates/just-a-demo.html
+++ b/paying_for_college/templates/just-a-demo.html
@@ -1190,25 +1190,45 @@
                     </section>
                 </section>
             </section>
-            <div class="block block__flush-sides block__bg question">
-                <h2 class="step_heading">
-                    Do you feel like acquiring this amount of debt by attending this school is a good investment in your future?
-                </h2>
-                <div class="question_answers">
-                    <button class="btn btn__grouped-first">
-                        No
-                    </button>
-                    <button class="btn btn__grouped">
-                        Yes
-                    </button>
-                    <button class="btn btn__grouped-last">
-                        Not sure
-                    </button>
+        </section>
+    </div>
+
+
+
+
+    <section class="question step">
+        <div class="content_wrapper">
+            <div class="content_main">
+                <div class="question_wrapper">
+                    <div class="question_content">
+                        <h2 class="step_heading">
+                            Do you feel like acquiring this amount of debt by attending this school is a good investment in your future?
+                        </h2>
+                        <div class="question_answers">
+                            <button class="btn btn__grouped-first">
+                                No
+                            </button>
+                            <button class="btn btn__grouped">
+                                Yes
+                            </button>
+                            <button class="btn btn__grouped-last">
+                                Not sure
+                            </button>
+                        </div>
+                        <p>
+                            Your response does not affect your ability to accept or reject the actual offer with your school.
+                        </p>
+                    </div>
                 </div>
-                <p>
-                    Your response does not affect your ability to accept or reject the actual offer with your school.
-                </p>
             </div>
+        </div>
+    </section>
+
+
+
+
+    <div class="wrapper">
+        <section class="content_main">
             <section class="step get-options">
                 <h2 class="step_heading">
                     Step 3: You have options

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -523,13 +523,37 @@
    ========================================================================== */
 
 .question {
-  padding-bottom: unit(30px / @base-font-size-px, em);
-  margin-top: unit(45px / @base-font-size-px, em);
-  background-color: @gray-20;
-}
+  background-color: @gold-20;
 
-.question_answers {
-  margin-bottom: unit(20px / @base-font-size-px, em);
+  &_wrapper {
+    .respond-to-min(@bp-sm-min, {
+      .grid_nested-col-group();
+    });
+  }
+
+  &_content {
+    .respond-to-min(@bp-sm-min, {
+      .grid_column(8);
+    });
+  }
+
+  &_answers {
+    margin-bottom: unit(20px / @base-font-size-px, em);
+
+    .respond-to-min(@bp-sm-min, {
+      margin-bottom: unit(30px / @base-font-size-px, em);
+    });
+  }
+
+  & .content_main {
+    padding-top: unit(20px / @base-font-size-px, em);
+    padding-bottom: unit(20px / @base-font-size-px, em);
+
+    .respond-to-min(@bp-sm-min, {
+      padding-top: unit(30px / @base-font-size-px, em);
+    padding-bottom: unit(30px / @base-font-size-px, em);
+    });
+  }
 }
 
 /* ==========================================================================

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -551,7 +551,7 @@
 
     .respond-to-min(@bp-sm-min, {
       padding-top: unit(30px / @base-font-size-px, em);
-    padding-bottom: unit(30px / @base-font-size-px, em);
+      padding-bottom: unit(30px / @base-font-size-px, em);
     });
   }
 }


### PR DESCRIPTION
Add large-screen styles for the big question
## Additions
- Big question LESS for screens wider than `@bp-sm-min` (600px)
## Changes
- HTML changes to accommodate the large-screen design
## Testing
- To test, pull in the `question-large` branch and run `gulp`. Fire up the app in standalone or UnityBox as normal. The page will be at `/paying-for-college2/demo`.
## Review
- @ascott1
- @marteki 
## Screenshots

| 600px and under | 601px and above |
| --- | --- |
| ![question-small](https://cloud.githubusercontent.com/assets/1862695/11787209/90663c4a-a258-11e5-8c00-0a424fff2efd.png) | ![questino-large](https://cloud.githubusercontent.com/assets/1862695/11787214/95958c20-a258-11e5-917b-fe031b7b1116.png) |
## Todos
- Fix header spacing after the latest Capital Framework updates are pulled in
## Checklist
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [X] Passes all existing automated tests
- [X] Placeholder code is flagged
- [X] Visually tested in supported browsers and devices
