### PR TITLE
Run essential gulp tasks when starting watch

### DIFF
--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -12,7 +12,7 @@ var browserSync = require( 'browser-sync' );
 
 var reload = browserSync.reload;
 
-gulp.task( 'watch', [ 'browserSync' ], function() {
+gulp.task( 'watch', [ 'browserSync', 'scripts', 'styles', 'images', 'copy:files' ], function() {
   gulp.watch( config.scripts.src, [ 'scripts', 'lint:scripts', reload ] );
   gulp.watch( config.styles.cwd + '/**/*.less', [ 'styles', reload ] );
   gulp.watch( config.images.src, [ 'images', reload ] );


### PR DESCRIPTION
This was driving me nuts. Now running gulp watch will build all of the JS/CSS and copy necessary files on it's initial run. This means no more:

```
gulp
gulp watch
```

Now we should be able to just run `gulp watch` while we sit back with a :tropical_drink: 
## Review

@mistergone @niqjohnson @marteki 
