### PR TITLE
Add styles for IE8 and below

### DIFF
--- a/paying_for_college/templates/just-a-demo.html
+++ b/paying_for_college/templates/just-a-demo.html
@@ -7,7 +7,12 @@
 {% block nemo_styles %}
 {% endblock %}
 {% block app_css %}
-<link rel="stylesheet" type="text/css" href="{% static "paying_for_college/disclosures/static/css/main.min.css" %}">
+<!--[if lt IE 9]>
+    <link rel="stylesheet" href="{% static "paying_for_college/disclosures/static/css/main.ie.css" %}">
+<![endif]-->
+<!--[if gt IE 8]><!-->
+    <link rel="stylesheet" href="{% static "paying_for_college/disclosures/static/css/main.min.css" %}">
+<!--<![endif]-->
 {% endblock %}
 {% block responsive_nav %}
 <a class="toggle-menu" href="#"><i class="cf-icon cf-icon-menu"></i><span class="u-visually-hidden">Menu</span></a>


### PR DESCRIPTION
Add a stylesheet for IE8 and below
## Additions
- Add `main.ie.css` stylesheet
## Changes
- Put `main.min.css` in an IE conditional comment so it only loads in versions of IE that can handle it (this follows what's been done on other new pages recently, like http://www.consumerfinance.gov/know-before-you-owe/real-estate-professionals/)
## Testing
1. Pull in the `ie8` branch and run `gulp`.
2. Fire up the app in standalone or UnityBox as normal. The page will be at `/paying-for-college2/demo`. Make sure the verify, big question, options, and next step sections still look OK in your modern browsers of choice.
3. Repeat the above to open up the same page in IE8 however you prefer to do that. Make sure the same sections degrade gracefully in IE8. (Note that I had to make sure the "Browser mode" was set to "IE8" and the "Document mode" was set to "IE8 standards" in the IE developer tools if you're using a Sauce Labs VM).
## Review
- @ascott1 
- @marteki
## Screenshots

![ie8](https://cloud.githubusercontent.com/assets/1862695/11848768/4a257610-a3f2-11e5-8e00-d8dfac246653.png)
## Checklist
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [X] Passes all existing automated tests
- [X] Placeholder code is flagged
- [X] Visually tested in supported browsers and devices
