### PR TITLE
add static pages

### DIFF
--- a/paying_for_college/config/urls.py
+++ b/paying_for_college/config/urls.py
@@ -28,10 +28,10 @@ urlpatterns = [
         BaseTemplateView.as_view(template_name='just-a-demo.html'),
         name='pfc-demo'),
     url(r'^know-before-you-owe-student-debt/$',
-        BaseTemplateView.as_view(template_name='just-a-demo.html'),
+        BaseTemplateView.as_view(template_name='kbyo-static.html'),
         name='pfc-kbyo'),
     url(r'^student-loan-forgiveness-pledge/$',
-        BaseTemplateView.as_view(template_name='just-a-demo.html'),
+        BaseTemplateView.as_view(template_name='pledge-static.html'),
         name='pfc-pledge'),
 
 ]
@@ -57,9 +57,9 @@ if STANDALONE:
         BaseTemplateView.as_view(template_name='just-a-demo.html'),
         name='standalone-pfc-demo'),
     url(r'^paying-for-college2/know-before-you-owe-student-debt/$',
-        BaseTemplateView.as_view(template_name='just-a-demo.html'),
+        BaseTemplateView.as_view(template_name='kbyo-static.html'),
         name='standalone-pfc-kbyo'),
     url(r'^paying-for-college2/student-loan-forgiveness-pledge/$',
-        BaseTemplateView.as_view(template_name='just-a-demo.html'),
+        BaseTemplateView.as_view(template_name='pledge-static.html'),
         name='standalone-pfc-pledge'),
     ]

--- a/paying_for_college/templates/kbyo-static.html
+++ b/paying_for_college/templates/kbyo-static.html
@@ -1,0 +1,68 @@
+{% extends base_template %}
+{% load staticfiles %}
+{% block page_meta %}
+<meta charset="UTF-8" />
+<meta property="og:title" content="Paying for College &gt; Consumer Financial Protection Bureau"/>
+<meta property="og:type" content="government"/>
+<meta property="og:url" content="{{ URL }}"/>
+{% endblock %}
+
+{% block title %}Paying for College{% endblock %}
+
+{% block breadcrumbs %}
+{% endblock %}
+{% block content %}
+<header class="pagetitle"><h1>Know Before You Owe: Student loans project</h1></header>
+
+<img src="http://consumerfinance.gov/f/kbyo_sle.png" alt="Know before you owe: Student Loans" width="792" height="195" class="aligncenter size-full wp-image-37157"/>
+<p>
+In 2011, we teamed up with the Department of Education to launch the <a href="http://consumerfinance.gov/pressreleases/consumer-financial-protection-bureau-and-department-of-education-partner-on-new-financial-aid-shopping-sheet/">Know Before You Owe: student loans project</a>. The project was aimed at creating a <a href="http://collegecost.ed.gov/shopping_sheet.pdf">financial aid shopping sheet</a> which colleges and universities could use to help students better understand the type and amount of grants and loans they qualify for. It also could be used to help students easily compare aid packages offered by different institutions. 
+</p>
+<p>
+Take a look at our journey to learn more about where the project started and how it’s going to help students across the country.
+</p>
+<div class="two-col">
+ <div class="col">
+<h3>October 2011: Project launch</h3>
+<p>In 2011, we released <a href="http://files.consumerfinance.gov/a/students/disclosure.pdf">a prototype</a> of a model financial aid offer form. We asked the public to react and tell us what was most helpful when comparing aid offers. Thousands of students, parents, guidance counselors, and college officials provided input.</p>></div>
+
+ <div class="col">
+<a href="/f/201306_cfpb_kbyo_graphic1.png"><img src="http://consumerfinance.gov/f/201306_cfpb_kbyo_graphic1.png" alt="201306_cfpb_kbyo_graphic1" width="310" height="401" class="alignright size-full wp-image-37309" /></a></div>
+
+<hr />
+
+<h3>January 2012: What you told us</h3> 
+<p>We received <a href="http://consumerfinance.gov/blog/your-feedback-on-know-before-you-owe-student-loans/">feedback</a> from thousands of you on almost every aspect of the “financial aid shopping sheet” prototype. Consumers said having a standardized way to receive financial aid information is important. We released a <a href="http://consumerfinance.gov/f/2012/01/Memorandum_KBYOStudentLoans_FeedbackSummary_Jan2012.pdf">memo</a> detailing your feedback about the shopping sheet to share with the Department of Education. </p>
+<hr />
+
+<div class="two-col">
+ <div class="col">
+<h3>April 2012: Comparing financial aid and college cost</h3> 
+<p>Soon after, we built a beta version of the <a href="/paying-for-college2/understanding-your-financial-aid-offer/">paying-for-college</a>  tool. The tool, which complements the shopping sheet, works to help students make cost comparisons tailored to their individual circumstances. Students who received their financial aid offers could use the tool to see how college costs could impact their loan payments down the road.</p></div>
+
+ <div class="col">
+<a href="/f/201204_cfpb_students_payingforcollege.png"><img src="http://consumerfinance.gov/f/201204_cfpb_students_payingforcollege.png" alt="201204_cfpb_students_payingforcollege" width="310" height="253" class="alignleft size-full wp-image-37293" /></a>
+</div>
+
+<hr />
+
+<div class="two-col">
+ <div class="col">
+<h3>July 2012: The final shopping sheet</h3>
+<p>After reviewing our memo and reading feedback from the public, the Department of Education unveiled the <a href="http://collegecost.ed.gov/shopping_sheet.pdf">final shopping sheet.</a> The final version reflects many of the suggestions consumers gave in response to the prototype.</p>
+
+<p>CFPB Director Richard Cordray joined Secretary of Education Arne Duncan for a conference call <a href="http://consumerfinance.gov/speeches/prepared-remarks-by-richard-cordray-in-a-press-call-about-the-financial-aid-shopping-sheet/">to discuss the finalized form and encourage college and university presidents</a> to adopt the shopping sheet for the 2013-14 school year.</p></div>
+
+<div class="col"><a href="http://consumerfinance.gov/f/201306_cfpb_kbyo_graphic3.png"><img src="http://consumerfinance.gov/f/201306_cfpb_kbyo_graphic3.png" alt="201306_cfpb_kbyo_graphic3" width="310" height="403" class="aligncenter size-full wp-image-37311" /></a>
+</div>
+
+<hr />
+
+<h3>November 2012: Hundreds of schools adopt the shopping sheet</h3> 
+<p>Just four months after the final product was released, Secretary Duncan announced that <a href="http://www.consumerfinance.gov/blog/more-than-500-colleges-agree-to-adopt-financial-aid-shopping-sheet-2/">500 colleges and universities</a> would be using the shopping sheet for the upcoming school year. </p>
+
+<hr />
+
+<h3>April 2014: Thousands more have signed on</h3>
+<p><a href="http://www2.ed.gov/policy/highered/guid/aid-offer/index.html">More than 2,000 schools</a> have now adopted the shopping sheet.</p>
+{% endblock %}

--- a/paying_for_college/templates/kbyo-static.html
+++ b/paying_for_college/templates/kbyo-static.html
@@ -7,7 +7,7 @@
 <meta property="og:url" content="{{ URL }}"/>
 {% endblock %}
 
-{% block title %}Paying for College{% endblock %}
+{% block title %}Know Before You Owe: Student loans project &gt; Consumer Financial Protection Bureau{% endblock %}
 
 {% block breadcrumbs %}
 {% endblock %}

--- a/paying_for_college/templates/pledge-static.html
+++ b/paying_for_college/templates/pledge-static.html
@@ -1,0 +1,52 @@
+{% extends base_template %}
+{% load staticfiles %}
+{% block page_meta %}
+<meta charset="UTF-8" />
+<meta property="og:title" content="Paying for College &gt; Consumer Financial Protection Bureau"/>
+<meta property="og:type" content="government"/>
+<meta property="og:url" content="{{ URL }}"/>
+{% endblock %}
+
+{% block title %}Paying for College{% endblock %}
+
+{% block breadcrumbs %}
+{% endblock %}
+{% block content %}
+<style><!--
+.buttonish{ background-color: #50A748; font-family: 'Avenir Next', Verdana, sans-serif; text-transform: uppercase; letter-spacing: 0.1em; border-radius: 0.35em; font-size: .875em; border: 1px outset #AFAFB3; position: relative; top: -1px; padding: .45em .75em; color:white; } .buttonish:hover{ color: #666; }
+--></style>
+<header class="pagetitle"><h1>Take the pledge</h1></header>
+<p>Public service organizations – for example, public school districts, police and fire departments, public hospitals, non-profits, and more – can take this pledge to help employees reduce their student debt.</p>
+<ul>
+<li>It’s a free, valuable benefit for your employees, and a great recruiting tool.</li>
+<li>Through one program, employees who qualify can have federal loans forgiven after 10 years, so they should get started early.</li>
+<li>If they have too much debt, not much income, or both, they can save thousands of dollars.</li></ul>
+
+<p>We’ll give you a simple toolkit—everything you need to help your employees tackle their student debt, including one-pagers for you and for your staff. </p>
+
+<blockquote><p>My organization pledges to:</p>
+<ul>
+<li>Talk to our employees about their options for student loan forgiveness.</li>
+<li>Help them prove that they work for a public service organization.</li>
+<li>Check-in with employees annually to make sure they stay on track.</li>
+</ul>
+<p><a class="buttonish" href=mailto:pledge@cfpb.gov?subject=We%20pledge%20to%20tackle%20student%20debt&body=Hi!%0A%0AI’d%20like%20to%20get%20started%20with%20the%20pledge%20to%20help%20my%20employees%20qualify%20for%20student%20loan%20forgiveness.%20Could%20you%20send%20me%20a%20toolkit?%0A%0AThanks,%0A%0A[Your%20name]%0A[Your%20organization]%0A[Your%20contact%20information]>Get started</a></p></blockquote>
+
+
+<hr />
+<div class="two-col">
+<div class="col">
+<h4>I have student debt and work in public service, how can I help?</h4>
+<p>The best way to get your employer on board is to ask!</p>
+
+<a class="buttonish" href="mailto:?subject=New%20program%20to%20help%20our%20colleagues&amp;body=Dear%20[your%20supervisor/administrator/HR%20representative],%0A%0AThere’s%20an%20interesting%20program%20that%20the%20Consumer%20Financial%20Protection%20Bureau%20is%20running,%20asking%20public%20service%20organizations%20to%20pledge%20to%20help%20their%20employees%20get%20student%20loan%20forgiveness%20benefits.%0A%0AI%20think%20we%20qualify,%20the%20benefits%20are%20free%20to%20us,%20and%20CFPB%20staff%20will%20walk%20us%20through%20the%20process.%0A%0ATake%20a%20look%20and%20see%20what%20you%20think:%20www.consumerfinance.gov/pledge.%0A%0AWhen%20we’re%20ready%20to%20get%20started,%20we%20can%20just%20email%20pledge@cfpb.gov%20and%20they%20have%20toolkits.%0A%0AThanks!">Get started</a>
+
+</div>
+<div class="col">
+<h4>What are my options for my own student loans?</h4>
+<p>Have more questions about these programs and how they work? We have answers.</p>
+
+<a class="buttonish" href="http://consumerfinance.gov/askcfpb/search?selected_facets=tag_exact%3Apublic+service+loan+forgiveness">Ask CFPB</a>
+
+</div>
+{% endblock %}

--- a/paying_for_college/templates/pledge-static.html
+++ b/paying_for_college/templates/pledge-static.html
@@ -7,7 +7,7 @@
 <meta property="og:url" content="{{ URL }}"/>
 {% endblock %}
 
-{% block title %}Paying for College{% endblock %}
+{% block title %}Take the pledge &gt; Consumer Financial Protection Bureau%}
 
 {% block breadcrumbs %}
 {% endblock %}

--- a/paying_for_college/templates/pledge-static.html
+++ b/paying_for_college/templates/pledge-static.html
@@ -7,7 +7,7 @@
 <meta property="og:url" content="{{ URL }}"/>
 {% endblock %}
 
-{% block title %}Take the pledge &gt; Consumer Financial Protection Bureau%}
+{% block title %}Take the pledge &gt; Consumer Financial Protection Bureau%}{% endblock %}
 
 {% block breadcrumbs %}
 {% endblock %}


### PR DESCRIPTION
Ports static WordPress pages into Django templates
## Additions
- static templates for kbyo and pledge pages with content ported from wordpress
## Changes
- updates urls to point to new templates
## Testing

after pulling in code, you should see the ported pages at  
- /paying-for-college2/student-loan-forgiveness-pledge/
- /paying-for-college2/know-before-you-owe-student-debt/

for reference, the original pages:
- http://www.consumerfinance.gov/pledge/ 
- http://www.consumerfinance.gov/students/knowbeforeyouowe/ 
## Review
- @marteki @ascott1 @niqjohnson 
