### PR TITLE
Json delivery

### DIFF
--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -167,18 +167,19 @@ class School(models.Model):
 
     def as_json(self):
         """delivers pertinent data points as json"""
+        ordered_out = OrderedDict()
         jdata = json.loads(self.data_json)
         dict_out = {
             'books': jdata['BOOKS'],
             'city': self.city,
             'control': self.control,
-            'defaultRate': self.default_rate,
-            'gradRate': self.grad_rate,
+            'defaultRate': "{0}".format(self.default_rate),
+            'gradRate': "{0}".format(self.grad_rate),
             'indicatorGroup': jdata['INDICATORGROUP'],
             'KBYOSS': self.KBYOSS,
-            'medianAnnualPay': self.median_annual_pay,
-            'medianMonthlyDebt': self.median_monthly_debt,
-            'medianTotalDebt': self.median_total_debt,
+            'medianAnnualPay': str(self.median_annual_pay),
+            'medianMonthlyDebt': "{0}".format(self.median_monthly_debt),
+            'medianTotalDebt': "{0}".format(self.median_total_debt),
             'offerAA': jdata['OFFERAA'],
             'offerBA': jdata['OFFERBA'],
             'offerGrad': jdata['OFFERGRAD'],
@@ -187,7 +188,7 @@ class School(models.Model):
             'otherOffCampus': jdata['OTHEROFFCAMPUS'],
             'otherOnCampus': jdata['OTHERONCAMPUS'],
             'otherWFamily': jdata['OTHERWFAMILY'],
-            'repay3yr': self.repay_3yr,
+            'repay3yr': "{0}".format(self.repay_3yr),
             'roomBrdOffCampus': jdata['ROOMBRDOFFCAMPUS'],
             'roomBrdOnCampus': jdata['ROOMBRDONCAMPUS'],
             'school': self.primary_alias,
@@ -201,7 +202,9 @@ class School(models.Model):
             'tuitionUnderOoss': jdata['TUITIONUNDEROSS'],
             'zip5': self.zip5,
         }
-        return json.dumps(dict_out)
+        for key in sorted(dict_out.keys()):
+            ordered_out[key] = dict_out[key]
+        return json.dumps(ordered_out)
 
     def __unicode__(self):
         return self.primary_alias + u" (%s)" % self.school_id

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -165,6 +165,44 @@ class School(models.Model):
                                      null=True,
                                      help_text="MEDIAN PAY 10 YEARS AFTER ENTRY")
 
+    def as_json(self):
+        """delivers pertinent data points as json"""
+        jdata = json.loads(self.data_json)
+        dict_out = {
+            'books': jdata['BOOKS'],
+            'city': self.city,
+            'control': self.control,
+            'defaultRate': self.default_rate,
+            'gradRate': self.grad_rate,
+            'indicatorGroup': jdata['INDICATORGROUP'],
+            'KBYOSS': self.KBYOSS,
+            'medianAnnualPay': self.median_annual_pay,
+            'medianMonthlyDebt': self.median_monthly_debt,
+            'medianTotalDebt': self.median_total_debt,
+            'offerAA': jdata['OFFERAA'],
+            'offerBA': jdata['OFFERBA'],
+            'offerGrad': jdata['OFFERGRAD'],
+            'onCampusAvail': jdata['ONCAMPUSAVAIL'],
+            'online': self.online_only,
+            'otherOffCampus': jdata['OTHEROFFCAMPUS'],
+            'otherOnCampus': jdata['OTHERONCAMPUS'],
+            'otherWFamily': jdata['OTHERWFAMILY'],
+            'repay3yr': self.repay_3yr,
+            'roomBrdOffCampus': jdata['ROOMBRDOFFCAMPUS'],
+            'roomBrdOnCampus': jdata['ROOMBRDONCAMPUS'],
+            'school': self.primary_alias,
+            'schoolID': self.pk,
+            'state': self.state,
+            'tuitionGradInDis': jdata['TUITIONGRADINDIS'],
+            'tuitionGradInS': jdata['TUITIONGRADINS'],
+            'tuitionGradOss': jdata['TUITIONGRADOSS'],
+            'tuitionUnderInDis': jdata['TUITIONUNDERINDIS'],
+            'tuitionUnderInS': jdata['TUITIONUNDERINS'],
+            'tuitionUnderOoss': jdata['TUITIONUNDEROSS'],
+            'zip5': self.zip5,
+        }
+        return json.dumps(dict_out)
+
     def __unicode__(self):
         return self.primary_alias + u" (%s)" % self.school_id
 

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -174,7 +174,7 @@ class SchoolRepresentation(View):
 
     def get(self, request, school_id, **kwargs):
         school = self.get_school(school_id)
-        return HttpResponse(school.data_json, content_type='application/json')
+        return HttpResponse(school.as_json(), content_type='application/json')
 
 
 class ProgramRepresentation(View):


### PR DESCRIPTION
This unifies school json output (api data + ipeds) and aligns vars with our documentation.
## Changes
- updates school view and model to assemble json output
## Testing
- try hitting the api for a school, such as:

```
/paying-for-college2/understanding-your-financial-aid-offer/api/school/155317.json
```

if you've pulled in the latest data, you should get:

``` python
{
    KBYOSS: true,
    books: "900",
    city: "Lawrence",
    control: "Public",
    defaultRate: "0.055",
    gradRate: "0.63",
    indicatorGroup: "1",
    medianAnnualPay: "44600",
    medianMonthlyDebt: "223.3066337",
    medianTotalDebt: "14799",
    offerAA: "Yes",
    offerBA: "Yes",
    offerGrad: "Yes",
    onCampusAvail: "Yes",
    online: false,
    otherOffCampus: "3568",
    otherOnCampus: "3568",
    otherWFamily: "3568",
    repay3yr: "0.8731063691",
    roomBrdOffCampus: "8852",
    roomBrdOnCampus: "7702",
    school: "University of Kansas",
    schoolID: 155317,
    state: "KS",
    tuitionGradInDis: "",
    tuitionGradInS: "",
    tuitionGradOss: "",
    tuitionUnderInDis: "10107",
    tuitionUnderInS: "10107",
    tuitionUnderOoss: "24873",
    zip5: "66045"
}
```
## Review
- @mistergone @ascott1 @rosskarchner and anyone else within the sound of my voice.
