### PR TITLE
Medium screen styles

### DIFF
--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -175,7 +175,7 @@
             <section class="review step content_wrapper">
                 <div class="content_main">
                     <div class="review_wrapper">
-                        <div class="evaluate_intro">
+                        <div class="review_intro">
                             <h2 class="step_heading">
                                 Step 1: Review your first year offer
                             </h2>
@@ -445,10 +445,10 @@
                                         Total grants and scholarships
                                     </div>
                                     <div class="line-item_value">
-                                        <span class="line-item_sign">
-                                            ( &minus; )
-                                        </span>
                                         <span class="line-item_currency">
+                                            <span class="line-item_sign">
+                                                ( &minus; )
+                                            </span>
                                             $
                                         </span>
                                         <span class="line-item_amount"
@@ -596,10 +596,10 @@
                                         </span>
                                     </div>
                                     <div class="line-item_value">
-                                        <span class="line-item_sign">
-                                            ( + )
-                                        </span>
                                         <span class="line-item_currency">
+                                            <span class="line-item_sign">
+                                                ( + )
+                                            </span>
                                             $
                                         </span>
                                         <span class="line-item_amount"
@@ -611,10 +611,10 @@
                                         Work study
                                     </div>
                                     <div class="line-item_value">
-                                        <span class="line-item_sign">
-                                            ( + )
-                                        </span>
                                         <span class="line-item_currency">
+                                            <span class="line-item_sign">
+                                                ( + )
+                                            </span>
                                             $
                                         </span>
                                         <span class="line-item_amount"
@@ -660,10 +660,10 @@
                                         Your contributions
                                     </div>
                                     <div class="line-item_value">
-                                        <span class="line-item_sign">
-                                            ( &minus; )
-                                        </span>
                                         <span class="line-item_currency">
+                                            <span class="line-item_sign">
+                                                ( &minus; )
+                                            </span>
                                             $
                                         </span>
                                         <span class="line-item_amount"
@@ -1155,10 +1155,10 @@
                                         Total private loans and payment plans
                                     </div>
                                     <div class="line-item_value">
-                                        <span class="line-item_sign">
-                                            ( + )
-                                        </span>
                                         <span class="line-item_currency">
+                                            <span class="line-item_sign">
+                                                ( + )
+                                            </span>
                                             $
                                         </span>
                                         <span class="line-item_amount"
@@ -1205,10 +1205,10 @@
                                         Your contributions
                                     </div>
                                     <div class="line-item_value">
-                                        <span class="line-item_sign">
-                                            ( &minus; )
-                                        </span>
                                         <span class="line-item_currency">
+                                            <span class="line-item_sign">
+                                                ( &minus; )
+                                            </span>
                                             $
                                         </span>
                                         <span class="line-item_amount"
@@ -1221,10 +1221,10 @@
                                         Your debt
                                     </div>
                                     <div class="line-item_value">
-                                        <span class="line-item_sign">
-                                            ( &minus; )
-                                        </span>
                                         <span class="line-item_currency">
+                                            <span class="line-item_sign">
+                                                ( &minus; )
+                                            </span>
                                             $
                                         </span>
                                         <span class="line-item_amount"
@@ -1319,10 +1319,10 @@
                                         Your contributions
                                     </div>
                                     <div class="line-item_value">
-                                        <span class="line-item_sign">
-                                            ( &minus; )
-                                        </span>
                                         <span class="line-item_currency">
+                                            <span class="line-item_sign">
+                                                ( &minus; )
+                                            </span>
                                             $
                                         </span>
                                         <span class="line-item_amount"
@@ -1335,10 +1335,10 @@
                                         Your debt
                                     </div>
                                     <div class="line-item_value">
-                                        <span class="line-item_sign">
-                                            ( &minus; )
-                                        </span>
                                         <span class="line-item_currency">
+                                            <span class="line-item_sign">
+                                                ( &minus; )
+                                            </span>
                                             $
                                         </span>
                                         <span class="line-item_amount"
@@ -1711,10 +1711,10 @@
                                             Total monthly expenses
                                         </div>
                                         <div class="line-item_value">
-                                            <span class="line-item_sign">
-                                                ( &minus; )
-                                            </span>
                                             <span class="line-item_currency">
+                                                <span class="line-item_sign">
+                                                    ( &minus; )
+                                                </span>
                                                 $
                                             </span>
                                             <span class="line-item_amount"
@@ -1726,10 +1726,10 @@
                                             Student loans
                                         </div>
                                         <div class="line-item_value">
-                                            <span class="line-item_sign">
-                                                ( &minus; )
-                                            </span>
                                             <span class="line-item_currency">
+                                                <span class="line-item_sign">
+                                                    ( &minus; )
+                                                </span>
                                                 $
                                             </span>
                                             <span class="line-item_amount"

--- a/src/disclosures/css/cf-enhancements.less
+++ b/src/disclosures/css/cf-enhancements.less
@@ -284,13 +284,16 @@ a.btn__full-small.btn__link {
   &__bleed {
 
     &:after {
-      padding-right: @grid_gutter-width * 2;
-      left: -@grid_gutter-width;
+
+      .respond-to-min(@bp-lg-min, {
+        padding-right: @grid_gutter-width * 2;
+        left: -@grid_gutter-width;
+      });
     }
 
     .column-well_content {
 
-      .respond-to-min(@bp-sm-min, {
+      .respond-to-min(@bp-lg-min, {
         padding-right: 0;
         padding-left: 0;
       });

--- a/src/disclosures/css/cf-enhancements.less
+++ b/src/disclosures/css/cf-enhancements.less
@@ -285,7 +285,7 @@ a.btn__full-small.btn__link {
 
     &:after {
 
-      .respond-to-min(@bp-lg-min, {
+      .respond-to-min(@bp-med-min, {
         padding-right: @grid_gutter-width * 2;
         left: -@grid_gutter-width;
       });
@@ -293,7 +293,7 @@ a.btn__full-small.btn__link {
 
     .column-well_content {
 
-      .respond-to-min(@bp-lg-min, {
+      .respond-to-min(@bp-med-min, {
         padding-right: 0;
         padding-left: 0;
       });

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -466,7 +466,7 @@
 
   &_wrapper {
 
-    .respond-to-min(@bp-sm-min, {
+    .respond-to-min(@bp-med-min, {
       .grid_nested-col-group();
     });
 
@@ -477,7 +477,11 @@
 
   &_intro {
 
-    .respond-to-min(@bp-sm-min, {
+    .respond-to-min(@bp-med-min, {
+      .grid_column(10);
+    });
+
+    .respond-to-min(@bp-xl-min, {
       .grid_column(8);
     });
   }
@@ -684,7 +688,7 @@
 
   &_wrapper {
 
-    .respond-to-min(@bp-sm-min, {
+    .respond-to-min(@bp-med-min, {
       .grid_nested-col-group();
     });
 
@@ -695,7 +699,11 @@
 
   &_intro {
 
-    .respond-to-min(@bp-sm-min, {
+    .respond-to-min(@bp-med-min, {
+      .grid_column(10);
+    });
+
+    .respond-to-min(@bp-xl-min, {
       .grid_column(8);
     });
   }
@@ -990,13 +998,19 @@
   });
 
   &_wrapper {
-    .respond-to-min(@bp-sm-min, {
+
+    .respond-to-min(@bp-med-min, {
       .grid_nested-col-group();
     });
   }
 
   &_content {
-    .respond-to-min(@bp-sm-min, {
+
+  .respond-to-min(@bp-med-min, {
+      .grid_column(10);
+    });
+
+    .respond-to-min(@bp-xl-min, {
       .grid_column(8);
     });
   }
@@ -1024,13 +1038,26 @@
   });
 
   &_wrapper {
+
+    .respond-to-min(@bp-med-min, {
+      .grid_nested-col-group();
+    });
+  }
+
+  &_wrapper + &_wrapper {
+
     .respond-to-min(@bp-sm-min, {
       .grid_nested-col-group();
     });
   }
 
   &_intro {
-    .respond-to-min(@bp-sm-min, {
+
+    .respond-to-min(@bp-med-min, {
+      .grid_column(10);
+    });
+
+    .respond-to-min(@bp-xl-min, {
       .grid_column(8);
     });
   }
@@ -1052,8 +1079,12 @@
   margin-top: unit(30px / @base-font-size-px, em);
 
   .respond-to-min(@bp-sm-min, {
-    .grid_column(4);
+    .grid_column(6);
     margin-top: unit(45px / @base-font-size-px, em);
+  });
+
+  .respond-to-min(@bp-med-min, {
+    .grid_column(4);
   });
 
   &__maximize-grants,
@@ -1075,7 +1106,7 @@
     .heading-3();
   }
 
-  // Rules on all but the first option on small screens but only the second row of options on larger screens
+  // Top borders on all but the first option on small screens and only the second row of options on larger screens
   & + & &_heading {
     border-top: 1px solid @gray-40;
 
@@ -1084,9 +1115,20 @@
     });
   }
 
-  & + & + & + & &_heading {
+  & + & + & &_heading {
 
     .respond-to-min(@bp-sm-min, {
+      border-top: 1px solid @gray-40;
+    });
+
+    .respond-to-min(@bp-med-min, {
+      border-top: none;
+    });
+  }
+
+  & + & + & + & &_heading {
+
+    .respond-to-min(@bp-med-min, {
       border-top: 1px solid @gray-40;
     });
   }
@@ -1102,14 +1144,19 @@
   &_wrapper {
     margin-top: unit(30px / @base-font-size-px, em);
 
-    .respond-to-min(@bp-sm-min, {
+    .respond-to-min(@bp-med-min, {
       margin-top: unit(45px / @base-font-size-px, em);
       .grid_nested-col-group();
     });
   }
 
   &_intro {
-    .respond-to-min(@bp-sm-min, {
+
+    .respond-to-min(@bp-med-min, {
+      .grid_column(10);
+    });
+
+    .respond-to-min(@bp-xl-min, {
       .grid_column(8);
     });
   }
@@ -1118,8 +1165,11 @@
     margin-top: unit(45px / @base-font-size-px, em);
 
     .respond-to-min(@bp-sm-min, {
-      margin-top: unit(60px / @base-font-size-px, em);
       .grid_nested-col-group();
+    });
+
+    .respond-to-min(@bp-med-min, {
+      margin-top: unit(60px / @base-font-size-px, em);
     });
   }
 
@@ -1128,6 +1178,10 @@
 
     .respond-to-min(@bp-sm-min, {
       margin-top: 0;
+      .grid_column(9);
+    });
+
+    .respond-to-min(@bp-med-min, {
       .grid_column(4);
     });
   }
@@ -1139,7 +1193,7 @@
   &_controls {
     margin-top: unit(20px / @base-font-size-px, em);
 
-    .respond-to-min(@bp-sm-min, {
+    .respond-to-min(@bp-med-min, {
       margin-top: unit(30px / @base-font-size-px, em);
     });
   }
@@ -1171,7 +1225,12 @@
   }
 
   &_intro {
+
     .respond-to-min(@bp-sm-min, {
+      .grid_column(9);
+    });
+
+    .respond-to-min(@bp-xl-min, {
       .grid_column(6);
     });
   }

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -303,6 +303,10 @@
     box-sizing: border-box;
     width: 100%;
 
+    .respond-to-min(@bp-sm-min, {
+      max-width: unit(280px / @base-font-size-px, em);
+    });
+
     &__currency {
       text-align: right;
     }
@@ -878,6 +882,7 @@
 
   &_projection {
     .grid_nested-col-group();
+    max-width: unit(380px / @base-font-size-px, em);
     margin-bottom: unit(20px / @base-font-size-px, em);
   }
 
@@ -887,10 +892,12 @@
 
   &_projection-value {
     .grid_column(5);
+    text-align: right;
   }
 }
 
 .debt-equation {
+  max-width: unit(380px / @base-font-size-px, em);
   padding-top: unit(10px / @base-font-size-px, em);
   margin-bottom: unit(30px / @base-font-size-px, em);
 
@@ -927,6 +934,7 @@
 }
 
 .bar-graph {
+  @bar-graph-container-max-width:  380px;
   @bar-graph-width:                45px;
   @bar-graph-width-narrow:         25px;
   @bar-graph-height:              130px;
@@ -939,6 +947,7 @@
   @bar-graph-line-top-cheat:        3px;
 
   height: @bar-graph-height;
+  max-width: unit(@bar-graph-container-max-width / @base-font-size-px, em);
   margin-bottom: unit(10px / @base-font-size-px, em);
   position: relative;
 
@@ -1050,37 +1059,41 @@
 
   .aid-form {
     margin-top: 0;
-  }
 
-  .aid-form_heading {
+    &_heading {
 
-    .respond-to-range(@bp-sm-min, @bp-graph-cols-min, {
-      border-bottom: none;
-    });
-  }
+      .respond-to-range(@bp-sm-min, @bp-graph-cols-min, {
+        border-bottom: none;
+      });
+    }
 
-  .aid-form_summary {
+    &_input {
+      max-width: none;
+    }
 
-    .respond-to-min(@bp-sm-min, {
-      padding-left: 0;
-      margin-top: unit(45px / @base-font-size-px, em);
-      margin-left: 0;
-      background-color: transparent;
-    });
+    &_summary {
 
-    .respond-to-range(@bp-sm-min, @bp-sm-max, {
-      padding-right: 0;
-    });
+      .respond-to-min(@bp-sm-min, {
+        padding-left: 0;
+        margin-top: unit(45px / @base-font-size-px, em);
+        margin-left: 0;
+        background-color: transparent;
+      });
 
-    .respond-to-min(@bp-lg-min, {
-      padding-left: unit(40px / @base-font-size-px, em);
-    });
-  }
+      .respond-to-range(@bp-sm-min, @bp-sm-max, {
+        padding-right: 0;
+      });
 
-  .aid-form_summary-heading {
-    .heading-4();
-    margin-bottom: unit(10px / @font-size, em);
-    text-transform: none;
+      .respond-to-min(@bp-lg-min, {
+        padding-left: unit(40px / @base-font-size-px, em);
+      });
+    }
+
+    &_summary-heading {
+      .heading-4();
+      margin-bottom: unit(10px / @font-size, em);
+      text-transform: none;
+    }
   }
 
   .line-item {

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -1037,6 +1037,7 @@
 
   .respond-to-min(@bp-sm-min, {
     .grid_column(10);
+    border-top: 1px solid @gray-40;
   });
 
   .respond-to-min(@bp-graph-cols-min, {
@@ -1049,6 +1050,13 @@
 
   .aid-form {
     margin-top: 0;
+  }
+
+  .aid-form_heading {
+
+    .respond-to-range(@bp-sm-min, @bp-graph-cols-min, {
+      border-bottom: none;
+    });
   }
 
   .aid-form_summary {

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -4,6 +4,8 @@
 
 @small-font-size-px:    14px;
 @x-small-font-size-px:  12px;
+// Minimum width that putting the + or - sign inline with values in two-column line items works
+@bp-inline-sign-min:    689px;
 
 .understanding-financial-aid-offer {
   .webfont-regular();
@@ -410,13 +412,13 @@
   @line-item-font-size: 18px;
 
   .grid_nested-col-group();
-  .heading-4();
   margin-bottom: unit(15px / @font-size, em);
+  .heading-4();
 
   &_sign {
-    position: relative;
-    left: unit(-5px / @font-size, em);
-    font-size: unit(18px / @font-size, em);
+    display: inline-block;
+    margin-right: unit(5px / @line-item-font-size, em);
+    font-size: unit(@line-item-font-size / @font-size, em);
   }
 
   &_currency {
@@ -584,6 +586,13 @@
       .grid_column(4);
       .grid_push(1);
     });
+
+    .line-item {
+
+      .respond-to-range(@bp-sm-min, @bp-inline-sign-min, {
+        font-size: unit(16px / @base-font-size-px, em);
+      });
+    }
   }
 
   &_terms {

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -67,7 +67,7 @@
     content: ' ';
   });
 
-  .respond-to-min(@bp-lg-min, {
+  .respond-to-min(@bp-med-min, {
     width: unit( (11 / @grid_total-columns) * 100, %);
   });
 }
@@ -345,7 +345,7 @@
       margin-left: 0;
     });
 
-    .respond-to-min(@bp-lg-min, {
+    .respond-to-min(@bp-med-min, {
       margin-right: -@grid_gutter-width;
       margin-left: -@grid_gutter-width;
     });
@@ -582,7 +582,7 @@
       margin-top: 0;
     });
 
-    .respond-to-min(@bp-lg-min, {
+    .respond-to-min(@bp-med-min, {
       .grid_column(4);
       .grid_push(1);
     });
@@ -794,7 +794,7 @@
       .grid_column(6);
     });
 
-    .respond-to-min(@bp-lg-min, {
+    .respond-to-min(@bp-med-min, {
       .grid_column(5);
     });
   }
@@ -811,7 +811,7 @@
     margin-top: 0;
   });
 
-  .respond-to-min(@bp-lg-min, {
+  .respond-to-min(@bp-med-min, {
     .grid_column(4);
     .grid_push(2);
   });
@@ -949,7 +949,7 @@
     left: 50%;
     background-color: @gray-10;
 
-    .respond-to-range(@bp-sm-min, @bp-sm-max, {
+    .respond-to-range(@bp-sm-min, @bp-med-max, {
       width: @bar-graph-width-narrow;
       border-right: (@bar-graph-width - @bar-graph-width-narrow) / 2 solid @gray-5;
       border-left: (@bar-graph-width - @bar-graph-width-narrow) / 2 solid @gray-5;
@@ -1015,7 +1015,7 @@
       background-color: transparent;
     });
 
-    .respond-to-range(@bp-sm-min, @bp-med-max, {
+    .respond-to-range(@bp-sm-min, @bp-sm-max, {
       padding-right: 0;
     });
 

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -52,13 +52,13 @@
 
   .respond-to-min(@bp-sm-min, {
     display: block;
-    width: 100%;
     height: 1px;
     border-right: 0;
     border-left: 0;
     margin-right: 0;
     position: absolute;
     bottom: 0;
+    right: @grid_gutter-width / 2;
     left: @grid_gutter-width / 2;
     z-index: 10;
     background-color: @gray-40;
@@ -272,6 +272,10 @@
   .form-label_text-wrapper {
 
     .respond-to-min(@bp-sm-min, {
+      .grid_column(12);
+    });
+
+    .respond-to-min(@bp-med-min, {
       .grid_column(15,24);
     });
 
@@ -283,6 +287,10 @@
   &_input-wrapper {
 
     .respond-to-min(@bp-sm-min, {
+      .grid_column(12);
+    });
+
+    .respond-to-min(@bp-med-min, {
       .grid_column(9,24);
     });
   }
@@ -331,6 +339,11 @@
       padding-bottom: 0;
       padding-left: @grid_gutter-width;
       margin-top: 0;
+      margin-right: 0;
+      margin-left: 0;
+    });
+
+    .respond-to-min(@bp-lg-min, {
       margin-right: -@grid_gutter-width;
       margin-left: -@grid_gutter-width;
     });
@@ -353,7 +366,7 @@
   &_group-header {
     margin-bottom: unit(20px / @base-font-size-px, em);
 
-    .respond-to-min(@bp-sm-min, {
+    .respond-to-min(@bp-lg-min, {
       margin-left: unit(-@aid-form-left-inset / @base-font-size-px, em);
     });
   }
@@ -422,6 +435,14 @@
     .grid_column(7);
 
     .respond-to-min(@bp-sm-min, {
+      .grid_column(6);
+    });
+
+    .respond-to-min(@bp-med-min, {
+      .grid_column(7);
+    });
+
+    .respond-to-min(@bp-xl-min, {
       .grid_column(8);
     });
   }
@@ -430,6 +451,14 @@
     .grid_column(5);
 
     .respond-to-min(@bp-sm-min, {
+      .grid_column(6);
+    });
+
+    .respond-to-min(@bp-med-min, {
+      .grid_column(5);
+    });
+
+    .respond-to-min(@bp-xl-min, {
       .grid_column(4);
     });
   }
@@ -520,7 +549,15 @@
   &_intro-content {
 
     .respond-to-min(@bp-sm-min, {
+      .grid_column(12);
+    });
+
+    .respond-to-min(@bp-med-min, {
       .grid_column(6);
+    });
+
+    .respond-to-min(@bp-lg-min, {
+      .grid_column(7);
     });
   }
 
@@ -538,28 +575,36 @@
   &_summary-wrapper {
 
     .respond-to-min(@bp-sm-min, {
-      .grid_column(4);
-      .grid_push(1);
+      .grid_column(6);
       padding-top: unit(30px / @base-font-size-px, em);
       margin-top: 0;
     });
+
+    .respond-to-min(@bp-lg-min, {
+      .grid_column(4);
+      .grid_push(1);
+    });
   }
 
-  &.cost-to-attend {
-    margin-top: unit(30px / @base-font-size-px, em);
-  }
-
-  .offer-part_terms {
+  &_terms {
 
     .respond-to-min(@bp-sm-min, {
+      .grid_column(12);
+    });
+
+    .respond-to-min(@bp-med-min, {
       .grid_column(15,24);
       margin-top: unit(-15px / @base-font-size-px, em);
     });
   }
 
-  .offer-part_term {
+  &_term {
     margin-top: unit(15px / @base-font-size-px, em);
     margin-bottom: unit(5px / @base-font-size-px, em);
+  }
+
+  &.cost-to-attend {
+    margin-top: unit(30px / @base-font-size-px, em);
   }
 }
 
@@ -959,6 +1004,10 @@
       margin-top: unit(45px / @base-font-size-px, em);
       margin-left: 0;
       background-color: transparent;
+    });
+
+    .respond-to-range(@bp-sm-min, @bp-med-max, {
+      padding-right: 0;
     });
 
     .respond-to-min(@bp-lg-min, {

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -52,7 +52,7 @@
 
   .respond-to-min(@bp-sm-min, {
     display: block;
-    width: unit( (11 / @grid_total-columns) * 100, %);
+    width: 100%;
     height: 1px;
     border-right: 0;
     border-left: 0;
@@ -63,6 +63,10 @@
     z-index: 10;
     background-color: @gray-40;
     content: ' ';
+  });
+
+  .respond-to-min(@bp-lg-min, {
+    width: unit( (11 / @grid_total-columns) * 100, %);
   });
 }
 
@@ -239,8 +243,11 @@
   margin-top: unit(30px / @base-font-size-px, em);
 
   .respond-to-min(@bp-sm-min, {
-    padding-left: unit(@aid-form-left-inset / @base-font-size-px, em);
     margin-top: 0;
+  });
+
+  .respond-to-min(@bp-lg-min, {
+    padding-left: unit(@aid-form-left-inset / @base-font-size-px, em);
   });
 
   &_heading {
@@ -730,6 +737,10 @@
   &_intro {
 
     .respond-to-min(@bp-sm-min, {
+      .grid_column(6);
+    });
+
+    .respond-to-min(@bp-lg-min, {
       .grid_column(5);
     });
   }
@@ -741,10 +752,14 @@
   margin-top: unit(30px / @base-font-size-px, em);
 
   .respond-to-min(@bp-sm-min, {
-    .grid_column(4);
-    .grid_push(2);
+    .grid_column(6);
     padding-top: unit(30px / @base-font-size-px, em);
     margin-top: 0;
+  });
+
+  .respond-to-min(@bp-lg-min, {
+    .grid_column(4);
+    .grid_push(2);
   });
 
   &_heading {
@@ -819,6 +834,7 @@
 
 .bar-graph {
   @bar-graph-width:                45px;
+  @bar-graph-width-narrow:         25px;
   @bar-graph-height:              130px;
   @bar-graph-label-width:         135px;
   @bar-graph-value-min-width:      95px;
@@ -878,6 +894,12 @@
     top: 0;
     left: 50%;
     background-color: @gray-10;
+
+    .respond-to-range(@bp-sm-min, @bp-sm-max, {
+      width: @bar-graph-width-narrow;
+      border-right: (@bar-graph-width - @bar-graph-width-narrow) / 2 solid @gray-5;
+      border-left: (@bar-graph-width - @bar-graph-width-narrow) / 2 solid @gray-5;
+    });
   }
 
   &_point__you {
@@ -933,10 +955,14 @@
   .aid-form_summary {
 
     .respond-to-min(@bp-sm-min, {
-      padding-left: unit(40px / @base-font-size-px, em);
+      padding-left: 0;
       margin-top: unit(45px / @base-font-size-px, em);
       margin-left: 0;
       background-color: transparent;
+    });
+
+    .respond-to-min(@bp-lg-min, {
+      padding-left: unit(40px / @base-font-size-px, em);
     });
   }
 

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -6,6 +6,8 @@
 @x-small-font-size-px:  12px;
 // Minimum width that putting the + or - sign inline with values in two-column line items works
 @bp-inline-sign-min:    689px;
+// Minimum width that bar graphs work in two columns
+@bp-graph-cols-min:     740px;
 
 .understanding-financial-aid-offer {
   .webfont-regular();
@@ -773,7 +775,7 @@
 .criteria {
   margin-top: unit(30px / @base-font-size-px, em);
 
-  .respond-to-min(@bp-sm-min, {
+  .respond-to-min(@bp-graph-cols-min, {
     margin-top: unit(45px / @base-font-size-px, em);
   });
 
@@ -786,11 +788,22 @@
     .respond-to-min(@bp-sm-min, {
       .grid_nested-col-group();
     });
+
+    &:after {
+
+      .respond-to-range(@bp-sm-min, @bp-graph-cols-min - 1, {
+        display: none;
+      });
+    }
   }
 
   &_intro {
 
     .respond-to-min(@bp-sm-min, {
+      .grid_column(10);
+    });
+
+    .respond-to-min(@bp-graph-cols-min, {
       .grid_column(6);
     });
 
@@ -806,6 +819,16 @@
   margin-top: unit(30px / @base-font-size-px, em);
 
   .respond-to-min(@bp-sm-min, {
+    .grid_column(10);
+    padding-top: 0;
+  });
+
+  .respond-to-range(@bp-sm-min, @bp-graph-cols-min - 1, {
+    padding-bottom: 0;
+    margin-top: unit(15px / @base-font-size-px, em);
+  });
+
+  .respond-to-min(@bp-graph-cols-min, {
     .grid_column(6);
     padding-top: unit(30px / @base-font-size-px, em);
     margin-top: 0;
@@ -831,6 +854,23 @@
 
   &_notification__better {
     .heading-4();
+  }
+
+  &.column-well__not-stacked:after {
+
+    .respond-to-range(@bp-sm-min, @bp-graph-cols-min - 1, {
+      display: none;
+    });
+  }
+
+  .column-well_content {
+
+    .respond-to-range(@bp-sm-min, @bp-graph-cols-min - 1, {
+      padding-top: unit(10px / @base-font-size-px, em);
+      padding-right: 0;
+      padding-left: 0;
+      border-top: 1px solid @gray-20;
+    });
   }
 }
 
@@ -913,7 +953,7 @@
     top: 0;
     background-color: @white;
 
-    .respond-to-min(@bp-sm-min, {
+    .respond-to-min(@bp-graph-cols-min, {
       background-color: @gray-5;
     });
   }
@@ -949,7 +989,7 @@
     left: 50%;
     background-color: @gray-10;
 
-    .respond-to-range(@bp-sm-min, @bp-med-max, {
+    .respond-to-range(@bp-graph-cols-min, @bp-med-max, {
       width: @bar-graph-width-narrow;
       border-right: (@bar-graph-width - @bar-graph-width-narrow) / 2 solid @gray-5;
       border-left: (@bar-graph-width - @bar-graph-width-narrow) / 2 solid @gray-5;
@@ -983,7 +1023,8 @@
    ========================================================================== */
 
 .average-salary .column-well_content {
-  .respond-to-min(@bp-sm-min, {
+
+  .respond-to-min(@bp-graph-cols-min, {
     position: absolute;
   });
 }
@@ -995,6 +1036,10 @@
   margin-bottom: unit(15px / @base-font-size-px, em);
 
   .respond-to-min(@bp-sm-min, {
+    .grid_column(10);
+  });
+
+  .respond-to-min(@bp-graph-cols-min, {
     .grid_column(6);
     padding-top: 0;
     border-top: none;

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -87,7 +87,16 @@
   }
 
   &_content {
+
     .respond-to-min(@bp-sm-min, {
+      .grid_column(9);
+    });
+
+    .respond-to-min(@bp-lg-min, {
+      .grid_column(7);
+    });
+
+    .respond-to-min(@bp-xl-min, {
       .grid_column(6);
     });
   }
@@ -97,6 +106,10 @@
     margin-bottom: unit(30px / @font-size, em);
 
     .respond-to-min(@bp-sm-min, {
+      .heading-3();
+    });
+
+    .respond-to-min(@bp-lg-min, {
       .heading-2();
       margin-bottom: unit(30px / @font-size, em);
     });
@@ -198,7 +211,16 @@
   }
 
   &_content {
+
     .respond-to-min(@bp-sm-min, {
+      .grid_column(9);
+    });
+
+    .respond-to-min(@bp-lg-min, {
+      .grid_column(7);
+    });
+
+    .respond-to-min(@bp-xl-min, {
       .grid_column(6);
     });
   }

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -977,6 +977,14 @@
     &_title {
 
       .respond-to-min(@bp-sm-min, {
+        .grid_column(7);
+      });
+
+      .respond-to-min(@bp-med-min, {
+        .grid_column(8);
+      });
+
+      .respond-to-min(@bp-xl-min, {
         .grid_column(9);
       });
     }
@@ -984,6 +992,14 @@
     &_value {
 
       .respond-to-min(@bp-sm-min, {
+        .grid_column(5);
+      });
+
+      .respond-to-min(@bp-med-min, {
+        .grid_column(4);
+      });
+
+      .respond-to-min(@bp-xl-min, {
         .grid_column(3);
       });
     }


### PR DESCRIPTION
Add styles for medium screens (601–1229px)
## Additions
- LESS for screens between `@bp-sm-min` (600px) and `@bp-large-max` (1230px)
## Changes
- HTML changes to accommodate the medium-screen designs
## Testing
- To test, pull in the `medium-screens` branch and run `gulp`. Fire up the app in standalone or UnityBox as normal. The page will be at `/paying-for-college2/understanding-your-financial-aid-offer`.
- I've tested this in IE8/Win7, IE9/Win7, IE11/Win7, Firefox/Win7, Chrome/Mac, Safari/Mac, Mobile Safari/iPhone6, and everything seems to be looking good
## Review
- @ascott1 or @mistergone 
- @marteki 
## Screenshots

| 601–689 px | 690–739px | 740–900px | 901–1020px | 1021–1229px |
| --- | --- | --- | --- | --- |
| Two columns in step 1 (but with smaller type in the summary column) | Larger type in step 1 summary column | Two columns in step 2 | Wide gutters in steps 1 and 2 | Indented forms |
| ![601](https://cloud.githubusercontent.com/assets/1862695/12305682/06891768-ba04-11e5-8fb9-82b4227f951a.png) | ![690](https://cloud.githubusercontent.com/assets/1862695/12305679/0682aa72-ba04-11e5-86fe-45fcea5cc3e7.png) | ![740](https://cloud.githubusercontent.com/assets/1862695/12305681/06831188-ba04-11e5-8425-2073eeffbd00.png) | ![901](https://cloud.githubusercontent.com/assets/1862695/12305678/067f9c06-ba04-11e5-9bbb-7702b6c55c7d.png) | ![1021](https://cloud.githubusercontent.com/assets/1862695/12305680/0682d83a-ba04-11e5-937f-42c4db2f9f5c.png) |
## Checklist
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [X] Passes all existing automated tests
- [X] Placeholder code is flagged
- [X] Visually tested in supported browsers and devices
