### PR TITLE
Options large

### DIFF
--- a/paying_for_college/templates/just-a-demo.html
+++ b/paying_for_college/templates/just-a-demo.html
@@ -1223,91 +1223,98 @@
             </div>
         </div>
     </section>
-
-
-
-
-    <div class="wrapper">
-        <section class="content_main">
-            <section class="step get-options">
-                <h2 class="step_heading">
-                    Step 3: You have options
-                </h2>
-                <p>
-                    Rest assured that there are things you can do if you are uncertain about taking the next step. Here are some choices you can make that may help you improve your financial future.
-                </p>
-                <h2 class="step_heading">
-                    Step 3: A few more things to consider
-                </h2>
-                <p>
-                    It’s important to feel confident in the financial decisions you are making. Here are some additional choices you can make that may help you improve your financial future even more.
-                </p>
-                <section class="option option__first">
-                    <h3>
+    <section class="get-options step content_wrapper">
+        <div class="content_main">
+            <div class="get-options_wrapper">
+                <div class="get-options_intro get-options_intro__no">
+                    <h2 class="step_heading">
+                        Step 3: You have options
+                    </h2>
+                    <p class="step_intro">
+                        Rest assured that there are things you can do if you are uncertain about taking the next step. Here are some choices you can make that may help you improve your financial future.
+                    </p>
+                </div>
+                <div class="get-options_intro get-options_intro__yes-not-sure">
+                    <h2 class="step_heading">
+                        Step 3: A few more things to consider
+                    </h2>
+                    <p class="step_intro">
+                        It’s important to feel confident in the financial decisions you are making. Here are some additional choices you can make that may help you improve your financial future even more.
+                    </p>
+                </div>
+            </div>
+            <div class="get-options_wrapper">
+                <section class="option option__maximize-grants">
+                    <h3 class="option_heading">
                         Maximize all available grants and scholarships.
                     </h3>
                     <p>
                         Consider applying for <a href="https://studentaid.ed.gov/sa/types/grants-scholarships">additional scholarships and grants</a>,  which provide money you don’t have to repay. By increasing the amount of this type of aid, you can decrease the overall amount of debt you have to borrow—and consequently pay back.
                     </p>
                 </section>
-                <section class="option">
-                    <h3>
+                <section class="option option__reduce-costs">
+                    <h3 class="option_heading">
                         Reduce your living costs.
                     </h3>
                     <p>
                         Living at home or finding cheaper off-campus housing can <a href="https://studentaid.ed.gov/sa/prepare-for-college/choosing-schools/consider/costs#lower-costs">reduce the cost of attendance</a>, meaning you’ll need to borrow less money overall.
                     </p>
                 </section>
-                <section class="option">
-                    <h3>
+                <section class="option option__different-program">
+                    <h3 class="option_heading">
                         Consider a different program with better outcomes.
                     </h3>
                     <p>
                         Salaries are often influenced by the degree you earn. If the projected salary of your program is far below the national average, you might consider a different program with a higher projected earning potential. Ask your admission counselor or search for “gainful employment” on your school’s website to <a href="#">learn more about your projected salary</a>.
                     </p>
                 </section>
-                <section class="option">
-                    <h3>
+                <section class="option option__transfer-credits">
+                    <h3 class="option_heading">
                         Make sure you don’t have to take classes twice.
                     </h3>
                     <p>
                         <a href="http://www.consumer.ftc.gov/articles/0395-choosing-college-questions-ask">Ask if credits from your school transfer</a> to degrees earned at other schools. Only X% of students who start at this school finish here. In the case you decide to finish your education somewhere else, it’s important to know if the hard work you’ve put into your degree will be honored at another school.
                     </p>
                 </section>
-                <section class="option">
-                    <h3>
+                <section class="option option__explore-schools">
+                    <h3 class="option_heading">
                         Explore other schools that have similar programs.
                     </h3>
                     <p>
                         Review your total cost of attendance and determine if a less expensive school option (such as a community college) might also meet your educational needs. <a href="#">See all schools</a> that offer the same type of program in your area.
                     </p>
                 </section>
-                <h3 class="get-options_heading">
-                    What you can do
-                </h3>
-                <h3 class="get-options_heading">
-                    If you want to make a change
-                </h3>
-                <p>
-                    Using some of the strategies outlined above in the evaluation, try <a href="#">adjusting some of the offer amounts</a> in the tool. For instance, you can try reducing the amount of federal or private loans to see how it affects your overall debt.
-                </p>
-            </section>
-            <section class="step next-steps">
-                <h2 class="step_heading">
-                    Next steps
-                </h2>
-                <p>
-                    We have sent an email to your school notifying them that you have reviewed your personalized offer.
-                </p>
-                <p>
-                    You can now choose to move forward in the enrollment process.
-                </p>
-                <p>
-                    Next you will need to complete a brief training called <a href="https://studentaid.ed.gov/sa/fafsa/next-steps/entrance-counseling">Federal Loan Entrance Counseling</a>, which explains in more detail the federal loans being offered to you. This must be done before you can sign your promissory note, which will lock in your loans before you enroll.
-                </p>
-            </section>
-        </section>
-    </div>
+                <section class="option option__take-action column-well">
+                    <div class="column-well_content">
+                        <h3 class="column-well_header">
+                            What you can do
+                        </h3>
+                        <h3 class="column-well_header">
+                            If you want to make a change
+                        </h3>
+                        <p>
+                            Using some of the strategies outlined above in the evaluation, try <a href="#">adjusting some of the offer amounts</a> in the tool. For instance, you can try reducing the amount of federal or private loans to see how it affects your overall debt.
+                        </p>
+                    </div>
+                </section>
+            </div>
+        </div>
+    </section>
+    <div class="content_line"></div>
+    <section class="next-steps step content_wrapper">
+        <div class="content_main">
+            <div class="next-steps_wrapper">
+                <div class="next-steps_intro">
+                    <h2 class="step_heading">
+                        Next steps
+                    </h2>
+                    <p class="step_intro">
+                        We have sent an email to your school notifying them that you have reviewed your personalized offer. You can now choose to move forward in the enrollment process.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </section>
 </main>
 <div class="financial-inputs">
     <h2>Student debt calculator demo</h2>

--- a/paying_for_college/templates/just-a-demo.html
+++ b/paying_for_college/templates/just-a-demo.html
@@ -1309,10 +1309,43 @@
                         Next steps
                     </h2>
                     <p class="step_intro">
-                        We have sent an email to your school notifying them that you have reviewed your personalized offer. You can now choose to move forward in the enrollment process.
+                        We have notified your school that you have reviewed your personalized offer. You can now choose to move forward in the enrollment process.
                     </p>
                 </div>
             </div>
+            <ol class="super-numerals next-steps_list">
+                <li class="super-numerals next-steps_list-item">
+                    <p class="next-steps_list-intro">
+                        Review the edits you made to your offer:
+                    </p>
+                    <ul>
+                        <li>[Edit 1]</li>
+                        <li>[Edit 2]</li>
+                    </ul>
+                </li>
+                <li class="super-numerals next-steps_list-item">
+                    <p class="next-steps_list-intro">
+                        If you choose to move forward with the enrollment process, request any necessary changes to your offer from your school.
+                    </p>
+                    <p>
+                        Edits you made during this session are meant for your guidance and are not sent to your school. Use the summary to assist you during the conversation.
+                    </p>
+                    <p>
+                        After requesting any changes, ask your school to send you a revised offer to make sure they reflect your desired financial plan.
+                    </p>
+                </li>
+                <li class="super-numerals next-steps_list-item">
+                    <p class="next-steps_list-intro">
+                        Print your offer or save it as a PDF for reference while talking with your school or making your final decision.
+                    </p>
+                    <div class="next-steps_controls">
+                        <button class="btn">
+                            <span class="btn_icon__left cf-icon cf-icon-print"></span>
+                            Print my offer
+                        </button>
+                    </div>
+                </li>
+            </ol>
         </div>
     </section>
 </main>

--- a/src/disclosures/css/cf-enhancements.less
+++ b/src/disclosures/css/cf-enhancements.less
@@ -171,3 +171,61 @@
     }
   }
 }
+
+/* ==========================================================================
+   Big numbered lists (from Know Before You Owe)
+   ========================================================================== */
+
+@char-icon-size: unit(32px / @base-font-size-px, em);
+@char-icon-spacing: 0.5em;
+
+.char-icon {
+  box-sizing: border-box;
+  padding-left: @char-icon-size + @char-icon-spacing;
+  position: relative;
+
+  &:before {
+    display: block;
+    box-sizing: border-box;
+    width: @char-icon-size;
+    height: @char-icon-size;
+    border-radius: 100%;
+    margin-right: @char-icon-spacing;
+    position: absolute;
+    left: 0;
+    top: unit(@base-line-height - @char-icon-size, em);
+    background: @green-tint;
+    color: @black;
+    .webfont-medium();
+    font-size: unit(18px / @base-font-size-px, em);
+    line-height: @char-icon-size;
+    text-align: center;
+    text-indent: 0;
+  }
+
+  &__1:before { content: '1'; }
+  &__2:before { content: '2'; }
+  &__3:before { content: '3'; }
+  &__4:before { content: '4'; }
+  &__5:before { content: '5'; }
+  &__6:before { content: '6'; }
+  &__7:before { content: '7'; }
+  &__8:before { content: '8'; }
+  &__9:before { content: '9'; }
+  &__0:before { content: '0'; }
+}
+
+// Ordered list with char-icon-style numerals
+.super-numerals {
+  padding-left: 0;
+  list-style: none;
+
+  & > li {
+    counter-increment: steps;
+    .char-icon();
+  }
+
+  & > li:before {
+    content: counter(steps);
+  }
+}

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -25,6 +25,12 @@
   &_heading {
     .heading-2();
   }
+
+  &_intro {
+    .respond-to-min(@bp-sm-min, {
+      .heading-3();
+    });
+  }
 }
 
 /* ==========================================================================
@@ -545,7 +551,7 @@
     });
   }
 
-  & .content_main {
+  .content_main {
     padding-top: unit(20px / @base-font-size-px, em);
     padding-bottom: unit(20px / @base-font-size-px, em);
 
@@ -560,26 +566,124 @@
    You have options
    ========================================================================== */
 
-.option {
-  padding-top: unit(245px / @base-font-size-px, em);
-  border-top: 1px solid @gray-50;
-  margin-top: unit(30px / @base-font-size-px, em);
-  background: center 15px no-repeat;
-  // Placeholder gray circle
-  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAMAAACahl6sAAAA7VBMVEX////n5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fxgD3mAAAAT3RSTlMAARo7XHuUprnM3/D4/yBNqdX5CHey7C7ABUib5AOd7iSK6AZaEXrnIZP0Hpj6GZIKgPZZ48aE+z7ZB48q0WwMqiZP8nT+lrUPyRXSHNfcklB2XQAABd5JREFUeAHt3YdyGnkSgPGvB5BzznbhY4/DuSg255x3/baXk3PeRMnZHFWscbYlSyiWBfTd7QVFEIiZ4d9T83uDr7qJCi0EQWYhAqiiswiA4LONMrlOZIbWUqoTa7XmcMi2kS0iU3RmjerzzUMOhuxqJF/M0J3UQD3x2KWQPSIyyspsUtWHToSkG0kZphdbtZ6o9jskI/KU3u1QrfQxJCvjE/hl3Xot9yckJ/IAP+1VLYUfckikit/Ser8WbshRkQpByKheDy8kL80KQcl4OhhOSEGkRJByqsXgQ+QVuU3QDuqPGnDIrv23CMOhu4+DDNmWlRuE44iWhwILeUuuEZ5jeimYkHdkkHDl9UIAIe9JkbAV9JzfIfL+j0L49JWz6mvIh/ID/fGqnvYx5ONinX5JFk7SAY8OfOL1r4O694lfE/lMLtFPb+nf/AhJH75Iv719s9pzyIerL9B/70yf7jHkKzmHC97TP/UU8o2cwQ0f6B96CDkup3DFR/o72ki07fDc6aDy69ydFYZ841IHVF76TWlFIV95p3FKJZP9xwpCPhw4i2N+/tW+n7t+i5JefQ7nnFud7jrk8AUcdOFwt0+/n13GTW/+rauJfCI4Sj7pZiIfe1dw1RvNkx2HfDhYx13J/OkOV0vE5Q7qIh1O5IOfcNvLZzoKea8ouE0L5zpYrXdEcJzIOx2ESBHnFWX51XrrOhYcvbTMRLYJJsi2ZUKy1zDhWrZ9yC7BCNnVLkT238CIG/ulzYP91TvYceCHlhMpCIZIoWWI3MaQ29IqJC+YIvkWIVLClJIsHXK0iTHNo0uGSAVjKrJUyCHBHNm4RIhUMKeyb3FITjBIcotCpIpBVVkYkhVMkuyCEHmASQ9kwbfxAzMYNT5vIpkJjJrIzAsRzJK5IWnLIek5IY2nmPW0MSckiWHJ2ZA9gmGy5/8hMoxhwzIbgmnRChFg1yS2rX0MHtDAuAbgAUmMSwIJ2NZoYtzaKRLwIoFxzTHFgy2YtwU8EMyTCIUIGxX7pOYhRICQoJnEvqmmxzoiYB2RWS1PohEinswQATPiCZEQh/QmDolD4pA4JA4hIuLVCkq8WjgmDlEiQaMTgn3xagUvDrEjDolD4pA4JEUEpNRTJQJUPaIRQoJGVH70tpYIWEtkVsujtgbz1tTwQDFPiU6IQGIt1k028GBzCuNSm8GDoQGMGxgCD6hjXB3wgATGJf4b8ngTpm16/N8QFNOU6IVsxbCtsyEPFcP04f9DqGNYndmQxA7M2pGYE1JVzNLqnBAsh8z/S8rdE9i07hFzJ8J6jFrP/BDdi0l7dUFIWTFJywtC0DQGpZWFISXFIC0tCuF+BnMy91kcUlPM0doSIWgGYzLKUiHXPYzxri8ZguYwJacsHTKomKKDLULQgxhyUGkVUlQM0WLLEH48hBmHfqR1iN49ghFH7mqbEB4rRuhj2oVQPoYJx8q0DxlSTNChZUK4lMeA/CWWC0ELOK+gLB9yQRXHqV7oIIRzr+C4V87RSQhnX8Vpr56lsxDVJA5Lqkb5SITHUk7qWzjqLT1J5yGcUBylJ+gmhL+9jZPe/hvdhXDzHRz0zk26DalOv4dz3puudh3Caf0Ax3ygp+k+hD/pRzjlI/0TKwnhD/oxDvlY/7DS63t3ci9VXDojGB92dOvUZnz81NFztPGBYOATuUL/vKEn/Pqj4xPNJH2TbJ6Iz5obODQfn/4H3pFBwpXXCwQQAm/JNcJzTC9BMCFsy8oNwnFEy0MEFgK79t8iDIfuPoYgQ5BX5DZBO6g/KgGHQEGkRJByqkUIPgTy0qwQlIyngxBOCBwVqQSToXodwguBjfukit/Ser8G4YZATuQBftqrWoLwQyAr4xP4Zd16LUN/QoCMyFN6t0O1AvQxBNKNpAzTi61aT1Sh3yHAHhEZZWU2qepDeif4ZFcj+WKG7qQG6onH+EPwz7aRLSJTdGaN6vPNQ/hG8NlGmVwnMkNrKdWJtVrDX0IQZBYigCo6iwD8E2XX7UHKO08rAAAAAElFTkSuQmCC);
-}
-
-.option__first {
-  border-top: none;
-}
-
-.get-options_heading {
-  margin-top: unit(45px / @font-size, em);
-  .heading-3();
+.get-options {
+  // Needed for the non-standard one-column well
+  overflow: hidden;
 
   .respond-to-min(@bp-sm-min, {
-    .heading-2();
+    padding-bottom: unit(30px / @base-font-size-px, em);
   });
+
+  &_wrapper {
+    .respond-to-min(@bp-sm-min, {
+      .grid_nested-col-group();
+    });
+  }
+
+  &_intro {
+    .respond-to-min(@bp-sm-min, {
+      .grid_column(8);
+    });
+  }
+
+  .content_main {
+    // Needed for the non-standard one-column well
+    padding-bottom: 0;
+  }
+
+  .step_intro {
+    margin-bottom: 0;
+  }
+
+  & + .content_line {
+    display: none;
+
+    .respond-to-min(@bp-sm-min, {
+      display: block;
+    });
+  }
+}
+
+.option {
+  margin-top: unit(30px / @base-font-size-px, em);
+
+  .respond-to-min(@bp-sm-min, {
+    .grid_column(4);
+    margin-top: unit(45px / @base-font-size-px, em);
+  });
+
+  &__maximize-grants,
+  &__reduce-costs,
+  &__different-program,
+  &__transfer-credits,
+  &__explore-schools {
+    background: center 15px no-repeat;
+    // Placeholder gray circle
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAMAAACahl6sAAAA7VBMVEX////n5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fxgD3mAAAAT3RSTlMAARo7XHuUprnM3/D4/yBNqdX5CHey7C7ABUib5AOd7iSK6AZaEXrnIZP0Hpj6GZIKgPZZ48aE+z7ZB48q0WwMqiZP8nT+lrUPyRXSHNfcklB2XQAABd5JREFUeAHt3YdyGnkSgPGvB5BzznbhY4/DuSg255x3/baXk3PeRMnZHFWscbYlSyiWBfTd7QVFEIiZ4d9T83uDr7qJCi0EQWYhAqiiswiA4LONMrlOZIbWUqoTa7XmcMi2kS0iU3RmjerzzUMOhuxqJF/M0J3UQD3x2KWQPSIyyspsUtWHToSkG0kZphdbtZ6o9jskI/KU3u1QrfQxJCvjE/hl3Xot9yckJ/IAP+1VLYUfckikit/Ser8WbshRkQpByKheDy8kL80KQcl4OhhOSEGkRJByqsXgQ+QVuU3QDuqPGnDIrv23CMOhu4+DDNmWlRuE44iWhwILeUuuEZ5jeimYkHdkkHDl9UIAIe9JkbAV9JzfIfL+j0L49JWz6mvIh/ID/fGqnvYx5ONinX5JFk7SAY8OfOL1r4O694lfE/lMLtFPb+nf/AhJH75Iv719s9pzyIerL9B/70yf7jHkKzmHC97TP/UU8o2cwQ0f6B96CDkup3DFR/o72ki07fDc6aDy69ydFYZ841IHVF76TWlFIV95p3FKJZP9xwpCPhw4i2N+/tW+n7t+i5JefQ7nnFud7jrk8AUcdOFwt0+/n13GTW/+rauJfCI4Sj7pZiIfe1dw1RvNkx2HfDhYx13J/OkOV0vE5Q7qIh1O5IOfcNvLZzoKea8ouE0L5zpYrXdEcJzIOx2ESBHnFWX51XrrOhYcvbTMRLYJJsi2ZUKy1zDhWrZ9yC7BCNnVLkT238CIG/ulzYP91TvYceCHlhMpCIZIoWWI3MaQ29IqJC+YIvkWIVLClJIsHXK0iTHNo0uGSAVjKrJUyCHBHNm4RIhUMKeyb3FITjBIcotCpIpBVVkYkhVMkuyCEHmASQ9kwbfxAzMYNT5vIpkJjJrIzAsRzJK5IWnLIek5IY2nmPW0MSckiWHJ2ZA9gmGy5/8hMoxhwzIbgmnRChFg1yS2rX0MHtDAuAbgAUmMSwIJ2NZoYtzaKRLwIoFxzTHFgy2YtwU8EMyTCIUIGxX7pOYhRICQoJnEvqmmxzoiYB2RWS1PohEinswQATPiCZEQh/QmDolD4pA4JA4hIuLVCkq8WjgmDlEiQaMTgn3xagUvDrEjDolD4pA4JEUEpNRTJQJUPaIRQoJGVH70tpYIWEtkVsujtgbz1tTwQDFPiU6IQGIt1k028GBzCuNSm8GDoQGMGxgCD6hjXB3wgATGJf4b8ngTpm16/N8QFNOU6IVsxbCtsyEPFcP04f9DqGNYndmQxA7M2pGYE1JVzNLqnBAsh8z/S8rdE9i07hFzJ8J6jFrP/BDdi0l7dUFIWTFJywtC0DQGpZWFISXFIC0tCuF+BnMy91kcUlPM0doSIWgGYzLKUiHXPYzxri8ZguYwJacsHTKomKKDLULQgxhyUGkVUlQM0WLLEH48hBmHfqR1iN49ghFH7mqbEB4rRuhj2oVQPoYJx8q0DxlSTNChZUK4lMeA/CWWC0ELOK+gLB9yQRXHqV7oIIRzr+C4V87RSQhnX8Vpr56lsxDVJA5Lqkb5SITHUk7qWzjqLT1J5yGcUBylJ+gmhL+9jZPe/hvdhXDzHRz0zk26DalOv4dz3puudh3Caf0Ax3ygp+k+hD/pRzjlI/0TKwnhD/oxDvlY/7DS63t3ci9VXDojGB92dOvUZnz81NFztPGBYOATuUL/vKEn/Pqj4xPNJH2TbJ6Iz5obODQfn/4H3pFBwpXXCwQQAm/JNcJzTC9BMCFsy8oNwnFEy0MEFgK79t8iDIfuPoYgQ5BX5DZBO6g/KgGHQEGkRJByqkUIPgTy0qwQlIyngxBOCBwVqQSToXodwguBjfukit/Ser8G4YZATuQBftqrWoLwQyAr4xP4Zd16LUN/QoCMyFN6t0O1AvQxBNKNpAzTi61aT1Sh3yHAHhEZZWU2qepDeif4ZFcj+WKG7qQG6onH+EPwz7aRLSJTdGaN6vPNQ/hG8NlGmVwnMkNrKdWJtVrDX0IQZBYigCo6iwD8E2XX7UHKO08rAAAAAElFTkSuQmCC);
+  }
+
+  &_heading {
+    padding-top: unit(245px / @font-size, em);
+    .heading-4();
+  }
+
+  // Rules on all but the first option on small screens but only the second row of options on larger screens
+  & + & &_heading {
+    border-top: 1px solid @gray-50;
+
+    .respond-to-min(@bp-sm-min, {
+      border-top: none;
+    });
+  }
+
+  & + & + & + & &_heading {
+
+    .respond-to-min(@bp-sm-min, {
+      border-top: 1px solid @gray-50;
+    });
+  }
+}
+
+// Non-standard one-column well
+.column-well {
+  padding-top: unit(25px / @base-font-size-px, em);
+  padding-bottom: unit(10px / @base-font-size-px, em);
+  position: relative;
+
+  .respond-to-min(@bp-sm-min, {
+    padding-top: unit(50px / @base-font-size-px, em);
+    padding-bottom: unit(50px / @base-font-size-px, em);
+  });
+
+  &:after {
+    width: 999px;
+    height: 999px;
+    position: absolute;
+    top: 0;
+    left: unit(-(@grid_gutter-width / @base-font-size-px) / 2, em);
+    z-index: 0;
+    background-color: @green-tint;
+    content: '';
+
+    .respond-to-min(@bp-sm-min, {
+      width: 100%;
+      left: 0;
+    });
+  }
+
+  &_content {
+    position: relative;
+    z-index: 1;
+
+    .respond-to-min(@bp-sm-min, {
+      padding-right: unit(30px / @base-font-size-px, em);
+      padding-left: unit(30px / @base-font-size-px, em);
+    });
+  }
+
+  &_header {
+    .heading-3();
+  }
 }
 
 /* ==========================================================================
@@ -587,9 +691,18 @@
    ========================================================================== */
 
 .next-steps {
-  padding-top: unit(15px / @base-font-size-px, em);
-  border-top: 1px solid @gray-50;
-  margin-top: unit(30px / @base-font-size-px, em);
+
+  &_wrapper {
+    .respond-to-min(@bp-sm-min, {
+      .grid_nested-col-group();
+    });
+  }
+
+  &_intro {
+    .respond-to-min(@bp-sm-min, {
+      .grid_column(8);
+    });
+  }
 }
 
 /* ==========================================================================

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -703,6 +703,36 @@
       .grid_column(8);
     });
   }
+
+  &_list {
+    margin-top: unit(45px / @base-font-size-px, em);
+
+    .respond-to-min(@bp-sm-min, {
+      margin-top: unit(60px / @base-font-size-px, em);
+      .grid_nested-col-group();
+    });
+  }
+
+  &_list-item {
+    margin-top: unit(30px / @base-font-size-px, em);
+
+    .respond-to-min(@bp-sm-min, {
+      margin-top: 0;
+      .grid_column(4);
+    });
+  }
+
+  &_list-intro {
+    .heading-4();
+  }
+
+  &_controls {
+    margin-top: unit(20px / @base-font-size-px, em);
+
+    .respond-to-min(@bp-sm-min, {
+      margin-top: unit(30px / @base-font-size-px, em);
+    });
+  }
 }
 
 /* ==========================================================================


### PR DESCRIPTION
Add large-screen styles for step 3 and next steps
## Additions
- Step 3 and next steps LESS for screens wider than `@bp-sm-min` (600px)
- LESS for big numbered lists
## Changes
- HTML changes to accommodate the large-screen design
## Testing
- To test, pull in the `options-large` branch and run `gulp`. Fire up the app in standalone or UnityBox as normal. The page will be at `/paying-for-college2/demo`.
## Review
- @ascott1: Do you foresee any problems with the way I'm doing that "non-standard one-column well" starting on line 647 of the LESS? It's basically the same way we do a bleeding sidebar but confined to one column (seems to be working everywhere I've tested it so far).
- @marteki
## Screenshots

| 600px and under | 601px and above |
| --- | --- |
| ![options-small](https://cloud.githubusercontent.com/assets/1862695/11821897/d53097c6-a339-11e5-8316-055f17f97768.png) | ![options-large](https://cloud.githubusercontent.com/assets/1862695/11821903/da133d5c-a339-11e5-892a-eecdecb991c8.png) |
## Todos
- Fix header spacing after the latest Capital Framework updates are pulled in
## Checklist
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [X] Passes all existing automated tests
- [X] Placeholder code is flagged
- [X] Visually tested in supported browsers and devices
