### PR TITLE
Private Loans and Totals!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 - new url for handling querystring offer data
 - added notification functionality for disclosures
-
-##  Unreleased
 - Added user interface for adding and removing private loans
 - Update version of student-debt-calc to support multiple private loans
 - Updated dispatchers to handle multiple private loans
+- Updated DOM and JS to display totals properly
 
 ## 1.1.0 - 2015-10-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+##  Unreleased
+- Added user interface for adding and removing private loans
+- Update version of student-debt-calc to support multiple private loans
+- Updated dispatchers to handle multiple private loans
+
 ## 1.1.0 - 2015-10-28
 
 ### Initial refactoring

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
   },
   "dependencies": {
     "format-usd": "^0.2.0",
-    "student-debt-calc": "1.0.2"
+    "student-debt-calc": "1.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
   },
   "dependencies": {
     "format-usd": "^0.2.0",
-    "student-debt-calc": "0.1.2"
+    "student-debt-calc": "1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
   },
   "dependencies": {
     "format-usd": "^0.2.0",
-    "student-debt-calc": "1.0.1"
+    "student-debt-calc": "1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
   },
   "dependencies": {
     "format-usd": "^0.2.0",
-    "student-debt-calc": "1.0.0"
+    "student-debt-calc": "1.0.1"
   }
 }

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -396,7 +396,7 @@
                                             type="text"
                                             id="grants__scholarships"
                                             name="grants__scholarships"
-                                            data-financial="scholarships"
+                                            data-financial="otherScholarships"
                                             autocorrect="off" value="0">
                                         </div>
                                     </div>
@@ -413,7 +413,7 @@
                                                     $
                                                 </span>
                                                 <span class="line-item_amount"
-                                                data-financial="totalGrantsScholarships">
+                                                data-financial="grantsSavingsTotal">
                                             </span>
                                             </div>
                                         </div>
@@ -452,7 +452,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="totalGrantsScholarships"
+                                        data-financial="grantsSavingsTotal"
                                         id="summary_total-grants-scholarships">
                                         </span>
                                     </div>
@@ -468,7 +468,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="totalCost"
+                                        data-financial="firstYearNetCost"
                                         id="summary_total-cost"></span>
                                     </div>
                                 </div>
@@ -632,7 +632,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="totalContributions"
+                                        data-financial="savingsTotal"
                                         id="summary_total-contributions">
                                     </span>
                                     </div>
@@ -652,7 +652,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="totalCost"></span>
+                                        data-financial="costOfAttendance"></span>
                                     </div>
                                 </div>
                                 <div class="line-item">
@@ -667,7 +667,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="totalContributions">
+                                        data-financial="savingsTotal">
                                         </span>
                                     </div>
                                 </div>
@@ -1406,7 +1406,7 @@
                                                     $
                                                 </span>
                                                 <span class="line-item_amount"
-                                                data-financial="totalPrivateLoans"></span>
+                                                data-financial="privateInstitutionalTotal"></span>
                                             </div>
                                         </div>
                                     </div>
@@ -1461,7 +1461,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="loanTotal"
+                                        data-financial="borrowingTotal"
                                         id="summary_total-loans"></span>
                                     </div>
                                 </div>
@@ -1689,7 +1689,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="totalRepayment"
+                                        data-financial="totalDebt"
                                         id="summary_total-repayment"></span>
                                     </div>
                                 </div>

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -963,7 +963,7 @@
                                                     class="aid-form_input
                                                     aid-form_input__currency"
                                                     type="text"
-                                                    id="contrib__private-loan"
+                                                    id="contrib__private-loan_0"
                                                     name="contrib__private-loan"
                                                     data-financial="privateLoan"
                                                     data-private-loan_key="amount"
@@ -990,7 +990,7 @@
                                                     class="aid-form_input
                                                     aid-form_input__percent"
                                                     type="text"
-                                                    id="contrib__private-loan-interest"
+                                                    id="contrib__private-loan-interest_0"
                                                     name="contrib__private-loan-interest"
                                                     data-financial="privateLoanRate"
                                                     data-private-loan_key="rate"
@@ -1027,7 +1027,7 @@
                                                     class="aid-form_input
                                                     aid-form_input__percent"
                                                     type="text"
-                                                    id="contrib__private-loan-fees"
+                                                    id="contrib__private-loan-fees_0"
                                                     name="contrib__private-loan-fees"
                                                     data-financial="privateLoanFees"
                                                     data-private-loan_key="fees"
@@ -1059,7 +1059,285 @@
                                                     class="aid-form_input
                                                     aid-form_input__time"
                                                     type="text"
-                                                    id="contrib__private-loan-grace-period"
+                                                    id="contrib__private-loan-grace-period_0"
+                                                    name="contrib__private-loan-grace-period"
+                                                    data-financial="privateLoanGracePeriod"
+                                                    data-private-loan_key="deferPeriod"
+                                                    autocorrect="off"
+                                                    value="0">
+                                                    <span
+                                                    class="aid-form_unit">
+                                                        months
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="private-loans_loan" data-private-loan="1">
+                                            <div class="private-loans_heading">
+                                                <div
+                                                class="private-loans_heading-text">
+                                                    Private loan
+                                                </div>
+                                                <button class="btn btn__link
+                                                private-loans_remove-btn"
+                                                type="button"
+                                                title="Remove this private loan">
+                                                    Remove
+                                                    <span class="cf-icon
+                                                    cf-icon-delete-round">
+                                                </span>
+                                                </button>
+                                            </div>
+                                            <div class="form-group_item">
+                                                <div
+                                                class="aid-form_label-wrapper">
+                                                    <label class="form-label"
+                                                    for="contrib__private-loan">
+                                                        Loan amount
+                                                    </label>
+                                                </div>
+                                                <div
+                                                class="aid-form_input-wrapper">
+                                                    <input
+                                                    class="aid-form_input
+                                                    aid-form_input__currency"
+                                                    type="text"
+                                                    id="contrib__private-loan_1"
+                                                    name="contrib__private-loan"
+                                                    data-financial="privateLoan"
+                                                    data-private-loan_key="amount"
+                                                    autocorrect="off"
+                                                    value="0">
+                                                </div>
+                                            </div>
+                                            <div class="form-group_item">
+                                                <div
+                                                class="aid-form_label-wrapper">
+                                                    <label class="form-label"
+                                                    for="contrib__private-loan-interest">
+                                                        Interest rate
+                                                    </label>
+                                                    <p
+                                                    class="aid-form_definition">
+                                                        Starts accumulating
+                                                        when you sign the loan
+                                                    </p>
+                                                </div>
+                                                <div
+                                                class="aid-form_input-wrapper">
+                                                    <input
+                                                    class="aid-form_input
+                                                    aid-form_input__percent"
+                                                    type="text"
+                                                    id="contrib__private-loan-interest_1"
+                                                    name="contrib__private-loan-interest"
+                                                    data-financial="privateLoanRate"
+                                                    data-private-loan_key="rate"
+                                                    autocorrect="off"
+                                                    value="0">
+                                                    <span class="aid-form_unit">
+                                                        %
+                                                    </span>
+                                                </div>
+                                            </div>
+                                            <div class="form-group_item">
+                                                <div
+                                                class="aid-form_label-wrapper">
+                                                    <label class="form-label"
+                                                    for="contrib__private-loan-fees">
+                                                        Loan fees
+                                                    </label>
+                                                    <p
+                                                    class="aid-form_definition">
+                                                        Added to loan total
+                                                        and paid off during
+                                                        repayment,
+                                                        disbursement amount
+                                                        remains the same (for
+                                                        example, a $49 fee is
+                                                        added to a $1,000 loan
+                                                        but you still receive
+                                                        $1,000)
+                                                    </p>
+                                                </div>
+                                                <div
+                                                class="aid-form_input-wrapper">
+                                                    <input
+                                                    class="aid-form_input
+                                                    aid-form_input__percent"
+                                                    type="text"
+                                                    id="contrib__private-loan-fees_1"
+                                                    name="contrib__private-loan-fees"
+                                                    data-financial="privateLoanFees"
+                                                    data-private-loan_key="fees"
+                                                    autocorrect="off"
+                                                    value="0">
+                                                    <span
+                                                    class="aid-form_unit">
+                                                        %
+                                                    </span>
+                                                </div>
+                                            </div>
+                                            <div class="form-group_item">
+                                                <div
+                                                class="aid-form_label-wrapper">
+                                                    <label class="form-label"
+                                                    for="contrib__private-loan-grace-period">
+                                                        Grace period
+                                                    </label>
+                                                    <p
+                                                    class="aid-form_definition">
+                                                        The amount of time
+                                                        before you must begin
+                                                        repayment
+                                                    </p>
+                                                </div>
+                                                <div
+                                                class="aid-form_input-wrapper">
+                                                    <input
+                                                    class="aid-form_input
+                                                    aid-form_input__time"
+                                                    type="text"
+                                                    id="contrib__private-loan-grace-period_1"
+                                                    name="contrib__private-loan-grace-period"
+                                                    data-financial="privateLoanGracePeriod"
+                                                    data-private-loan_key="deferPeriod"
+                                                    autocorrect="off"
+                                                    value="0">
+                                                    <span
+                                                    class="aid-form_unit">
+                                                        months
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="private-loans_loan" data-private-loan="2">
+                                            <div class="private-loans_heading">
+                                                <div
+                                                class="private-loans_heading-text">
+                                                    Private loan
+                                                </div>
+                                                <button class="btn btn__link
+                                                private-loans_remove-btn"
+                                                type="button"
+                                                title="Remove this private loan">
+                                                    Remove
+                                                    <span class="cf-icon
+                                                    cf-icon-delete-round">
+                                                </span>
+                                                </button>
+                                            </div>
+                                            <div class="form-group_item">
+                                                <div
+                                                class="aid-form_label-wrapper">
+                                                    <label class="form-label"
+                                                    for="contrib__private-loan">
+                                                        Loan amount
+                                                    </label>
+                                                </div>
+                                                <div
+                                                class="aid-form_input-wrapper">
+                                                    <input
+                                                    class="aid-form_input
+                                                    aid-form_input__currency"
+                                                    type="text"
+                                                    id="contrib__private-loan_2"
+                                                    name="contrib__private-loan"
+                                                    data-financial="privateLoan"
+                                                    data-private-loan_key="amount"
+                                                    autocorrect="off"
+                                                    value="0">
+                                                </div>
+                                            </div>
+                                            <div class="form-group_item">
+                                                <div
+                                                class="aid-form_label-wrapper">
+                                                    <label class="form-label"
+                                                    for="contrib__private-loan-interest">
+                                                        Interest rate
+                                                    </label>
+                                                    <p
+                                                    class="aid-form_definition">
+                                                        Starts accumulating
+                                                        when you sign the loan
+                                                    </p>
+                                                </div>
+                                                <div
+                                                class="aid-form_input-wrapper">
+                                                    <input
+                                                    class="aid-form_input
+                                                    aid-form_input__percent"
+                                                    type="text"
+                                                    id="contrib__private-loan-interest_2"
+                                                    name="contrib__private-loan-interest"
+                                                    data-financial="privateLoanRate"
+                                                    data-private-loan_key="rate"
+                                                    autocorrect="off"
+                                                    value="0">
+                                                    <span class="aid-form_unit">
+                                                        %
+                                                    </span>
+                                                </div>
+                                            </div>
+                                            <div class="form-group_item">
+                                                <div
+                                                class="aid-form_label-wrapper">
+                                                    <label class="form-label"
+                                                    for="contrib__private-loan-fees">
+                                                        Loan fees
+                                                    </label>
+                                                    <p
+                                                    class="aid-form_definition">
+                                                        Added to loan total
+                                                        and paid off during
+                                                        repayment,
+                                                        disbursement amount
+                                                        remains the same (for
+                                                        example, a $49 fee is
+                                                        added to a $1,000 loan
+                                                        but you still receive
+                                                        $1,000)
+                                                    </p>
+                                                </div>
+                                                <div
+                                                class="aid-form_input-wrapper">
+                                                    <input
+                                                    class="aid-form_input
+                                                    aid-form_input__percent"
+                                                    type="text"
+                                                    id="contrib__private-loan-fees_2"
+                                                    name="contrib__private-loan-fees"
+                                                    data-financial="privateLoanFees"
+                                                    data-private-loan_key="fees"
+                                                    autocorrect="off"
+                                                    value="0">
+                                                    <span
+                                                    class="aid-form_unit">
+                                                        %
+                                                    </span>
+                                                </div>
+                                            </div>
+                                            <div class="form-group_item">
+                                                <div
+                                                class="aid-form_label-wrapper">
+                                                    <label class="form-label"
+                                                    for="contrib__private-loan-grace-period">
+                                                        Grace period
+                                                    </label>
+                                                    <p
+                                                    class="aid-form_definition">
+                                                        The amount of time
+                                                        before you must begin
+                                                        repayment
+                                                    </p>
+                                                </div>
+                                                <div
+                                                class="aid-form_input-wrapper">
+                                                    <input
+                                                    class="aid-form_input
+                                                    aid-form_input__time"
+                                                    type="text"
+                                                    id="contrib__private-loan-grace-period_2"
                                                     name="contrib__private-loan-grace-period"
                                                     data-financial="privateLoanGracePeriod"
                                                     data-private-loan_key="deferPeriod"

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -1445,7 +1445,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="totalPrivateLoans"
+                                        data-financial="privateInstitutionalTotal"
                                         id="summary_total-private-loans">
                                     </span>
                                     </div>
@@ -1594,7 +1594,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="totalCost"></span>
+                                        data-financial="firstYearNetCost"></span>
                                     </div>
                                 </div>
                                 <div class="line-item">
@@ -1609,7 +1609,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="totalContributions">
+                                        data-financial="savingsTotal">
                                         </span>
                                     </div>
                                 </div>
@@ -1625,7 +1625,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="loanTotal"></span>
+                                        data-financial="borrowingTotal"></span>
                                     </div>
                                 </div>
                                 <div class="content_line aid-form_equals-line">

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -652,7 +652,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="costOfAttendance"></span>
+                                        data-financial="firstYearNetCost"></span>
                                     </div>
                                 </div>
                                 <div class="line-item">
@@ -769,7 +769,7 @@
                                             type="text"
                                             id="contrib__subsidized"
                                             name="contrib__subsidized"
-                                            data-financial="staffSubsidized"
+                                            data-financial="directSubsidized"
                                             autocorrect="off" value="0">
                                         </div>
                                         <div class="offer-part_terms">
@@ -817,7 +817,7 @@
                                             type="text"
                                             id="contrib__unsubsidized"
                                             name="contrib__unsubsidized"
-                                            data-financial="staffUnsubsidized"
+                                            data-financial="directUnsubsidized"
                                             autocorrect="off" value="0">
                                         </div>
                                         <div class="offer-part_terms">
@@ -1480,7 +1480,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="totalCost"></span>
+                                        data-financial="firstYearNetCost"></span>
                                     </div>
                                 </div>
                                 <div class="line-item">
@@ -1495,7 +1495,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="totalContributions">
+                                        data-financial="savingsTotal">
                                     </span>
                                     </div>
                                 </div>
@@ -1511,7 +1511,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="loanTotal"></span>
+                                        data-financial="borrowingTotal"></span>
                                     </div>
                                 </div>
                                 <div class="content_line aid-form_equals-line">

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -933,7 +933,7 @@
                                         </p>
                                     </div>
                                     <div class="private-loans">
-                                        <div class="private-loans_loan" data-private-loan="0">
+                                        <div class="private-loans_loan" data-private-loan="true">
                                             <div class="private-loans_heading">
                                                 <div
                                                 class="private-loans_heading-text">
@@ -1072,7 +1072,7 @@
                                                 </div>
                                             </div>
                                         </div>
-                                        <div class="private-loans_loan" data-private-loan="1">
+                                        <div class="private-loans_loan" data-private-loan="true">
                                             <div class="private-loans_heading">
                                                 <div
                                                 class="private-loans_heading-text">
@@ -1211,7 +1211,7 @@
                                                 </div>
                                             </div>
                                         </div>
-                                        <div class="private-loans_loan" data-private-loan="2">
+                                        <div class="private-loans_loan" data-private-loan="true">
                                             <div class="private-loans_heading">
                                                 <div
                                                 class="private-loans_heading-text">
@@ -1352,7 +1352,8 @@
                                         </div>
                                         <button class="btn btn__link
                                         private-loans_add-btn" type="button"
-                                        title="Add another private loan">
+                                        title="Add another private loan"
+                                        data-add-loan-button="true">
                                             <span class="cf-icon
                                             cf-icon-plus-round"></span>
                                             Add another private loan

--- a/src/disclosures/js/dispatchers/publish-update.js
+++ b/src/disclosures/js/dispatchers/publish-update.js
@@ -4,17 +4,27 @@ var financialModel = require( '../models/financial-model' );
 
 var publishUpdate = {
   financialData: function( prop, val ) {
-    // If this is an object, then we're handling a private loan
-    if ( typeof prop === 'object' ) {
-      var index = prop.index,
-          key = prop.key;
-      if ( typeof financialModel.values.privateLoanMulti[index] == 'undefined' ) {
-        financialModel.values.privateLoanMulti[index] = {};
-      }
-      financialModel.values.privateLoanMulti[index][key] = val;
-    } else {
-      financialModel.values[prop] = val;
-    }
+    financialModel.values[prop] = val;
+    financialModel.calc( financialModel.values );
+  },
+
+  updatePrivateLoan: function( index, prop, val ) {
+    financialModel.values.privateLoanMulti[index][prop] = val;
+    financialModel.calc( financialModel.values );
+  },
+
+  dropPrivateLoan: function( index ) {
+    financialModel.values.privateLoanMulti.splice( index, 1 );
+    financialModel.calc( financialModel.values );
+  },
+
+  addPrivateLoan: function() {
+    var newLoanObject = { amount: 0,
+                          fees: 0,
+                          rate: 0,
+                          deferPeriod: 0
+                        };
+    financialModel.values.privateLoanMulti.push( newLoanObject );
     financialModel.calc( financialModel.values );
   }
 };

--- a/src/disclosures/js/index.js
+++ b/src/disclosures/js/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var fetch = require('./dispatchers/get-api-values');
+var fetch = require( './dispatchers/get-api-values' );
 var financialModel = require( './models/financial-model' );
 var financialView = require( './views/financial-view' );
 var metricView = require( './views/metric-view' );

--- a/src/disclosures/js/models/financial-model.js
+++ b/src/disclosures/js/models/financial-model.js
@@ -13,51 +13,26 @@ var financialModel = {
     this.calc();
   },
 
+  sumScholarships: function() {
+    var model = financialModel.values;
+    // model.scholarships as a sum of UI inputs
+    model.scholarships =
+      model.schoolGrants +
+      model.stateGrants +
+      model.otherScholarships +
+      // since these values aren't in the UI we optionally add them as 0
+      ( model.militaryAssistance || 0 ) +
+      ( model.giBill || 0 );
+  },
+
   calc: function() {
+    this.sumScholarships();
     this.values = recalculate( this.values );
     this.sumTotals();
   },
 
   sumTotals: function() {
     var model = financialModel.values;
-
-    // total family contributions and loans
-    // since these values aren't in the UI we optionally add them as 0
-    model.family =
-      ( model.parentLoan || 0 ) +
-      ( model.parentplus || 0 );
-
-    // total other scholarships and grants
-    // since these values aren't in the UI we optionally add them as 0
-    model.scholarships =
-      ( model.otherScholarships || 0 ) +
-      ( model.militaryAssistance || 0 ) +
-      ( model.giBill || 0 );
-
-    // total grants and scholarships
-    model.totalGrantsScholarships =
-      model.scholarships + model.pell;
-
-    // total cost is attendance minus grants and scholarships
-    model.totalCost =
-      model.costOfAttendance - model.totalGrantsScholarships;
-
-    // total contributions
-    model.totalContributions =
-      model.savings + model.family + model.workstudy;
-
-    // total private loans
-    // TODO accomodate for multiple private loans
-    model.totalPrivateLoans =
-      model.privateLoan + model.institutionalLoan;
-
-    // loan totals
-    model.loanTotal =
-      model.federalTotal + model.totalPrivateLoans;
-
-    // remaining cost
-    model.remainingCost =
-      model.totalCost - model.totalContributions - model.loanTotal;
 
     // monthly expenses
     model.totalMonthlyExpenses =

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -10,6 +10,7 @@ var financialView = {
   $privateLoans: $( '[data-private-loan]' ),
   $addPrivateButton: $( '.private-loans_add-btn' ),
   $privateContainer: $( '.private-loans' ),
+  privateLoanKeys: [ 'amount', 'fees', 'rate', 'deferPeriod' ],
 
   init: function() {
     var values = getModelValues.financial();
@@ -17,6 +18,7 @@ var financialView = {
     this.keyupListener();
     this.addPrivateListener();
     this.removePrivateListener();
+    this.resetPrivateLoanView();
   },
 
   setPrivateLoans: function( values ) {
@@ -56,6 +58,7 @@ var financialView = {
           $ele = $container.find( '.private-loans_loan:first' );
       $ele.clone().insertAfter( $container.find( '.private-loans_loan:last' ) );
       $container.find( '.private-loans_loan:last .aid-form_input' ).val( '0' );
+      publish.addPrivateLoan();
     } );
   },
 
@@ -67,6 +70,17 @@ var financialView = {
     } );
   },
 
+  resetPrivateLoanView: function() {
+    // remove the 2 excess private loans (3 exist initially as a NoJS fallback)
+    this.$privateLoans.each( function() {
+      var index = $( this ).index();
+      if ( index > 0 ) {
+        $( this ).remove();
+        publish.dropPrivateLoan( index );
+      }
+    } );
+  },
+
   keyupListener: function() {
     this.$review.on( 'keyup', '[data-financial]', function() {
       this.financialKey = $( this ).attr( 'data-financial' );
@@ -74,13 +88,10 @@ var financialView = {
       if ( typeof $( this ).attr( 'data-private-loan_key' ) !== 'undefined' ) {
         var index = $( this ).closest( '[data-private-loan]' ).index(),
             key = $( this ).attr( 'data-private-loan_key' );
-        this.financialKey = {
-          financialKey: this.financialKey,
-          index: index,
-          key: key
-        };
+        publish.updatePrivateLoan( index, key, this.keyValue );
+      } else {
+        publish.financialData( this.financialKey, this.keyValue );
       }
-      publish.financialData( this.financialKey, this.keyValue );
       var values = getModelValues.financial();
       financialView.updateView( values );
     } );

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -225,7 +225,7 @@ settlementAidOfferPage.prototype = Object.create({}, {
     // TODO: Refactor this here and in the HTML/CSS for multiple private loans?
     privateLoanAmount: {
       get: function() {
-        return element( by.id( 'contrib__private-loan' ) );
+        return element( by.css( '[data-private-loan] [data-private-loan_key="amount"]' ) );
       }
     },
     setPrivateLoanAmount: {
@@ -235,7 +235,7 @@ settlementAidOfferPage.prototype = Object.create({}, {
     },
     privateLoanInterestRate: {
       get: function() {
-        return element( by.id( 'contrib__private-loan-interest' ) );
+        return element( by.css( '[data-private-loan] [data-private-loan_key="rate"]' ) );
       }
     },
     setPrivateLoanInterestRate: {
@@ -245,7 +245,7 @@ settlementAidOfferPage.prototype = Object.create({}, {
     },
     privateLoanFees: {
       get: function() {
-        return element( by.id( 'contrib__private-loan-fees' ) );
+        return element( by.css( '[data-private-loan] [data-private-loan_key="fees"]' ) );
       }
     },
     setPrivateLoanFees: {
@@ -255,7 +255,7 @@ settlementAidOfferPage.prototype = Object.create({}, {
     },
     privateLoanGracePeriod: {
       get: function() {
-        return element( by.id( 'contrib__private-loan-grace-period' ) );
+        return element( by.css( '[data-private-loan] [data-private-loan_key="deferPeriod"]' ) );
       }
     },
     setPrivateLoanGracePeriod: {

--- a/test/js-unit/financial-model-spec.js
+++ b/test/js-unit/financial-model-spec.js
@@ -4,22 +4,19 @@ var model = require( '../../src/disclosures/js/models/financial-model' );
 
 describe( 'financial model', function() {
 
-  it( 'sums totals', function() {
+  it( 'sums scholarships', function() {
     model.values = {
-      totalGrantsScholarships: 0,
-      scholarships: 100,
-      pell: 100,
-      totalCost: 0,
-      costOfAttendance: 250,
-      totalContributions: 0,
-      savings: 300,
-      family: 300,
-      workstudy: 300
+      tuitionFees: 9999,
+      undergrad: true,
+      pellCap: 3750,
+      pell: 99,
+      otherScholarships: 100,
+      schoolGrants: 100,
+      stateGrants: 100
     }
-    model.sumTotals();
-    expect( model.values.totalGrantsScholarships ).to.equal( 200 );
-    expect( model.values.totalCost ).to.equal( 50 );
-    expect( model.values.totalContributions ).to.equal( 900 );
+    model.calc();
+    expect( model.values.scholarships ).to.equal( 300 );
+    expect( model.values.grantsTotal ).to.equal( 399 );
   });
 
 

--- a/test/js-unit/publish-update-spec.js
+++ b/test/js-unit/publish-update-spec.js
@@ -17,5 +17,18 @@ describe( 'publish updates to the model', function() {
     expect( model.values.pizza ).to.equal( 'cheese' );
   });
 
+  it( 'drops private Loans from privateLoanMulti', function() {
+    model.values = {
+      privateLoanMulti: [
+        { 'loan': 1 },
+        { 'loan': 2 },
+        { 'loan': 3 }
+      ]
+    };
+
+    pub.dropPrivateLoan( 1 );
+    
+    expect( model.values.privateLoanMulti ).to.eql( [ { 'loan': 1 }, { 'loan': 3 } ] );
+  });
 
 });


### PR DESCRIPTION
This PR fixes a lot of outstanding issues about adding, removing, and calculating multiple Private Loans. Also, it fixes most of the displayed totals in Part 1.
## Additions
- Added user interface for adding and removing private loans
## Removals
- Removed some code which was redundantly calculating totals which are already calculated in `student-debt-calc`
## Changes
- Update version of student-debt-calc to support multiple private loans
- Updated dispatchers to handle multiple private loans
- Updated DOM and JS to display totals properly
## Testing
- Pull it down, getting it running per the README, and just have a great time!
## Review
- @marteki and @niqjohnson and @higs4281, and maybe @ascott1 if he has some time
## Screenshots

![screen shot 2016-01-20 at 3 01 51 pm](https://cloud.githubusercontent.com/assets/1490703/12461419/c83bb988-bf86-11e5-9478-ada0263e6dfb.png)
![screen shot 2016-01-20 at 3 02 32 pm](https://cloud.githubusercontent.com/assets/1490703/12461430/dbf9e288-bf86-11e5-86e2-2191e227ebce.png)
## Todos
- Fix debt totals
- Fix interest rates (currently not being converted to decimals)
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
## Special Thanks

Thanks to @ascott1 and @niqjohnson and @marteki for guiding me through the new stuff!
## Animated GIF

![shelob](https://cloud.githubusercontent.com/assets/1490703/12461467/13f88126-bf87-11e5-932d-1eabbb9ee1ee.gif)
