### PR TITLE
Fixes from design review

### DIFF
--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -92,29 +92,31 @@
                                     this to help calculate your total debt
                                     after graduation.
                                 </p>
-                                <select id="estimated-years-attending">
-                                    <option>
-                                        Select an option
-                                    </option>
-                                    <option>
-                                        1
-                                    </option>
-                                    <option>
-                                        2
-                                    </option>
-                                    <option>
-                                        3
-                                    </option>
-                                    <option>
-                                        4
-                                    </option>
-                                    <option>
-                                        5
-                                    </option>
-                                    <option>
-                                        6
-                                    </option>
-                                </select>
+                                <div class="cf-select">
+                                    <select id="estimated-years-attending">
+                                        <option>
+                                            Select an option
+                                        </option>
+                                        <option>
+                                            1
+                                        </option>
+                                        <option>
+                                            2
+                                        </option>
+                                        <option>
+                                            3
+                                        </option>
+                                        <option>
+                                            4
+                                        </option>
+                                        <option>
+                                            5
+                                        </option>
+                                        <option>
+                                            6
+                                        </option>
+                                    </select>
+                                </div>
                             </div>
                             <div class="verify_controls">
                                 <a href="#info-right"

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -2418,7 +2418,7 @@
                             <p class="next-steps_list-intro">
                                 Review the edits you made to your offer:
                             </p>
-                            <ul>
+                            <ul class="change-list">
                                 <li>
                                    You [increased/decreased] the [field name]
                                    by [$amount].

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -7,6 +7,12 @@
 {% block nemo_styles %}
 {% endblock %}
 {% block app_css %}
+<script>
+    /*! modernizr 3.3.1 (Custom Build) | MIT *
+    * http://modernizr.com/download/?-csspointerevents-setclasses
+    * Need to get styled <select>s working !*/
+    !function(e,n,s){function t(e,n){return typeof e===n}function o(){var e,n,s,o,a,i,f;for(var c in l)if(l.hasOwnProperty(c)){if(e=[],n=l[c],n.name&&(e.push(n.name.toLowerCase()),n.options&&n.options.aliases&&n.options.aliases.length))for(s=0;s<n.options.aliases.length;s++)e.push(n.options.aliases[s].toLowerCase());for(o=t(n.fn,"function")?n.fn():n.fn,a=0;a<e.length;a++)i=e[a],f=i.split("."),1===f.length?Modernizr[f[0]]=o:(!Modernizr[f[0]]||Modernizr[f[0]]instanceof Boolean||(Modernizr[f[0]]=new Boolean(Modernizr[f[0]])),Modernizr[f[0]][f[1]]=o),r.push((o?"":"no-")+f.join("-"))}}function a(e){var n=c.className,s=Modernizr._config.classPrefix||"";if(u&&(n=n.baseVal),Modernizr._config.enableJSClass){var t=new RegExp("(^|\\s)"+s+"no-js(\\s|$)");n=n.replace(t,"$1"+s+"js$2")}Modernizr._config.enableClasses&&(n+=" "+s+e.join(" "+s),u?c.className.baseVal=n:c.className=n)}function i(){return"function"!=typeof n.createElement?n.createElement(arguments[0]):u?n.createElementNS.call(n,"http://www.w3.org/2000/svg",arguments[0]):n.createElement.apply(n,arguments)}var r=[],l=[],f={_version:"3.3.1",_config:{classPrefix:"",enableClasses:!0,enableJSClass:!0,usePrefixes:!0},_q:[],on:function(e,n){var s=this;setTimeout(function(){n(s[e])},0)},addTest:function(e,n,s){l.push({name:e,fn:n,options:s})},addAsyncTest:function(e){l.push({name:null,fn:e})}},Modernizr=function(){};Modernizr.prototype=f,Modernizr=new Modernizr;var c=n.documentElement,u="svg"===c.nodeName.toLowerCase();Modernizr.addTest("csspointerevents",function(){var e=i("a").style;return e.cssText="pointer-events:auto","auto"===e.pointerEvents}),o(),a(r),delete f.addTest,delete f.addAsyncTest;for(var p=0;p<Modernizr._q.length;p++)Modernizr._q[p]();e.Modernizr=Modernizr}(window,document);
+</script>
 <!--[if lt IE 9]>
     <link rel="stylesheet" href="{% static "paying_for_college/disclosures/static/css/main.ie.css" %}">
 <![endif]-->

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -98,22 +98,22 @@
                                             Select an option
                                         </option>
                                         <option>
-                                            1
+                                            1 year
                                         </option>
                                         <option>
-                                            2
+                                            2 years
                                         </option>
                                         <option>
-                                            3
+                                            3 years
                                         </option>
                                         <option>
-                                            4
+                                            4 years
                                         </option>
                                         <option>
-                                            5
+                                            5 years
                                         </option>
                                         <option>
-                                            6
+                                            6 years
                                         </option>
                                     </select>
                                 </div>

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -221,6 +221,7 @@
                                             type="text" id="costs__tuition"
                                             name="costs__tuition"
                                             data-financial="tuitionFees"
+                                            disabled
                                             autocorrect="off" value="0">
                                         </div>
                                     </div>

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -487,7 +487,7 @@
                                     <p>
                                         This section includes loans that your
                                         parents have to repay, but are not
-                                        included in your personal debt or
+                                        included in <em>your</em> personal debt or
                                         student loan payments.
                                     </p>
                                 </div>

--- a/src/disclosures/css/cf-enhancements.less
+++ b/src/disclosures/css/cf-enhancements.less
@@ -347,6 +347,7 @@ a.btn__full-small.btn__link {
                  unit( 6px / @base-font-size-px, em );
         border: 0;
         outline: 2px solid transparent;
+        .webfont-regular();
         appearance: none;
         background-color: @white;
         color: @black;

--- a/src/disclosures/css/cf-enhancements.less
+++ b/src/disclosures/css/cf-enhancements.less
@@ -329,3 +329,67 @@ a.btn__full-small.btn__link {
     }
   }
 }
+
+/* ==========================================================================
+   Capital Framework <select>
+   from https://github.com/cfpb/cfgov-refresh/blob/3a3a42dc08d644c93016bcd789f719ce5807fb77/cfgov/unprocessed/css/forms.less
+   ========================================================================== */
+
+.cf-select {
+    position: relative;
+    margin-top: 0.5em;
+    border: 1px solid @gray-40;
+
+    select {
+        height: unit( 30px / @base-font-size-px, em );
+        width: 100%;
+        padding: unit( 4px / @base-font-size-px, em )
+                 unit( 6px / @base-font-size-px, em );
+        border: 0;
+        outline: 2px solid transparent;
+        appearance: none;
+        background-color: @white;
+        color: @black;
+
+        &:hover,
+        &:active,
+        &:focus {
+            outline-color: @pacific;
+            outline-offset: 0;
+        }
+    }
+
+    select[disabled] {
+        color: @gray-60;
+        background-color: @gray-10;
+    }
+
+    select option:disabled {
+        color: @gray-60;
+    }
+
+    &:after {
+        position: absolute;
+        top: 0;
+        right: 0;
+        height: unit( 30px / @base-font-size-px, em );
+        width: unit( 30px / @base-font-size-px, em );
+        border-left: 1px solid @gray-40;
+        background-color: @gray-10;
+        color: @gray-60;
+        content: @cf-icon-down;
+        font-family: 'CFPB Minicons';
+        line-height: unit( 30px / @base-font-size-px, em );
+        text-align: center;
+        pointer-events: none;
+    }
+}
+
+.no-csspointerevents .cf-select {
+    &:after {
+        height: 0;
+        width: 0;
+        border: 0;
+        content: '';
+    }
+}

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -318,6 +318,10 @@
 
     &[disabled] {
       background-color: @gray-10;
+      color: @black;
+      // Need to set -webkit-text-fill-color to make disabled input text @black in Safari/iOS
+      -webkit-text-fill-color: @black;
+      opacity: 1;
     }
   }
 

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -113,12 +113,11 @@
     .heading-4();
     margin-bottom: unit(30px / @font-size, em);
 
-    .respond-to-min(@bp-sm-min, {
+    .respond-to-min(@desktop-min, {
       .heading-3();
     });
 
     .respond-to-min(@bp-lg-min, {
-      .heading-2();
       margin-bottom: unit(30px / @font-size, em);
     });
   }
@@ -526,7 +525,7 @@
     });
 
     .respond-to-min(@bp-xl-min, {
-      .grid_column(8);
+      .grid_column(7);
     });
   }
 }
@@ -775,7 +774,7 @@
     });
 
     .respond-to-min(@bp-xl-min, {
-      .grid_column(8);
+      .grid_column(7);
     });
   }
 }
@@ -1228,7 +1227,7 @@
     });
 
     .respond-to-min(@bp-xl-min, {
-      .grid_column(8);
+      .grid_column(7);
     });
   }
 
@@ -1327,7 +1326,7 @@
     });
 
     .respond-to-min(@bp-xl-min, {
-      .grid_column(8);
+      .grid_column(7);
     });
   }
 

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -385,6 +385,10 @@
     });
   }
 
+  .form-group + .form-group {
+    margin-top: unit(60px / @base-font-size-px, em);
+  }
+
   .form-group_item {
 
     .respond-to-min(@bp-sm-min, {
@@ -395,7 +399,14 @@
   .form-group_item + .form-group_item {
 
     .respond-to-min(@bp-sm-min, {
-      margin-top: unit(20px / @base-font-size-px, em)
+      margin-top: unit(20px / @base-font-size-px, em);
+    });
+  }
+
+  .form-label {
+
+    .respond-to-min(@bp-med-min, {
+      margin-top: unit(4px / @base-font-size-px, em);
     });
   }
 
@@ -733,9 +744,9 @@
     text-align: left;
   }
 
-  &_loan + .private-loans_loan {
-    margin-top: 30px;
-  } 
+  &_loan + &_loan {
+    margin-top: unit(45px / @base-font-size-px, em);
+  }
 }
 
 .debt-summary {
@@ -818,27 +829,31 @@
       .grid_column(5);
     });
   }
+
+  & + & {
+    padding-top: unit(15px / @base-font-size-px, em);
+    border-top: 1px solid @gray-20;
+
+    .respond-to-min(@bp-graph-cols-min, {
+      padding-top: 0;
+      border-top: none;
+    });
+  }
 }
 
 .metric {
-  padding-top: unit(10px / @base-font-size-px, em);
-  border-top: 1px solid @gray-20;
-  margin-top: unit(30px / @base-font-size-px, em);
 
   .respond-to-min(@bp-sm-min, {
     .grid_column(10);
-    padding-top: 0;
   });
 
   .respond-to-range(@bp-sm-min, @bp-graph-cols-min - 1, {
     padding-bottom: 0;
-    margin-top: unit(15px / @base-font-size-px, em);
   });
 
   .respond-to-min(@bp-graph-cols-min, {
     .grid_column(6);
     padding-top: unit(30px / @base-font-size-px, em);
-    margin-top: 0;
   });
 
   .respond-to-min(@bp-med-min, {
@@ -863,6 +878,13 @@
     .heading-4();
   }
 
+  &.column-well__not-stacked {
+
+    .respond-to-range(@bp-sm-min, @bp-graph-cols-min - 1, {
+      padding-top: 0;
+    });
+  }
+
   &.column-well__not-stacked:after {
 
     .respond-to-range(@bp-sm-min, @bp-graph-cols-min - 1, {
@@ -873,10 +895,8 @@
   .column-well_content {
 
     .respond-to-range(@bp-sm-min, @bp-graph-cols-min - 1, {
-      padding-top: unit(10px / @base-font-size-px, em);
       padding-right: 0;
       padding-left: 0;
-      border-top: 1px solid @gray-20;
     });
   }
 }
@@ -1043,12 +1063,14 @@
 
 .estimated-expenses {
   padding-top: unit(10px / @base-font-size-px, em);
+  padding-bottom: unit(15px / @base-font-size-px, em);
   border-top: 1px solid @gray-40;
   margin-top: unit(30px / @base-font-size-px, em);
   margin-bottom: unit(15px / @base-font-size-px, em);
 
   .respond-to-min(@bp-sm-min, {
     .grid_column(10);
+    padding-bottom: 0;
     border-top: 1px solid @gray-40;
   });
 

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -1361,6 +1361,11 @@
 
   &_controls {
     margin-top: unit(20px / @base-font-size-px, em);
+    margin-left: -2.5em;
+
+    .respond-to-min(@bp-sm-min, {
+      margin-left: 0;
+    });
 
     .respond-to-min(@bp-med-min, {
       margin-top: unit(30px / @base-font-size-px, em);
@@ -1374,6 +1379,14 @@
       display: block;
     });
   }
+}
+
+.change-list {
+  padding-left: 1em;
+
+  .respond-to-min(@bp-sm-min, {
+    padding-left: 2em;
+  });
 }
 
 /* ==========================================================================

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -315,6 +315,10 @@
       width: unit(65px / @base-font-size-px, em);
       text-align: right;
     }
+
+    &[disabled] {
+      background-color: @gray-10;
+    }
   }
 
   &_unit {

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -682,7 +682,7 @@
 .loans {
 
   &_line {
-    border-top: 1px dashed @gray-40;
+    border-top: 1px dotted @gray-40;
     margin-top: unit(30px / @base-font-size-px, em);
     margin-bottom: unit(15px / @base-font-size-px, em);
     background-color: transparent;
@@ -694,7 +694,7 @@
 }
 
 .private-loans {
-  border-bottom: 1px dashed @gray-40;
+  border-bottom: 1px dotted @gray-40;
   margin-bottom: unit(15px / @base-font-size-px, em);
 
   &_heading {

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -47,11 +47,16 @@ describe( 'A dynamic financial aid disclosure that\'s required by settlement', f
   } );
 
   // *** Step 1: Review your offer ***
-  // TODO: After the offer URL implementation conforms to spec, 
+  // TODO: After the offer URL implementation conforms to spec,
   // we should draw values straight from the page based on URL values
   // rather than setting all of them explicitly here.
 
   // Cost of attendance
+
+  it( 'should not let a student edit the tuition', function() {
+    page.confirmVerification();
+    expect( page.tuitionFeesCosts.isEnabled() ).toEqual( false );
+  } );
 
   it( 'should properly update when the tuition is modified', function() {
     page.confirmVerification();


### PR DESCRIPTION
Fixes all style issues found in the design review
## Additions
- Modernizr check for `csspointerevents` to make the custom-styled `<select>`s work on IE 10 and under (@mistergone, @ascott1, and I agreed that sticking the JS right in the page is the best solution for now)
- Custom `<select>` styling borrowed from cfgov-refresh
- Functional test to make sure settlement students can't edit the tuition and fees
## Changes
- All style issues identified at ghe/paying-for-college/dynamic-disclosures-design/issues/44
## Testing
- To test, pull in the `design-review` branch and run `gulp`. Fire up the app in standalone or UnityBox as normal.
- I've tested this in IE8/Win7, IE9/Win7, IE10/Win7, IE11/Win7, Firefox/Win7, Chrome/Mac, Safari/Mac, Mobile Safari/iPhone6, and everything seems to be looking good
- When testing, pay special attention to the `<select>` to make sure clicking on the arrow correctly opens it (it should work in all browsers)
## Review
- @mistergone 
- @marteki 
- Optionally @ascott1 if you want to and have time
## All the screenshots!

| 600px and below | 601–689 px | 690–739px | 740–900px | 901–1020px | 1021–1229px | 1230 px and above |
| --- | --- | --- | --- | --- | --- | --- |
| ![320](https://cloud.githubusercontent.com/assets/1862695/12487691/3eda4e7e-c036-11e5-8ef7-56946c0c66cd.png) | ![601](https://cloud.githubusercontent.com/assets/1862695/12487696/428134ca-c036-11e5-977b-990bafbea5de.png) | ![690](https://cloud.githubusercontent.com/assets/1862695/12487698/4851a2fe-c036-11e5-80f6-83f8bf5af0bc.png) | ![740](https://cloud.githubusercontent.com/assets/1862695/12487700/4ce66f16-c036-11e5-8b24-efead7b4134b.png) | ![901](https://cloud.githubusercontent.com/assets/1862695/12487705/51003a96-c036-11e5-9e24-1785096930f6.png) | ![1021](https://cloud.githubusercontent.com/assets/1862695/12487708/550e41f0-c036-11e5-9fc1-0d1ef53b6209.png) | ![1250](https://cloud.githubusercontent.com/assets/1862695/12487712/594eaa84-c036-11e5-8355-2304d751382b.png) |
## To do
- All the functional tests that check calculations are failing spectacularly now that the tuition input is disabled. @marteki and @mistergone are refactoring the tests right now, so I'm ignoring for this PR.
## Checklist
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [X] Placeholder code is flagged
- [X] Visually tested in supported browsers and devices
