### PR TITLE
Large-screen styles for step 2

### DIFF
--- a/paying_for_college/templates/just-a-demo.html
+++ b/paying_for_college/templates/just-a-demo.html
@@ -770,115 +770,133 @@
                     </div>
                 </div>
             </section>
-            <section class="step evaluate">
-                <h2 class="step_heading">
-                    Step 2: Evaluate your offer
-                </h2>
-                <p>
-                    Asking yourself these questions will help you understand how accepting this offer can impact your ability to pay back your student debt and impact your financial future.
-                </p>
-                <section class="criteria">
-                    <h3 class="criteria_heading">
-                        Will I graduate?
-                    </h3>
-                    <p>
-                        Graduation is not a guarantee. And if you don’t graduate, you’ll still have to repay federal and private loans (and possibly even some grants), but you won’t have the added benefit of your degree to help earn more money.
+        </section>
+    </div>
+
+
+
+    <section class="evaluate step content_wrapper">
+        <div class="content_main">
+            <div class="evaluate_wrapper">
+                <div class="evaluate_intro">
+                    <h2 class="step_heading">
+                        Step 2: Evaluate your offer
+                    </h2>
+                    <p class="step_intro">
+                        Asking yourself these questions will help you understand how accepting this offer can impact your ability to pay back your student debt and impact your financial future.
                     </p>
-                    <section class="metric graduation-rate">
-                        <h4 class="metric_heading">
-                            Graduation rate
-                        </h4>
-                        <p class="metric_explanation">
-                            Percentage of full-time students who graduate from a college or university
+                </div>
+            </div>
+            <section class="criteria column-well_wrapper">
+                <h3 class="criteria_heading">
+                    Will I graduate?
+                </h3>
+                <div class="criteria_wrapper">
+                    <div class="criteria_intro">
+                        <p>
+                            Graduation is not a guarantee. And if you don’t graduate, you’ll still have to repay federal and private loans (and possibly even some grants), but you won’t have the added benefit of your degree to help earn more money.
                         </p>
-                        <div class="bar-graph">
-                            <div class="bar-graph_bar"></div>
-                            <div class="bar-graph_point bar-graph_point__you u-clearfix">
-                                <div class="bar-graph_row">
-                                    <div class="bar-graph_label">
-                                        [School Name]
-                                    </div>
-                                    <div class="bar-graph_value">
-                                        <div class="bar-graph_line"></div>
-                                        <div class="bar-graph_number">
-                                            12%
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="bar-graph_point bar-graph_point__average u-clearfix">
-                                <div class="bar-graph_row">
-                                    <div class="bar-graph_label">
-                                        National average
-                                    </div>
-                                    <div class="bar-graph_value">
-                                        <div class="bar-graph_line"></div>
-                                        <div class="bar-graph_number">
-                                            86%
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="cf-notification cf-notification__error">
-                            <span class="cf-notification_icon cf-notification_icon__error cf-icon cf-icon-error-round"></span>
-                            <p class="cf-notification_text">
-                                Lower graduation rate than national average
+                    </div>
+                    <section class="metric graduation-rate column-well column-well__bleed column-well__not-stacked">
+                        <div class="column-well_content">
+                            <h4 class="metric_heading">
+                                Graduation rate
+                            </h4>
+                            <p class="metric_explanation">
+                                Percentage of full-time students who graduate from a college or university
                             </p>
+                            <div class="bar-graph">
+                                <div class="bar-graph_bar"></div>
+                                <div class="bar-graph_point bar-graph_point__you u-clearfix">
+                                    <div class="bar-graph_row">
+                                        <div class="bar-graph_label">
+                                            [School Name]
+                                        </div>
+                                        <div class="bar-graph_value">
+                                            <div class="bar-graph_line"></div>
+                                            <div class="bar-graph_number">
+                                                12%
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="bar-graph_point bar-graph_point__average u-clearfix">
+                                    <div class="bar-graph_row">
+                                        <div class="bar-graph_label">
+                                            National average
+                                        </div>
+                                        <div class="bar-graph_value">
+                                            <div class="bar-graph_line"></div>
+                                            <div class="bar-graph_number">
+                                                86%
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="metric_notification metric_notification__better">
+                                Higher graduation rate than national average
+                            </div>
                         </div>
                     </section>
-                </section>
-                <section class="criteria">
-                    <h3 class="criteria_heading">
-                        How will I afford my loan payment?
-                    </h3>
-                    <p>
-                        Take into consideration how much money you can expect to make if you graduate, and then evaluate how much of that will be living expenses and loan payments.
-                    </p>
-                    <section class="metric average-salary">
-                        <h4 class="metric_heading">
-                            Average salary
-                        </h4>
-                        <p class="metric_explanation">
-                            Expected first-year salary after graduating from your program
+                </div>
+            </section>
+            <section class="criteria column-well_wrapper">
+                <h3 class="criteria_heading">
+                    How will I afford my loan payment?
+                </h3>
+                <div class="criteria_wrapper">
+                    <div class="criteria_intro">
+                        <p>
+                            Take into consideration how much money you can expect to make if you graduate, and then evaluate how much of that will be living expenses and loan payments.
                         </p>
-                        <div class="bar-graph">
-                            <div class="bar-graph_bar"></div>
-                            <div class="bar-graph_point bar-graph_point__you u-clearfix">
-                                <div class="bar-graph_row">
-                                    <div class="bar-graph_label">
-                                        [School Name]
-                                    </div>
-                                    <div class="bar-graph_value">
-                                        <div class="bar-graph_line"></div>
-                                        <div class="bar-graph_number">
-                                            $26,000
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="bar-graph_point bar-graph_point__average u-clearfix">
-                                <div class="bar-graph_row">
-                                    <div class="bar-graph_label">
-                                        National average
-                                    </div>
-                                    <div class="bar-graph_value">
-                                        <div class="bar-graph_line"></div>
-                                        <div class="bar-graph_number">
-                                            $34,000
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="cf-notification cf-notification__error">
-                            <span class="cf-notification_icon cf-notification_icon__error cf-icon cf-icon-error-round"></span>
-                            <p class="cf-notification_text">
-                                Lower salary than national average
+                    </div>
+                    <section class="metric average-salary column-well column-well__bleed column-well__not-stacked">
+                        <div class="column-well_content">
+                            <h4 class="metric_heading">
+                                Average salary
+                            </h4>
+                            <p class="metric_explanation">
+                                Expected first-year salary after graduating from your program
                             </p>
+                            <div class="bar-graph">
+                                <div class="bar-graph_bar"></div>
+                                <div class="bar-graph_point bar-graph_point__you u-clearfix">
+                                    <div class="bar-graph_row">
+                                        <div class="bar-graph_label">
+                                            [School Name]
+                                        </div>
+                                        <div class="bar-graph_value">
+                                            <div class="bar-graph_line"></div>
+                                            <div class="bar-graph_number">
+                                                $26,000
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="bar-graph_point bar-graph_point__average u-clearfix">
+                                    <div class="bar-graph_row">
+                                        <div class="bar-graph_label">
+                                            National average
+                                        </div>
+                                        <div class="bar-graph_value">
+                                            <div class="bar-graph_line"></div>
+                                            <div class="bar-graph_number">
+                                                $34,000
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="cf-notification metric_notification cf-notification__error">
+                                <span class="cf-notification_icon cf-notification_icon__error cf-icon cf-icon-error-round"></span>
+                                <p class="cf-notification_text">
+                                    Lower salary than national average
+                                </p>
+                            </div>
                         </div>
                     </section>
-                    <section class="metric estimated-expenses">
+                    <section class="estimated-expenses">
                         <h4 class="metric_heading">
                             Estimated expenses
                         </h4>
@@ -1025,182 +1043,147 @@
                             </div>
                         </div>
                     </section>
-                </section>
-                <section class="criteria">
-                    <h3 class="criteria_heading">
-                        Am I about to take out too many loans?
-                    </h3>
-                    <p>
-                        There are two factors that make up your debt burden—your loan payment and your salary. The general rule of thumb is that you shouldn’t borrow more than you will make during your first year out of college. That means your student loan payment shouldn’t be more than 14% of your monthly income.
-                    </p>
-                    <p>
-                        If your debt burden is too high, it increases the chances of defaulting on your loan or not being able to pay for other necessities, like health insurance. Since it’s difficult to predict or actively increase your future salary, the best way to lower your debt burden is to reduce the amount of student loans you take out.
-                    </p>
-                    <section class="metric debt-burden">
-                        <h4 class="metric_heading">
-                            Your estimated debt burden
-                        </h4>
-                        <p class="metric_explanation">
-                            We calculate your debt burden by dividing your monthly loan payment by the average salary for students who attended your school.
-                        </p>
-                        <div class="debt-burden_projection">
-                            <div class="debt-burden_projection-name">
-                                Projected salary
-                            </div>
-                            <div class="debt-burden_projection-value">
-                                $30,000 / yr.<br>
-                                $2,500 / mo.
-                            </div>
-                        </div>
-                        <div class="debt-burden_projection">
-                            <div class="debt-burden_projection-name">
-                                Your projected loan payment
-                            </div>
-                            <div class="debt-burden_projection-value">
-                                $550 / mo.
-                            </div>
-                        </div>
-                        <div class="debt-equation u-clearfix">
-                            <div class="debt-equation_part debt-equation_part__loan">
-                                <div class="debt-equation_number">
-                                    $550
-                                </div>
-                                <div class="debt-equation_label">
-                                    loan payment
-                                </div>
-                            </div>
-                            <div class="debt-equation_symbol">
-                                /
-                            </div>
-                            <div class="debt-equation_part debt-equation_part__income">
-                                <div class="debt-equation_number">
-                                    $2,500
-                                </div>
-                                <div class="debt-equation_label">
-                                    monthly salary
-                                </div>
-                            </div>
-                            <div class="debt-equation_symbol">
-                                =
-                            </div>
-                            <div class="debt-equation_part debt-equation_part__percent">
-                                <div class="debt-equation_number">
-                                    22%
-                                </div>
-                                <div class="debt-equation_label">
-                                    of your income
-                                </div>
-                            </div>
-                        </div>
-                        <div class="cf-notification cf-notification__error">
-                            <span class="cf-notification_icon cf-notification_icon__error cf-icon cf-icon-error-round"></span>
-                            <p class="cf-notification_text">
-                                Loan payment is higher than recommended 14% of salary
-                            </p>
-                        </div>
-                    </section>
-                    <section class="metric total-debt-after-graduation">
-                        <h4 class="metric_heading">
-                            Total debt after graduation
-                        </h4>
-                        <p class="metric_explanation">
-                            Average total debt (for the length of your program) that students studying [program name] at [School Name] or similar programs had after graduation
-                        </p>
-                        <div class="bar-graph">
-                            <div class="bar-graph_bar"></div>
-                            <div class="bar-graph_point bar-graph_point__you u-clearfix">
-                                <div class="bar-graph_row">
-                                    <div class="bar-graph_label">
-                                        [School Name]
-                                    </div>
-                                    <div class="bar-graph_value">
-                                        <div class="bar-graph_line"></div>
-                                        <div class="bar-graph_number">
-                                            $38,000
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="bar-graph_point bar-graph_point__average u-clearfix">
-                                <div class="bar-graph_row">
-                                    <div class="bar-graph_label">
-                                        National average
-                                    </div>
-                                    <div class="bar-graph_value">
-                                        <div class="bar-graph_line"></div>
-                                        <div class="bar-graph_number">
-                                            $28,000
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="cf-notification cf-notification__error">
-                            <span class="cf-notification_icon cf-notification_icon__error cf-icon cf-icon-error-round"></span>
-                            <p class="cf-notification_text">
-                                Higher debt than national average
-                            </p>
-                        </div>
-                    </section>
-                </section>
-                <section class="criteria">
-                    <h3 class="criteria_heading">
-                        What if I can’t afford my student loan payments?
-                    </h3>
-                    <p>
-                        If you stop paying your loan, you could go into default. Defaulting on a loan can have serious negative affects on your financial future by lowering your credit score and making it very difficult to get a car or home loan.
-                    </p>
-                    <section class="metric loan-default-rates">
-                        <h4 class="metric_heading">
-                            Loan default rates
-                        </h4>
-                        <p class="metric_explanation">
-                            Percentage of students who default on loans after entering repayment
-                        </p>
-                        <div class="bar-graph">
-                            <div class="bar-graph_bar"></div>
-                            <div class="bar-graph_point bar-graph_point__you u-clearfix">
-                                <div class="bar-graph_row">
-                                    <div class="bar-graph_label">
-                                        [School Name]
-                                    </div>
-                                    <div class="bar-graph_value">
-                                        <div class="bar-graph_line"></div>
-                                        <div class="bar-graph_number">
-                                            72%
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="bar-graph_point bar-graph_point__average u-clearfix">
-                                <div class="bar-graph_row">
-                                    <div class="bar-graph_label">
-                                        National average
-                                    </div>
-                                    <div class="bar-graph_value">
-                                        <div class="bar-graph_line"></div>
-                                        <div class="bar-graph_number">
-                                            32%
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="cf-notification cf-notification__error">
-                            <span class="cf-notification_icon cf-notification_icon__error cf-icon cf-icon-error-round"></span>
-                            <p class="cf-notification_text">
-                                Higher default rate than national average
-                            </p>
-                        </div>
-                    </section>
-                </section>
+                </div>
             </section>
-        </section>
-    </div>
-
-
-
-
+            <section class="criteria column-well_wrapper">
+                <h3 class="criteria_heading">
+                    Am I about to take out too many loans?
+                </h3>
+                <div class="criteria_wrapper">
+                    <div class="criteria_intro">
+                        <p>
+                            There are two factors that make up your debt burden—your loan payment and your salary. The general rule of thumb is that you shouldn’t borrow more than you will make during your first year out of college. That means your student loan payment shouldn’t be more than 14% of your monthly income.
+                        </p>
+                        <p>
+                            If your debt burden is too high, it increases the chances of defaulting on your loan or not being able to pay for other necessities, like health insurance. Since it’s difficult to predict or actively increase your future salary, the best way to lower your debt burden is to reduce the amount of student loans you take out.
+                        </p>
+                    </div>
+                    <section class="metric debt-burden column-well column-well__bleed column-well__not-stacked">
+                        <div class="column-well_content">
+                            <h4 class="metric_heading">
+                                Your estimated debt burden
+                            </h4>
+                            <p class="metric_explanation">
+                                We calculate your debt burden by dividing your monthly loan payment by the average salary for students who attended your school.
+                            </p>
+                            <div class="debt-burden_projection">
+                                <div class="debt-burden_projection-name">
+                                    Projected salary
+                                </div>
+                                <div class="debt-burden_projection-value">
+                                    $30,000 / yr.<br>
+                                    $2,500 / mo.
+                                </div>
+                            </div>
+                            <div class="debt-burden_projection">
+                                <div class="debt-burden_projection-name">
+                                    Your projected loan payment
+                                </div>
+                                <div class="debt-burden_projection-value">
+                                    $550 / mo.
+                                </div>
+                            </div>
+                            <div class="debt-equation u-clearfix">
+                                <div class="debt-equation_part debt-equation_part__loan">
+                                    <div class="debt-equation_number">
+                                        $550
+                                    </div>
+                                    <div class="debt-equation_label">
+                                        loan payment
+                                    </div>
+                                </div>
+                                <div class="debt-equation_symbol">
+                                    /
+                                </div>
+                                <div class="debt-equation_part debt-equation_part__income">
+                                    <div class="debt-equation_number">
+                                        $2,500
+                                    </div>
+                                    <div class="debt-equation_label">
+                                        monthly salary
+                                    </div>
+                                </div>
+                                <div class="debt-equation_symbol">
+                                    =
+                                </div>
+                                <div class="debt-equation_part debt-equation_part__percent">
+                                    <div class="debt-equation_number">
+                                        22%
+                                    </div>
+                                    <div class="debt-equation_label">
+                                        of your income
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="cf-notification metric_notification cf-notification__error">
+                                <span class="cf-notification_icon cf-notification_icon__error cf-icon cf-icon-error-round"></span>
+                                <p class="cf-notification_text">
+                                    Loan payment is higher than recommended 14% of salary
+                                </p>
+                            </div>
+                        </div>
+                    </section>
+                </div>
+            </section>
+            <section class="criteria column-well_wrapper">
+                <h3 class="criteria_heading">
+                    What if I can’t afford my student loan payments?
+                </h3>
+                <div class="criteria_wrapper">
+                    <div class="criteria_intro">
+                        <p>
+                            If you stop paying your loan, you could go into default. Defaulting on a loan can have serious negative affects on your financial future by lowering your credit score and making it very difficult to get a car or home loan.
+                        </p>
+                    </div>
+                    <section class="metric loan-default-rates column-well column-well__bleed column-well__not-stacked">
+                        <div class="column-well_content">
+                            <h4 class="metric_heading">
+                                Loan default rates
+                            </h4>
+                            <p class="metric_explanation">
+                                Percentage of students who default on loans after entering repayment
+                            </p>
+                            <div class="bar-graph">
+                                <div class="bar-graph_bar"></div>
+                                <div class="bar-graph_point bar-graph_point__you u-clearfix">
+                                    <div class="bar-graph_row">
+                                        <div class="bar-graph_label">
+                                            [School Name]
+                                        </div>
+                                        <div class="bar-graph_value">
+                                            <div class="bar-graph_line"></div>
+                                            <div class="bar-graph_number">
+                                                72%
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="bar-graph_point bar-graph_point__average u-clearfix">
+                                    <div class="bar-graph_row">
+                                        <div class="bar-graph_label">
+                                            National average
+                                        </div>
+                                        <div class="bar-graph_value">
+                                            <div class="bar-graph_line"></div>
+                                            <div class="bar-graph_number">
+                                                32%
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="cf-notification metric_notification cf-notification__error">
+                                <span class="cf-notification_icon cf-notification_icon__error cf-icon cf-icon-error-round"></span>
+                                <p class="cf-notification_text">
+                                    Higher default rate than national average
+                                </p>
+                            </div>
+                        </div>
+                    </section>
+                </div>
+            </section>
+        </div>
+    </section>
     <section class="question step">
         <div class="content_wrapper">
             <div class="content_main">
@@ -1228,7 +1211,7 @@
             </div>
         </div>
     </section>
-    <section class="get-options step content_wrapper">
+    <section class="get-options step content_wrapper column-well_wrapper">
         <div class="content_main">
             <div class="get-options_wrapper">
                 <div class="get-options_intro get-options_intro__no">
@@ -1289,12 +1272,12 @@
                         Review your total cost of attendance and determine if a less expensive school option (such as a community college) might also meet your educational needs. <a href="#">See all schools</a> that offer the same type of program in your area.
                     </p>
                 </section>
-                <section class="option option__take-action column-well">
+                <section class="option option__take-action column-well column-well__emphasis">
                     <div class="column-well_content">
-                        <h3 class="column-well_header">
+                        <h3 class="option__take-action-header">
                             What you can do
                         </h3>
-                        <h3 class="column-well_header">
+                        <h3 class="option__take-action-header">
                             If you want to make a change
                         </h3>
                         <p>

--- a/paying_for_college/templates/just-a-demo.html
+++ b/paying_for_college/templates/just-a-demo.html
@@ -808,28 +808,24 @@
                             <div class="bar-graph">
                                 <div class="bar-graph_bar"></div>
                                 <div class="bar-graph_point bar-graph_point__you u-clearfix">
-                                    <div class="bar-graph_row">
-                                        <div class="bar-graph_label">
-                                            [School Name]
-                                        </div>
-                                        <div class="bar-graph_value">
-                                            <div class="bar-graph_line"></div>
-                                            <div class="bar-graph_number">
-                                                12%
-                                            </div>
+                                    <div class="bar-graph_label">
+                                        Your school
+                                    </div>
+                                    <div class="bar-graph_line"></div>
+                                    <div class="bar-graph_value">
+                                        <div class="bar-graph_number">
+                                            92%
                                         </div>
                                     </div>
                                 </div>
                                 <div class="bar-graph_point bar-graph_point__average u-clearfix">
-                                    <div class="bar-graph_row">
-                                        <div class="bar-graph_label">
-                                            National average
-                                        </div>
-                                        <div class="bar-graph_value">
-                                            <div class="bar-graph_line"></div>
-                                            <div class="bar-graph_number">
-                                                86%
-                                            </div>
+                                    <div class="bar-graph_label">
+                                        National average
+                                    </div>
+                                    <div class="bar-graph_line"></div>
+                                    <div class="bar-graph_value">
+                                        <div class="bar-graph_number">
+                                            86%
                                         </div>
                                     </div>
                                 </div>
@@ -862,28 +858,24 @@
                             <div class="bar-graph">
                                 <div class="bar-graph_bar"></div>
                                 <div class="bar-graph_point bar-graph_point__you u-clearfix">
-                                    <div class="bar-graph_row">
-                                        <div class="bar-graph_label">
-                                            [School Name]
-                                        </div>
-                                        <div class="bar-graph_value">
-                                            <div class="bar-graph_line"></div>
-                                            <div class="bar-graph_number">
-                                                $26,000
-                                            </div>
+                                    <div class="bar-graph_label">
+                                        Your school
+                                    </div>
+                                    <div class="bar-graph_line"></div>
+                                    <div class="bar-graph_value">
+                                        <div class="bar-graph_number">
+                                            $26,000
                                         </div>
                                     </div>
                                 </div>
                                 <div class="bar-graph_point bar-graph_point__average u-clearfix">
-                                    <div class="bar-graph_row">
-                                        <div class="bar-graph_label">
-                                            National average
-                                        </div>
-                                        <div class="bar-graph_value">
-                                            <div class="bar-graph_line"></div>
-                                            <div class="bar-graph_number">
-                                                $34,000
-                                            </div>
+                                    <div class="bar-graph_label">
+                                        National average
+                                    </div>
+                                    <div class="bar-graph_line"></div>
+                                    <div class="bar-graph_value">
+                                        <div class="bar-graph_number">
+                                            $34,000
                                         </div>
                                     </div>
                                 </div>
@@ -1146,28 +1138,24 @@
                             <div class="bar-graph">
                                 <div class="bar-graph_bar"></div>
                                 <div class="bar-graph_point bar-graph_point__you u-clearfix">
-                                    <div class="bar-graph_row">
-                                        <div class="bar-graph_label">
-                                            [School Name]
-                                        </div>
-                                        <div class="bar-graph_value">
-                                            <div class="bar-graph_line"></div>
-                                            <div class="bar-graph_number">
-                                                72%
-                                            </div>
+                                    <div class="bar-graph_label">
+                                        Your school
+                                    </div>
+                                    <div class="bar-graph_line"></div>
+                                    <div class="bar-graph_value">
+                                        <div class="bar-graph_number">
+                                            72%
                                         </div>
                                     </div>
                                 </div>
                                 <div class="bar-graph_point bar-graph_point__average u-clearfix">
-                                    <div class="bar-graph_row">
-                                        <div class="bar-graph_label">
-                                            National average
-                                        </div>
-                                        <div class="bar-graph_value">
-                                            <div class="bar-graph_line"></div>
-                                            <div class="bar-graph_number">
-                                                32%
-                                            </div>
+                                    <div class="bar-graph_label">
+                                        National average
+                                    </div>
+                                    <div class="bar-graph_line"></div>
+                                    <div class="bar-graph_value">
+                                        <div class="bar-graph_number">
+                                            32%
                                         </div>
                                     </div>
                                 </div>

--- a/src/disclosures/css/cf-enhancements.less
+++ b/src/disclosures/css/cf-enhancements.less
@@ -229,3 +229,94 @@
     content: counter(steps);
   }
 }
+
+/* ==========================================================================
+   Well that runs the entire height of a column
+   ========================================================================== */
+
+.column-well {
+  padding-top: unit(25px / @base-font-size-px, em);
+  padding-bottom: unit(10px / @base-font-size-px, em);
+  position: relative;
+
+  .respond-to-min(@bp-sm-min, {
+    padding-top: unit(30px / @base-font-size-px, em);
+    padding-bottom: unit(30px / @base-font-size-px, em);
+  });
+
+  &:after {
+    display: block;
+    width: 9999px;
+    height: 9999px;
+    position: absolute;
+    top: 0;
+    left: unit(-(@grid_gutter-width / @base-font-size-px) / 2, em);
+    z-index: 0;
+    background-color: @gray-5;
+    content: '';
+
+    .respond-to-min(@bp-sm-min, {
+      width: 100%;
+      left: 0;
+    });
+  }
+
+  &_wrapper {
+    overflow: hidden;
+  }
+
+  &_content {
+    position: relative;
+    z-index: 1;
+
+    .respond-to-min(@bp-sm-min, {
+      padding-right: unit(30px / @base-font-size-px, em);
+      padding-left: unit(30px / @base-font-size-px, em);
+    });
+  }
+
+  &__bleed {
+
+    &:after {
+      padding-right: @grid_gutter-width * 2;
+      left: -@grid_gutter-width;
+    }
+
+    .column-well_content {
+
+      .respond-to-min(@bp-sm-min, {
+        padding-right: 0;
+        padding-left: 0;
+      });
+    }
+  }
+
+  &__not-stacked {
+    padding-top: 0;
+    padding-bottom: 0;
+
+    .respond-to-min(@bp-sm-min, {
+      padding-top: unit(30px / @base-font-size-px, em);
+      padding-bottom: unit(30px / @base-font-size-px, em);
+    });
+
+    &:after {
+      display: none;
+
+      .respond-to-min(@bp-sm-min, {
+        display: block;
+      });
+    }
+  }
+
+  &__emphasis {
+    .respond-to-min(@bp-sm-min, {
+      padding-top: unit(50px / @base-font-size-px, em);
+      padding-bottom: unit(50px / @base-font-size-px, em);
+    });
+
+    &:after {
+      background-color: @green-20;
+    }
+  }
+}

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -342,87 +342,132 @@
    Evaluating your offer
    ========================================================================== */
 
-.criteria + .criteria {
-  margin-top: unit(45px / @base-font-size-px, em);
+.evaluate {
+
+  &_wrapper {
+
+    .respond-to-min(@bp-sm-min, {
+      .grid_nested-col-group();
+    });
+
+    & + .criteria {
+      margin-top: unit(30px / @base-font-size-px, em);
+    }
+  }
+
+  &_intro {
+
+    .respond-to-min(@bp-sm-min, {
+      .grid_column(8);
+    });
+  }
 }
 
-.criteria_heading {
-  .heading-3();
+.criteria {
+  margin-top: unit(45px / @base-font-size-px, em);
 
   .respond-to-min(@bp-sm-min, {
-    .heading-2();
+    border-bottom: 1px solid @gray-20;
   });
+
+  &_heading {
+    .heading-3();
+  }
+
+  &_wrapper {
+
+    .respond-to-min(@bp-sm-min, {
+      .grid_nested-col-group();
+    });
+  }
+
+  &_intro {
+
+    .respond-to-min(@bp-sm-min, {
+      .grid_column(5);
+    });
+  }
 }
 
 .metric {
   padding-top: unit(10px / @base-font-size-px, em);
-  border-top: 1px solid @gray-40;
+  border-top: 1px solid @gray-20;
   margin-top: unit(30px / @base-font-size-px, em);
-}
-
-.metric_heading {
-  .heading-4();
 
   .respond-to-min(@bp-sm-min, {
-    .heading-3();
+    .grid_column(4);
+    .grid_push(2);
+    padding-top: unit(30px / @base-font-size-px, em);
+    margin-top: 0;
   });
+
+  &_heading {
+    .heading-4();
+  }
+
+  &_explanation {
+    margin-bottom: unit(15px / 14px, em);
+    font-size: unit(14px / @base-font-size-px, em);
+  }
+
+  &_notification__better {
+    .heading-4();
+    margin-bottom: 0;
+  }
 }
 
-.metric_explanation {
-  margin-bottom: unit(15px / 14px, em);
-  font-size: unit(14px / @base-font-size-px, em);
-}
+.debt-burden {
 
-.debt-burden_projection {
-  .grid_nested-col-group();
-  margin-bottom: unit(20px / @base-font-size-px, em);
-}
+  &_projection {
+    .grid_nested-col-group();
+    margin-bottom: unit(20px / @base-font-size-px, em);
+  }
 
-.debt-burden_projection-name {
-  .grid_column(7);
-}
+  &_projection-name {
+    .grid_column(7);
+  }
 
-.debt-burden_projection-value {
-  .grid_column(5);
+  &_projection-value {
+    .grid_column(5);
+  }
 }
 
 .debt-equation {
   padding-top: unit(10px / @base-font-size-px, em);
   margin-bottom: unit(30px / @base-font-size-px, em);
+
+  &_part {
+    float: left;
+  }
+
+  &_part__loan {
+    width: 25%;
+  }
+
+  &_part__income {
+    width: 25%;
+  }
+
+  &_part__percent {
+    width: 20%;
+  }
+
+  &_symbol {
+    @symbol-font-size-px: 36px;
+    margin-top: unit(3px / @symbol-font-size-px, em);
+    width: 15%;
+    float: left;
+    .webfont-medium();
+    font-size: @symbol-font-size-px;
+    text-align: center;
+  }
+
+  &_number {
+    .webfont-medium();
+    font-size: unit(18px / @base-font-size-px, em);
+  }
 }
 
-.debt-equation_part {
-  float: left;
-}
-
-.debt-equation_part__loan {
-  width: 25%;
-}
-
-.debt-equation_part__income {
-  width: 25%;
-}
-
-.debt-equation_part__percent {
-  width: 20%;
-}
-
-.debt-equation_symbol {
-  @symbol-font-size-px: 36px;
-  margin-top: unit(3px / @symbol-font-size-px, em);
-  width: 15%;
-  float: left;
-  .webfont-medium();
-  font-size: @symbol-font-size-px;
-  text-align: center;
-}
-
-.debt-equation_number {
-  .webfont-medium();
-  font-size: unit(18px / @base-font-size-px, em);
-}
-
-// Needs to be nested to keep variables scoped
 .bar-graph {
   @bar-graph-width:       45px;
   @bar-graph-height:      130px;
@@ -467,32 +512,51 @@
     left: 50%;
     background-color: @gray-10;
   }
+
+  &_point__you {
+
+    .bar-graph_number{
+      .webfont-medium();
+      font-size: unit(18px / @base-font-size-px, em);
+    }
+
+    .bar-graph_line {
+      border-top-color: @black;
+      border-top-style: solid;
+    }
+  }
+
+  &_point__average {
+    color: @dark-gray;
+
+    .bar-graph_line {
+      border-top-color: @dark-gray;
+      border-top-style: dotted;
+    }
+  }
 }
 
-.bar-graph_point__you {
+/* ==========================================================================
+   Estimated monthly expenses
+   ========================================================================== */
 
-  .bar-graph_number{
-    .webfont-medium();
-    font-size: unit(18px / @base-font-size-px, em);
-  }
-
-  .bar-graph_line {
-    border-top-color: @black;
-    border-top-style: solid;
-  }
-}
-
-.bar-graph_point__average {
-  color: @dark-gray;
-
-  .bar-graph_line {
-    border-top-color: @dark-gray;
-    border-top-style: dotted;
-  }
+.average-salary .column-well_content {
+  .respond-to-min(@bp-sm-min, {
+    position: absolute;
+  });
 }
 
 .estimated-expenses {
   @expense-summary-font-size: 18px;
+  padding-top: unit(10px / @base-font-size-px, em);
+  border-top: 1px solid @gray-20;
+  margin-top: unit(30px / @base-font-size-px, em);
+
+  .respond-to-min(@bp-sm-min, {
+    .grid_column(6);
+    padding-top: 0;
+    margin-top: unit(15px / @base-font-size-px, em);
+  });
 
   &_form {
     margin-top: 0;
@@ -504,7 +568,6 @@
     margin-bottom: unit(45px / @base-font-size-px, em);
     background-color: @gold-20;
   }
-
 
   &_heading {
     padding-bottom: unit(5px / @expense-summary-font-size, em);
@@ -567,8 +630,6 @@
    ========================================================================== */
 
 .get-options {
-  // Needed for the non-standard one-column well
-  overflow: hidden;
 
   .respond-to-min(@bp-sm-min, {
     padding-bottom: unit(30px / @base-font-size-px, em);
@@ -587,7 +648,6 @@
   }
 
   .content_main {
-    // Needed for the non-standard one-column well
     padding-bottom: 0;
   }
 
@@ -627,6 +687,10 @@
     .heading-4();
   }
 
+  &__take-action-header {
+    .heading-3();
+  }
+
   // Rules on all but the first option on small screens but only the second row of options on larger screens
   & + & &_heading {
     border-top: 1px solid @gray-40;
@@ -641,48 +705,6 @@
     .respond-to-min(@bp-sm-min, {
       border-top: 1px solid @gray-40;
     });
-  }
-}
-
-// Non-standard one-column well
-.column-well {
-  padding-top: unit(25px / @base-font-size-px, em);
-  padding-bottom: unit(10px / @base-font-size-px, em);
-  position: relative;
-
-  .respond-to-min(@bp-sm-min, {
-    padding-top: unit(50px / @base-font-size-px, em);
-    padding-bottom: unit(50px / @base-font-size-px, em);
-  });
-
-  &:after {
-    width: 999px;
-    height: 999px;
-    position: absolute;
-    top: 0;
-    left: unit(-(@grid_gutter-width / @base-font-size-px) / 2, em);
-    z-index: 0;
-    background-color: @green-20;
-    content: '';
-
-    .respond-to-min(@bp-sm-min, {
-      width: 100%;
-      left: 0;
-    });
-  }
-
-  &_content {
-    position: relative;
-    z-index: 1;
-
-    .respond-to-min(@bp-sm-min, {
-      padding-right: unit(30px / @base-font-size-px, em);
-      padding-left: unit(30px / @base-font-size-px, em);
-    });
-  }
-
-  &_header {
-    .heading-3();
   }
 }
 

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -469,9 +469,15 @@
 }
 
 .bar-graph {
-  @bar-graph-width:       45px;
-  @bar-graph-height:      130px;
-  @bar-graph-line-width:  51px;
+  @bar-graph-width:                45px;
+  @bar-graph-height:              130px;
+  @bar-graph-label-width:         135px;
+  @bar-graph-value-min-width:      95px;
+  @bar-graph-you-font-size:        18px;
+  @bar-graph-average-font-size:    16px;
+  @bar-graph-line-overhang:         6px;
+  // A little cheat to make the line look vertically centered
+  @bar-graph-line-top-cheat:        3px;
 
   height: @bar-graph-height;
   margin-bottom: unit(10px / @base-font-size-px, em);
@@ -482,21 +488,33 @@
     position: absolute;
   }
 
-  &_row {
-    .grid_nested-col-group();
-  }
-
   &_label,
   &_value {
-    .grid_column(6);
+    position: absolute;
+    top: 0;
+    background-color: @white;
+
+    .respond-to-min(@bp-sm-min, {
+      background-color: @gray-5;
+    });
+  }
+
+  &_label {
+    width: @bar-graph-label-width;
+    left: 0;
+    z-index: 10;
+  }
+
+  &_value {
+    min-width: @bar-graph-value-min-width;
+    padding-left: 8px;
+    right: 0;
   }
 
   &_line {
-    display: inline-block;
-    width: @bar-graph-line-width;
+    width: 100%;
     border-top-width: 3px;
-    margin-bottom: 5px;
-    margin-right: 5px;
+    position: absolute;
   }
 
   &_number {
@@ -506,7 +524,7 @@
   &_bar {
     width: @bar-graph-width;
     height: @bar-graph-height;
-    margin-left: unit( (@grid_gutter-width / 2) + (@bar-graph-line-width - @bar-graph-width) / 2, px);
+    margin-left: -@bar-graph-line-overhang;
     position: absolute;
     top: 0;
     left: 50%;
@@ -514,15 +532,13 @@
   }
 
   &_point__you {
-
-    .bar-graph_number{
-      .webfont-medium();
-      font-size: unit(18px / @base-font-size-px, em);
-    }
+    .webfont-medium();
+    font-size: unit(@bar-graph-you-font-size / @base-font-size-px, em);
 
     .bar-graph_line {
       border-top-color: @black;
       border-top-style: solid;
+      top: unit( (@bar-graph-you-font-size + @bar-graph-line-top-cheat) / 2, px);
     }
   }
 
@@ -532,6 +548,7 @@
     .bar-graph_line {
       border-top-color: @dark-gray;
       border-top-style: dotted;
+      top: unit( (@bar-graph-average-font-size + @bar-graph-line-top-cheat) / 2, px);
     }
   }
 }

--- a/src/disclosures/js/index.js
+++ b/src/disclosures/js/index.js
@@ -2,6 +2,7 @@
 
 var financialModel = require( './models/financial-model' );
 var financialView = require( './views/financial-view' );
+var metricView = require( './views/metric-view' );
 
 require('./utils/nemo');
 require('./utils/nemo-shim');
@@ -10,6 +11,8 @@ var app = {
   init: function() {
     financialModel.init();
     financialView.init();
+    // Placeholder to set bar graphs
+    metricView.demo();
   }
 };
 

--- a/src/disclosures/js/views/metric-view.js
+++ b/src/disclosures/js/views/metric-view.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var metricView = {
+
+  // Placeholder to set bar graphs
+  demo: function() {
+    $( '.graduation-rate .bar-graph_point__you' ).css( 'top', '5px' );
+    $( '.graduation-rate .bar-graph_point__average' ).css( 'top', '30px' );
+    $( '.average-salary .bar-graph_point__you' ).css( 'top', '80px' );
+    $( '.average-salary .bar-graph_point__average' ).css( 'top', '40px' );
+    $( '.loan-default-rates .bar-graph_point__you' ).css( 'top', '25px' );
+    $( '.loan-default-rates .bar-graph_point__average' ).css( 'top', '70px' );
+  }
+
+}
+
+module.exports = metricView;


### PR DESCRIPTION
Add large-screen styles for step 2 (not the expenses form yet, though)
## Additions
- Step 2 LESS for screens wider than `@bp-sm-min` (600px)
- Placeholder JS to set demo values for the bar charts
## Changes
- HTML changes to accommodate the large-screen design
- Full-column wells moved out of the app styles and into the CF enhancement styles (and refactored)
## Testing
- To test, pull in the `evaluate-large` branch and run `gulp`. Fire up the app in standalone or UnityBox as normal. The page will be at `/paying-for-college2/demo`.
- You can ignore the monthly expenses form for now—that will be addressed in a separate PR.
- I've tested this in IE8/Win7, IE9/Win7, IE11/Win7, Firefox/Win7, Chrome/Mac, Safari/Mac, Mobile Safari/iPhone6, and everything (especially the bar charts) seems to be looking good
## Review
- @ascott1 (I can pull out the placeholder JS if it's not looking good)
## Screenshots

| 600px and under | 601px and above |
| --- | --- |
| ![evaluate-small](https://cloud.githubusercontent.com/assets/1862695/11935844/25f11382-a7d8-11e5-901c-1a31bca728d6.png) | ![evaluate-large](https://cloud.githubusercontent.com/assets/1862695/11935849/2fd0997c-a7d8-11e5-8c54-f5b7b2ad0919.png) |
## Todos
- Remove placeholder bar chart JS when the real JS is ready
## Checklist
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [X] Passes all existing automated tests
- [X] Placeholder code is flagged
- [X] Visually tested in supported browsers and devices
