### PR TITLE
Functional tests fix after URL change from demo

### DIFF
--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -14,12 +14,23 @@ describe( 'A dynamic financial aid disclosure that\'s required by settlement', f
 		expect( browser.getTitle() ).toBe( 'Understanding your financial aid offer > Consumer Financial Protection Bureau' );
 	} );
 
-	it( 'should contain an offer ID', function(){
+	it( 'should contain an offer ID in the URL', function(){
 		expect( browser.getCurrentUrl() ).toContain( 'oid' );
 	} );
 
+	it( 'should contain a college ID and a program ID in the URL', function(){
+		expect( browser.getCurrentUrl() ).toContain( 'iped' );
+		expect( browser.getCurrentUrl() ).toContain( 'pid' );
+	} );
+
+	it( 'should contain required aid offer values in the URL', function(){
+		expect( browser.getCurrentUrl() ).toContain( 'tuit' );
+        expect( browser.getCurrentUrl() ).toContain( 'hous' );
+        expect( browser.getCurrentUrl() ).toContain( 'book' );
+	} );
+
 	// TODO - Add expectation that other sections are invisible
-	it( 'should display the verify offer area first and no other sections', function() {
+	it( 'should display the verify offer area and no other sections', function() {
 		browser.wait( EC.visibilityOf(page.verifySection ), 8000 );
 	} );
 
@@ -36,6 +47,9 @@ describe( 'A dynamic financial aid disclosure that\'s required by settlement', f
 	} );
 
 	// *** Step 1: Review your offer ***
+  // TODO: After the offer URL implementation conforms to spec, 
+  // we should draw values straight from the page based on URL values
+  // rather than setting all of them explicitly here.
 
 	// TODO - Uncomment remaining cost when it's hooked up
 	it( 'should properly update when the tuition is modified', function() {

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -25,8 +25,8 @@ describe( 'A dynamic financial aid disclosure that\'s required by settlement', f
 
 	it( 'should contain required aid offer values in the URL', function(){
 		expect( browser.getCurrentUrl() ).toContain( 'tuit' );
-        expect( browser.getCurrentUrl() ).toContain( 'hous' );
-        expect( browser.getCurrentUrl() ).toContain( 'book' );
+    expect( browser.getCurrentUrl() ).toContain( 'hous' );
+    expect( browser.getCurrentUrl() ).toContain( 'book' );
 	} );
 
 	// TODO - Add expectation that other sections are invisible

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -2,7 +2,7 @@
 
 var settlementAidOfferPage = function() {
     // TODO: We will need to add offer variables to the end of the following URL.
-    browser.get( 'http://localhost:8000/paying-for-college2/demo/?oid=1f9y8w1t6y3q0r' );
+    browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/?iped=408039&pid=981&oid=f38283b5b7c939a058889f997949efa566c616c5&tuit=38976&hous=3000&book=650&tran=500&othr=500&pelg=1500&schg=2000&stag=2000&othg=100&ta=3000&mta=3000&gib=3000&fam=4000&wkst=3000&parl=10000&perl=3000&subl=15000&unsl=2000&ppl=1000&gpl=1000&prvl=3000&prvi=4.55&insl=3000&insi=4.55' );
 };
 
 settlementAidOfferPage.prototype = Object.create({}, {


### PR DESCRIPTION
This fixes the functional tests after our URL change so they don't fail. Also uses the proper URL structure according to our spec.
## Additions
- Added new settlement tests requiring the URL to have a college ID, a program ID, and certain other required variables.
## Changes
- Changed the URL in the page model from /demo/ to one using /understanding-your-financial-aid-offer/ that includes variables.
## Testing

Pull in the `functional-tests` branch and run `npm install`.

Make sure you have webdriver and protractor all set up:

``` bash
npm install -g webdriver-manager protractor
webdriver-manager update --standalone
```

Run `gulp`, and load the standalone server. 

To run the tests:

``` bash
# Open a new terminal tab, and start webdriver:
webdriver-manager start
# Open a third tab, and run:
protractor test/functional/conf.js
```

You should eventually see something like the following:

```
Using the selenium server at http://localhost:4444/wd/hub
[launcher] Running 1 instances of WebDriver
Started

.............
13 specs, 0 failures
Finished in 15.958 seconds
[launcher] 0 instance(s) of WebDriver still running
[launcher] chrome #1 passed
```
## Review
- Any two of the following: @ascott1 @higs4281 @niqjohnson @mistergone
## Checklist
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [X] Passes all existing automated tests
- [X] Placeholder code is flagged
- [X] Visually tested in supported browsers and devices
