### PR TITLE
add url to school payload

### DIFF
--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -223,6 +223,7 @@ class School(models.Model):
             'tuitionUnderInDis': jdata['TUITIONUNDERINDIS'],
             'tuitionUnderInS': jdata['TUITIONUNDERINS'],
             'tuitionUnderOoss': jdata['TUITIONUNDEROSS'],
+            'url': self.url,
             'zip5': self.zip5,
         }
         for key in sorted(dict_out.keys()):


### PR DESCRIPTION
We have website data for most of our schools, although it's usually just the home page.
## Additions
- adds "url" attribute to the schoolData object when worksheet is rendered
## Review
- @niqjohnson 
