### PR TITLE
Add military tuition assistance and GI Bill fields

### DIFF
--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -390,6 +390,45 @@
                                     <div class="form-group_item">
                                         <div class="aid-form_label-wrapper">
                                             <label class="form-label"
+                                            for="grants__military">
+                                                Military tuition assistance
+                                            </label>
+                                            <p class="aid-form_definition">
+                                                Money for active or reserve service members that you don’t have to pay back
+                                            </p>
+                                        </div>
+                                        <div class="aid-form_input-wrapper">
+                                            <input class="aid-form_input
+                                            aid-form_input__currency"
+                                            type="text" id="grants__military"
+                                            name="grants__military"
+                                            data-financial="militaryAssistance"
+                                            autocorrect="off" value="0">
+                                        </div>
+                                    </div>
+                                    <div class="form-group_item">
+                                        <div class="aid-form_label-wrapper">
+                                            <label class="form-label"
+                                            for="grants__gi">
+                                                GI Bill
+                                            </label>
+                                            <p class="aid-form_definition">
+                                                Money for service members or veterans that you don’t have to pay back
+                                            </p>
+                                        </div>
+                                        <div class="aid-form_input-wrapper">
+                                            <input class="aid-form_input
+                                            aid-form_input__currency"
+                                            type="text"
+                                            id="grants__gi"
+                                            name="grants__gi"
+                                            data-financial="giBill"
+                                            autocorrect="off" value="0">
+                                        </div>
+                                    </div>
+                                    <div class="form-group_item">
+                                        <div class="aid-form_label-wrapper">
+                                            <label class="form-label"
                                             for="grants__scholarships">
                                                 Other grants and scholarships
                                             </label>


### PR DESCRIPTION
Adds inputs for military tuition assistance and the GI Bill
## Additions
- Military tuition assistance and GI Bill labels, descriptions, and inputs to the "Grants and scholarships" section
## Testing
- To test, pull in the `military-grants` branch and run `gulp`. Fire up the app in standalone or UnityBox as normal.
- I've tested this in IE8/Win7, IE9/Win7, IE10/Win7, IE11/Win7, Firefox/Win7, Chrome/Mac, Safari/Mac, Mobile Safari/iPhone6, and everything seems to be looking good
- Note that this branch is failing some unit and functional tests, just like `master` is right now. The changes here should add no additional failures.
## Review
- @marteki and/or @mistergone and/or @higs4281
## Screenshots

![gi](https://cloud.githubusercontent.com/assets/1862695/12587595/10e91fd6-c423-11e5-86bc-45acb7bfa770.png)
## Checklist
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [X] Placeholder code is flagged
- [X] Visually tested in supported browsers and devices
