### PR TITLE
Add link to feedback form and tests

### DIFF
--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -2547,10 +2547,12 @@
                             </p>
                         </div>
                     </div>
-                    <button class="btn btn__full-small" type="button"
-                    title="Give feedback on this tool">
+                    <a class="btn btn__full-small"
+                    title="Give feedback on this tool"
+                    href="/{{url_root}}/understanding-your-financial-aid-offer/feedback"
+                    target="_blank">
                         Tell us how
-                    </button>
+                    </a>
                 </div>
             </section>
         </section>

--- a/test/functional/conf.js
+++ b/test/functional/conf.js
@@ -2,7 +2,7 @@ exports.config = {
 	framework: 'jasmine2',
   	seleniumAddress: 'http://localhost:4444/wd/hub',
  	capabilities: { 'browserName': 'chrome' },
- 	specs: ['dd-functional-settlement-spec.js'],
+ 	specs: ['dd-functional-settlement-spec.js', 'dd-feedback-spec.js'],
 
  	onPrepare:function(){
  		browser.ignoreSynchronization = true;

--- a/test/functional/dd-feedback-spec.js
+++ b/test/functional/dd-feedback-spec.js
@@ -19,12 +19,18 @@ fdescribe( 'The "Was this tool helpful?" section', function() {
   it( 'should open the feedback form in a new tab', function() {
     page.confirmVerification();
     page.followFeedbackLink();
-    browser.getAllWindowHandles().then( function ( handles ) {
-      expect( handles.length ).toBe( 2 );
-      browser.switchTo().window( handles[1] ).then( function () {
-        browser.wait( EC.visibilityOf( $( '.pfc-feedback > #id_message' ) ), 8000 )
+    browser.getAllWindowHandles()
+      .then( function ( handles ) {
+        expect( handles.length ).toBe( 2 );
+        browser.switchTo().window( handles[1] )
+          .then( function () {
+            browser.wait( EC.visibilityOf( $( '.pfc-feedback > #id_message' ) ), 8000 )
+          } )
+          .then( function () {
+            browser.close();
+            browser.switchTo().window( handles[0] );
+          } );;
       } );
-    } );
   } );
 
 } );

--- a/test/functional/dd-feedback-spec.js
+++ b/test/functional/dd-feedback-spec.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var SettlementPage = require( './settlementAidOfferPage.js' );
+
+fdescribe( 'The "Was this tool helpful?" section', function() {
+  var page;
+  var EC = protractor.ExpectedConditions;
+
+  beforeEach(function() {
+    page = new SettlementPage();
+  } );
+
+  it( 'should contain a link to the feedback form', function() {
+    page.confirmVerification();
+    browser.wait( EC.visibilityOf( page.feedbackLink ), 8000 );
+    expect( page.feedbackLink.getAttribute( 'href' ) ).toMatch( /\/paying-for-college2\/understanding-your-financial-aid-offer\/feedback$/ );
+  } );
+
+  it( 'should open the feedback form in a new tab', function() {
+    page.confirmVerification();
+    page.followFeedbackLink();
+    browser.getAllWindowHandles().then( function ( handles ) {
+      expect( handles.length ).toBe( 2 );
+      browser.switchTo().window( handles[1] ).then( function () {
+        browser.wait( EC.visibilityOf( $( '.pfc-feedback > #id_message' ) ), 8000 )
+      } );
+    } );
+  } );
+
+} );

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -433,8 +433,8 @@ settlementAidOfferPage.prototype = Object.create({}, {
       }
     },
     followFeedbackLink: {
-      value: function( otherexpensesamount ) {
-        return this.feedbackLink.click();
+      value: function() {
+        this.feedbackLink.click();
       }
     }
 

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -425,6 +425,17 @@ settlementAidOfferPage.prototype = Object.create({}, {
       get: function() {
         return element( by.css( '.get-options' ) );
       }
+    },
+    //Feedback
+    feedbackLink: {
+      get: function() {
+        return element( by.css( '.feedback .btn' ) );
+      }
+    },
+    followFeedbackLink: {
+      value: function( otherexpensesamount ) {
+        return this.feedbackLink.click();
+      }
     }
 
 } );


### PR DESCRIPTION
Adds link to the feedback form (and tests)
## Additions
- Link to feedback form from the "Tell us how" button at the bottom of the page
- Functional tests
## Changes
- The "Tell us how" `button` is now an `a`
## Testing
- To test, pull in the `feedback-link` branch and run `gulp`. Fire up the app in standalone or UnityBox as normal. The "Tell us how" button should open the feedback from in a new tab/window.
- I've tested this in IE8/Win7, IE9/Win7, IE10/Win7, IE11/Win7, Firefox/Win7, Chrome/Mac, Safari/Mac, Mobile Safari/iPhone6, and everything seems to be looking good
- Note that this branch is failing some unit and functional tests, just like `master` is right now. The changes here should add no additional failures.
## Review
- @marteki, @caheberer, @kurzn: I followed how the current tool works and am opening the feedback form in a new tab/window. Does that make sense, design-wise? (Actually, the current tool opens the form in a pop-up, which gets blocked by some browsers, so I'm using a plain old new tab/window with `target="_blank"`)
- @marteki, @mistergone: Do the new functional tests look OK? I added them in their own spec to prevent any merge conflicts with the other testing stuff that's being worked on; I can move them elsewhere if it makes more sense. Also, I'm pretty sure I'm testing for the presence of a new tab correctly, but let me know if that seems off to you.
- @higs4281: Is `href="/{{url_root}}/understanding-your-financial-aid-offer/feedback"` the Django-approved way to link to the feedback page?
## Checklist
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [X] Placeholder code is flagged
- [X] Visually tested in supported browsers and devices
