### PR TITLE
Move to new brand palette

### DIFF
--- a/src/disclosures/css/brand-palette.less
+++ b/src/disclosures/css/brand-palette.less
@@ -4,68 +4,142 @@
    ========================================================================== */
 
 // Official palette.
-// Current as of April 9, 2015.
+// Current as of November 13, 2015.
 // To view the colors in the Design Manual, visit:
 // https://cfpb.github.io/design-manual/identity/color-principles.html#palette
-
-// Primary colors:
-
-@green:             #2CB34A;
-@green-midtone:     #ADDC91;
-@green-tint:        #DBEDD4;
-
-@black:             #101820;
-
-
-// Background colors:
-
-@darkgray:          #43484E;
-
-@gray:              #75787B;
-@gray-80:           #919395;
-@gray-50:           #BABBBD;
-@gray-20:           #E3E4E5;
-@gray-10:           #F1F2F2;
-@gray-5:            #F8F8F8;
+//
+// | Green      | Teal       | Pacific    | Navy       | Red        | Gold       | Neutral    | Black/Gray |
+// | ---------- | ---------- | ---------- | ---------- | ---------- | ---------- | ---------- | ---------- |
+// |            |            |            |            |            |            |            | 101820     |
+// |            |            |            |            |            |            |            |            |
+// | 1e9642     | 005e5d     | 0050b4     | 002d72     | b63014     | dc731c     | 63574e     | 43484e     | dark
+// | 20aa3f     | 257675     | 0072ce     | 254b87     | d14124     | ff9e1b     | 796e65     | 5a5d61     | base
+// | 66c368     | 579695     | 4497dc     | 5674a3     | dd735d     | ffb858     | 948b84     | 75787b     | 80
+// | addc91     | 89b6b5     | 7eb7e8     | 889cc0     | e79e8e     | ffce8d     | b5aca5     | 919395     | 60
+// | c7e5b3     | b4d2d1     | afd2f2     | b3c0d9     | f0c3b8     | ffe1b9     | cdc7c2     | b4b5b6     | 40
+// | e2efd8     | d4e7e6     | d6e8fa     | d3daeb     | f7e0d9     | fff0dd     | e3e2df     | d2d3d5     | 20
+// |            |            |            |            |            |            |            | e7e8e9     | 10
+// |            |            |            |            |            |            |            | f7f8f9     | 5
 
 
-// Secondary colors:
+// Green family
 
-@redorange:         #D12124;
-@redorange-80:      #DA6750;
-@redorange-50:      #E8A091;
-@redorange-20:      #F6D9D3;
-
-@gold:              #FF9E1B;
-@gold-80:           #FFB149;
-@gold-50:           #FFCE8D;
-@gold-20:           #FFECD1;
-
-@neutral:           #796E65;
-@neutral-80:        #948B84;
-@neutral-50:        #BCB6B2;
-@neutral-20:        #E4E2E0;
-
-@navy:              #002D72;
-@navy-80:           #33578E;
-@navy-50:           #7F96B8;
-@navy-20:           #CCD5E3;
-
-@pacific:           #0072CE;
-@pacific-80:        #328ED8;
-@pacific-50:        #7FB8E6;
-@pacific-20:        #CCE3F5;
-
-@teal:              #005E5D;
-@teal-80:           #337E7D;
-@teal-50:           #7FAEAE;
-@teal-20:           #CCDFDF;
+@dark-green:   #1e9642;
+@green:        #20aa3f; // Primary brand green color
+@green-80:     #66c368;
+@green-60:     #addc91; // Formerly known as "Green: Midtone"
+@green-40:     #c7e5b3;
+@green-20:     #e2efd8;
 
 
-// Unofficial colors not part of the official palette,
-// but are in use for easier coding semantics or UX needs.
+// Teal family
 
-// Active state of destructive action buttons.
-@dark-redorange:    #9C301B;
+@dark-teal:    #005e5d; // Formerly known as regular ol' "Teal"
+@teal:         #257675; // Close to what was previously called "Teal 80"
+@teal-80:      #579695;
+@teal-60:      #89b6b5;
+@teal-40:      #b4d2d1;
+@teal-20:      #d4e7e6;
 
-@white:             #FFF;
+
+// Pacific family
+
+@dark-pacific: #0050b4;
+@pacific:      #0072ce;
+@pacific-80:   #4497dc;
+@pacific-60:   #7eb7e8;
+@pacific-40:   #afd2f2;
+@pacific-20:   #d6e8fa;
+
+
+// Navy family
+
+@dark-navy:    #002d72; // Formerly known as regular ol' "Navy"
+@navy:         #254b87; // Close to what was previously called "Navy 80"
+@navy-80:      #5674a3;
+@navy-60:      #889cc0;
+@navy-40:      #b3c0d9;
+@navy-20:      #d3daeb;
+
+
+// Red family (formerly known as "Red Orange")
+
+@dark-red:     #b63014;
+@red:          #d14124;
+@red-80:       #dd735d;
+@red-60:       #e79e8e;
+@red-40:       #f0c3b8;
+@red-20:       #f7e0d9;
+
+
+// Gold family
+
+@dark-gold:    #dc731c;
+@gold:         #ff9e1b;
+@gold-80:      #ffb858;
+@gold-60:      #ffce8d;
+@gold-40:      #ffe1b9;
+@gold-20:      #fff0dd;
+
+
+
+// Neutral family
+
+@dark-neutral: #63574e;
+@neutral:      #796e65;
+@neutral-80:   #948b84;
+@neutral-60:   #b5aca5;
+@neutral-40:   #cdc7c2;
+@neutral-20:   #e3e2df;
+
+
+// Gray family
+
+@black:        #101820; // Also known as "CFPB Black"
+
+@dark-gray:    #43484e;
+@gray:         #5a5d61;
+@gray-80:      #75787b; // Formerly known as regular ol' "Gray"
+@gray-60:      #919395; // Formerly known as "Gray 80"
+@gray-40:      #b4b5b6; // Close to what was known as "Gray 50"
+@gray-20:      #d2d3d5;
+@gray-10:      #e7e8e9; // Close to what was known as "Gray 20"
+@gray-5:       #f7f8f9;
+
+@white:        #fff;
+
+
+/**
+ * Deprecated or significantly modified color variables as of the version of
+ * this file that appears in generator-cf v1.4.0
+ *
+ * Run project-wide Find and Replace actions to update variables
+ * as specified below.
+ *
+ * IMPORTANT: You must execute these in the specified order
+ * to ensure that you don't overwrite previous updates.
+ */
+
+//     Replace:         With:
+// --------------------------------
+//  1. @green-midtone   @green-60
+//  2. @green-tint      @green-20
+//  3. @teal            @dark-teal
+//  4. @teal-80         @teal
+//  5. @teal-50         @teal-60
+//  6. @pacific-50      @pacific-60
+//  7. @navy            @dark-navy
+//  8. @navy-80         @navy
+//  9. @navy-50         @navy-60
+// 10. @dark-redorange  @dark-red
+// 11. @redorange       @red
+// 12. @redorange-80    @red-80
+// 13. @redorange-50    @red-60
+// 14. @redorange-20    @red-20
+// 15. @gold-50         @gold-60
+// 16. @neutral-50      @neutral-60
+// 17. @darkgray        @dark-gray
+// 18. @gray-80         @gray-60
+// 19. @gray            @gray-80
+// 20. @gray-50         @gray-40
+// 21. @gray-20         @gray-10

--- a/src/disclosures/css/cf-enhancements.less
+++ b/src/disclosures/css/cf-enhancements.less
@@ -126,12 +126,12 @@
   border: 1px solid @gray;
 
   &__error {
-    background: @redorange-20;
+    background: @red-20;
     border-color: @input-error;
   }
 
   &__success {
-    background: @green-tint;
+    background: @green-20;
     border-color: @input-success;
   }
 
@@ -194,7 +194,7 @@
     position: absolute;
     left: 0;
     top: unit(@base-line-height - @char-icon-size, em);
-    background: @green-tint;
+    background: @green-20;
     color: @black;
     .webfont-medium();
     font-size: unit(18px / @base-font-size-px, em);

--- a/src/disclosures/css/cf-theme-overrides.less
+++ b/src/disclosures/css/cf-theme-overrides.less
@@ -29,27 +29,27 @@
 // a
 @link-text:                     @pacific;
 @link-underline:                @pacific;
-@link-text-visited:             @teal;
-@link-underline-visited:        @teal;
-@link-text-hover:               @pacific-50;
-@link-underline-hover:          @pacific-50;
-@link-text-active:              @navy;
-@link-underline-active:         @navy;
+@link-text-visited:             @dark-teal;
+@link-underline-visited:        @dark-teal;
+@link-text-hover:               @pacific-60;
+@link-underline-hover:          @pacific-60;
+@link-text-active:              @dark-navy;
+@link-underline-active:         @dark-navy;
 
 // thead
 @thead-text:                    @white;
-@thead-bg:                      @darkgray;
+@thead-bg:                      @dark-gray;
 @td-bg:                         @gray-5;
 @td-bg-alt:                     @gray-10;
 
 // input
 @input-bg:                      @white;
-@input-border:                  @gray;
+@input-border:                  @gray-80;
 @input-border-focus:            @pacific;
-@input-placeholder:             @gray-80;
+@input-placeholder:             @gray-60;
 
 // .figure__bordered
-@figure__bordered:              @gray-50;
+@figure__bordered:              @gray-40;
 
 
 /* cf-buttons
@@ -61,24 +61,24 @@
 @btn-text:                      @white;
 @btn-bg:                        @pacific;
 @btn-bg-hover:                  @pacific-80;
-@btn-bg-active:                 @navy-80;
+@btn-bg-active:                 @navy;
 
 // .btn__secondary
 @btn__secondary-text:           @white;
-@btn__secondary-bg:             @gray;
-@btn__secondary-bg-hover:       @gray-80;
-@btn__secondary-bg-active:      @darkgray;
+@btn__secondary-bg:             @gray-80;
+@btn__secondary-bg-hover:       @gray-60;
+@btn__secondary-bg-active:      @dark-gray;
 
 // .btn__warning
 @btn__warning-text:             @white;
-@btn__warning-bg:               @redorange;
-@btn__warning-bg-hover:         @redorange-80;
-@btn__warning-bg-active:        @dark-redorange;
+@btn__warning-bg:               @red;
+@btn__warning-bg-hover:         @red-80;
+@btn__warning-bg-active:        @dark-red;
 
 // .btn__disabled
-@btn__disabled-text:            @gray;
-@btn__disabled-bg:              @gray-20;
-@btn__disabled-outline:         @gray-20;
+@btn__disabled-text:            @gray-80;
+@btn__disabled-bg:              @gray-10;
+@btn__disabled-outline:         @gray-10;
 
 // Sizing variables
 
@@ -105,14 +105,14 @@
 
 // .expandable__padded
 @expandable__padded-bg:         @gray-10;
-@expandable__padded-bg-hover:   @gray-20;
-@expandable__padded-divider:    @gray-50;
+@expandable__padded-bg-hover:   @gray-10;
+@expandable__padded-divider:    @gray-40;
 
 // .expandable-group
-@expandable-group_header-text:  @gray;
+@expandable-group_header-text:  @gray-80;
 @expandable-group_header-bg:    @gray-10;
 @expandable-group-bg:           @white;
-@expandable-group-divider:      @gray-50;
+@expandable-group-divider:      @gray-40;
 
 // Sizing variables
 
@@ -126,7 +126,7 @@
 // Color variables
 
 // .error
-@input-error:                   @redorange;
+@input-error:                   @red;
 
 // warning
 @input-warning:                 @gold;
@@ -138,10 +138,10 @@
 @input-disabled:                 @gray-10;
 
 // .form-label-helper-text
-@label-helper:                  @darkgray;
+@label-helper:                  @dark-gray;
 
 // .form-l-inset_container
-@input-inset-bg:                @gray-20;
+@input-inset-bg:                @gray-10;
 
 // .form-l-inset_container.is-checked
 @input-inset-selected:          @pacific-20;
@@ -176,28 +176,28 @@
 // Color variables
 
 // .block
-@block__border-top:             @gray-50;
-@block__border-bottom:          @gray-50;
+@block__border-top:             @gray-40;
+@block__border-bottom:          @gray-40;
 @block__bg:                     @gray-10;
 
 // .content_main
-@content_main-border:           @gray-50;
+@content_main-border:           @gray-40;
 
 // .content_sidebar
 @content_sidebar-bg:            @gray-10;
-@content_sidebar-border:        @gray-50;
+@content_sidebar-border:        @gray-40;
 
 // .content_bar
 @content_bar:                   @green;
 
 // .content_line
-@content_line:                  @gray-50;
+@content_line:                  @gray-40;
 
 // .grid_column__top-divider
-@grid_column__top-divider:      @gray-50;
+@grid_column__top-divider:      @gray-40;
 
 // .grid_column__top-divider
-@grid_column__left-divider:     @gray-50;
+@grid_column__left-divider:     @gray-40;
 
 
 /* cf-pagination
@@ -205,8 +205,8 @@
 
 // Color variables
 
-@pagination-text:               @gray;
-@pagination-bg:                 @gray-20;
+@pagination-text:               @gray-80;
+@pagination-bg:                 @gray-10;
 
 // Sizing variables
 
@@ -221,38 +221,38 @@
 
 // .pull-quote
 @pull-quote_body:               @black;
-@pull-quote_citation:           @gray;
+@pull-quote_citation:           @gray-80;
 
 // .micro-copy
-@micro-copy-text:               @gray;
+@micro-copy-text:               @gray-80;
 
 // .date
-@date-text:                     @gray;
+@date-text:                     @gray-80;
 
 // .category-slug
 @category-slug-text:            @black;
 @category-slug-hover:           @link-text-hover;
 
 // .header-slug
-@header-slug-thin-border:       @gray-20;
+@header-slug-thin-border:       @gray-10;
 @header-slug-thick-border:      @green;
 
 // .padded-header
-@padded-header-text:            @darkgray;
+@padded-header-text:            @dark-gray;
 @padded-header-bg:              @gray-10;
-@padded-header-border:          @gray-50;
+@padded-header-border:          @gray-40;
 
 // .fancy-slug
 @fancy-slug-text:               @black;
 @fancy-slug-bg:                 @white;
-@fancy-slug-border:             @gray-50;
+@fancy-slug-border:             @gray-40;
 
 // .meta-header
-@meta-header-border:            @gray-50;
+@meta-header-border:            @gray-40;
 
 // .jump-link
 @jump-link__bg:                 @gray-10;
-@jump-link__bg-border:          @gray-20;
+@jump-link__bg-border:          @gray-10;
 
 // .list__branded
 @list__branded-bullet:          @green;

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -151,7 +151,7 @@
 
   .form-label-header {
     padding-bottom: unit(5px / @small-font-size-px, em);
-    border-bottom: 1px solid @gray-50;
+    border-bottom: 1px solid @gray-40;
     margin-bottom: unit(15px / @small-font-size-px, em);
   }
 
@@ -236,7 +236,7 @@
 
   &.debt-summary {
     margin-top: 0;
-    background-color: @gold-50;
+    background-color: @gold-60;
   }
 
   .content_line {
@@ -287,7 +287,7 @@
 
 .offer-part_terms {
   padding-bottom: unit(17px / @base-font-size-px, em);
-  border-bottom: 1px dashed @gray-50;
+  border-bottom: 1px dashed @gray-40;
 }
 
 .offer-part_terms__last {
@@ -301,7 +301,7 @@
 }
 
 .private-loans {
-  border-bottom: 1px dashed @gray-50;
+  border-bottom: 1px dashed @gray-40;
   margin-bottom: unit(15px / @base-font-size-px, em);
 }
 
@@ -356,7 +356,7 @@
 
 .metric {
   padding-top: unit(10px / @base-font-size-px, em);
-  border-top: 1px solid @gray-50;
+  border-top: 1px solid @gray-40;
   margin-top: unit(30px / @base-font-size-px, em);
 }
 
@@ -465,7 +465,7 @@
     position: absolute;
     top: 0;
     left: 50%;
-    background-color: @gray-20;
+    background-color: @gray-10;
   }
 }
 
@@ -483,10 +483,10 @@
 }
 
 .bar-graph_point__average {
-  color: @darkgray;
+  color: @dark-gray;
 
   .bar-graph_line {
-    border-top-color: @darkgray;
+    border-top-color: @dark-gray;
     border-top-style: dotted;
   }
 }
@@ -629,7 +629,7 @@
 
   // Rules on all but the first option on small screens but only the second row of options on larger screens
   & + & &_heading {
-    border-top: 1px solid @gray-50;
+    border-top: 1px solid @gray-40;
 
     .respond-to-min(@bp-sm-min, {
       border-top: none;
@@ -639,7 +639,7 @@
   & + & + & + & &_heading {
 
     .respond-to-min(@bp-sm-min, {
-      border-top: 1px solid @gray-50;
+      border-top: 1px solid @gray-40;
     });
   }
 }
@@ -662,7 +662,7 @@
     top: 0;
     left: unit(-(@grid_gutter-width / @base-font-size-px) / 2, em);
     z-index: 0;
-    background-color: @green-tint;
+    background-color: @green-20;
     content: '';
 
     .respond-to-min(@bp-sm-min, {


### PR DESCRIPTION
Move to the updated brand color palette
## Changes

Update `brand-palette.less` to the latest version (https://github.com/cfpb/generator-cf/blob/master/app/templates/src/static/css/brand-palette.less) and update colors used in this project per the instructions at the end of that file. Namely:

| Replace: | With: |
| --- | --- |
| green-midtone | green-60 |
| green-tint | green-20 |
| teal | dark-teal |
| teal-80 | teal |
| teal-50 | teal-60 |
| pacific-50 | pacific-60 |
| navy | dark-navy |
| navy-80 | navy |
| navy-50 | navy-60 |
| dark-redorange | dark-red |
| redorange | red |
| redorange-80 | red-80 |
| redorange-50 | red-60 |
| redorange-20 | red-20 |
| gold-50 | gold-60 |
| neutral-50 | neutral-60 |
| darkgray | dark-gray |
| gray-80 | gray-60 |
| gray | gray-80 |
| gray-50 | gray-40 |
| gray-20 | gray-10 |
## Testing
- Pull in this branch and run `gulp`. The LESS files should compile with no errors. You can take a quick look at `just-a-demo` to make sure colors look right, but I can't tell a difference between the old and new colors in most cases.
- If someone could triple-check my find and replace in the changed files (and let me know if there are any other files I didn't catch), that would be great.
## Review
- @ascott1 
- @marteki 
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] Visually tested in supported browsers and devices
