### PR TITLE
add BLS spending stats to nationalData

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ Tools to help students make informed financial decisions about college.
 ### Testing dependencies
 - [mock](https://github.com/testing-cabal/mock)
 - [coverage](https://coverage.readthedocs.org/en/latest/)
-- [selenium](https://selenium-python.readthedocs.org/installation.html)
-- [behave](http://pythonhosted.org/behave/)
-- [PyHamcrest](https://pyhamcrest.readthedocs.org/en/V1.8.2/)
 
 ### Installation
 This project is not fully functional, but feel free to give it a spin. Here's how:
@@ -68,7 +65,7 @@ The last step is to rebuild the solr index:
 ./manage.py runserver
 ```
 
-The college-cost tools should show up at [http://127.0.0.1:8000/paying-for-college/](http://127.0.0.1:8000/paying-for-college/)
+The college-cost tools should show up at [http://localhost:8000/paying-for-college2/](http://127.0.0.1:8000/paying-for-college/)
 
 The app is set up to run as a component of CFPB's website, [consumerfinance.gov](http://www.consumerfinance.gov), so if you run it locally, some fonts and font-related icons may not load because of [Cross-Origin Resource Sharing](http://www.w3.org/TR/cors/) policies.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The last step is to rebuild the solr index:
 ./manage.py runserver
 ```
 
-The college-cost tools should show up at [http://localhost:8000/paying-for-college2/](http://127.0.0.1:8000/paying-for-college/)
+The college-cost tools should show up at [localhost:8000/paying-for-college2/](http://localhost:8000/paying-for-college2/)
 
 The app is set up to run as a component of CFPB's website, [consumerfinance.gov](http://www.consumerfinance.gov), so if you run it locally, some fonts and font-related icons may not load because of [Cross-Origin Resource Sharing](http://www.w3.org/TR/cors/) policies.
 

--- a/paying_for_college/disclosures/scripts/nat_stats.py
+++ b/paying_for_college/disclosures/scripts/nat_stats.py
@@ -13,6 +13,17 @@ college-choice/dev/_data/national_stats.yaml'
 FIXTURES_DIR = Path(__file__).ancestor(3)
 NAT_DATA_FILE = '{0}/fixtures/national_stats.json'.format(FIXTURES_DIR)
 BACKUP_FILE = '{0}/fixtures/national_stats_backup.json'.format(FIXTURES_DIR)
+BLS_FILE = '{0}/fixtures/bls_data.json'.format(FIXTURES_DIR)
+
+
+def get_bls_stats():
+    """deliver BLS spending stats stored in repo"""
+    try:
+        with open(BLS_FILE, 'r') as f:
+            data = json.loads(f.read())
+    except:
+        data = {}
+    return data
 
 
 def get_stats_yaml():

--- a/paying_for_college/fixtures/bls_data.json
+++ b/paying_for_college/fixtures/bls_data.json
@@ -1,0 +1,57 @@
+{
+    "Retirement": {
+        "WE": 6184, 
+        "under_25": 2269, 
+        "NE": 6392, 
+        "note": "Pensions and personal insurance", 
+        "MW": 5633, 
+        "SO": 5182, 
+        "average_annual": 5726
+    }, 
+    "Transportation": {
+        "WE": 9192, 
+        "under_25": 6167, 
+        "NE": 9321, 
+        "note": "Cars, public transit, insurance", 
+        "MW": 8807, 
+        "SO": 9041, 
+        "average_annual": 9073
+    }, 
+    "Entertainment": {
+        "WE": 3034, 
+        "under_25": 1319, 
+        "NE": 2744, 
+        "note": "Events, pets, hobbies, equipment", 
+        "MW": 2760, 
+        "SO": 2516, 
+        "average_annual": 2728
+    }, 
+    "Food": {
+        "WE": 7175, 
+        "under_25": 4423, 
+        "NE": 6854, 
+        "note": "Dining out and in; all food costs", 
+        "MW": 16212, 
+        "SO": 6898, 
+        "average_annual": 6759
+    }, 
+    "Housing": {
+        "WE": 19672, 
+        "under_25": 11459, 
+        "NE": 21067, 
+        "note": "Mortgage, rent, utilities, insurance", 
+        "MW": 16212, 
+        "SO": 16030, 
+        "average_annual": 17798
+    }, 
+    "Year": 2014, 
+    "Healthcare": {
+        "WE": 4401, 
+        "under_25": 1103, 
+        "NE": 4565, 
+        "note": "Including insurance", 
+        "MW": 4398, 
+        "SO": 4024, 
+        "average_annual": 4290
+    }
+}

--- a/paying_for_college/fixtures/test_fixture.json
+++ b/paying_for_college/fixtures/test_fixture.json
@@ -1,6 +1,23 @@
 [
 {
     "fields": {
+        "city": "Mayaguez",
+        "accreditor": "",
+        "url": "",
+        "ope6_id": 243197,
+        "ope8_id": 24319722,
+        "degrees_predominant": "",
+        "degrees_highest": "4",
+        "state": "PR",
+        "operating": true,
+        "data_json": "{\"NETPRICEOK\": \"12964\", \"ONCAMPUSAVAIL\": \"Yes\", \"TUITIONGRADOSS\": \"\", \"NETPRICE110K\": \"19303\", \"TUITIONGRADINDIS\": \"\", \"AVGMONTHLYPAY\": \"1225\", \"GRADRATERANK\": \"465\", \"INDICATORGROUP\": \"1\", \"OTHERONCAMPUS\": \"3568\", \"NETPRICE48K\": \"18475\", \"BAH\": \"1311\", \"CONTROL\": \"Public\", \"ZIP\": \"66045\", \"AVGSTULOANDEBTRANK\": \"233.26\", \"OFFERBA\": \"Yes\", \"OFFERAA\": \"Yes\", \"ONLINE\": \"No\", \"OTHEROFFCAMPUS\": \"3568\", \"OFFERGRAD\": \"Yes\", \"SCHOOL_ID\": \"155317\", \"TUITIONUNDERINDIS\": \"10107\", \"TUITIONGRADINS\": \"\", \"ROOMBRDONCAMPUS\": \"7702\", \"GRADRATE\": \"64\", \"CITY\": \"Lawrence\", \"TUITIONUNDERINS\": \"10107\", \"ALIAS\": \"University of Kansas | Univ of Kansas | Kansas University | KU | Kansas Jayhawks | Univ of KS |University of KS | Kansas Univ | Kansas U | KUMC | University of Kansas Medical Center | KU Medical Center | Kansas University Medical Center\", \"STATE\": \"KS\", \"NETPRICEGENERAL\": \"16326\", \"NETPRICE3OK\": \"15089\", \"OTHERWFAMILY\": \"3568\", \"SCHOOL\": \"University of Kansas\", \"NETPRICE75K\": \"19303\", \"BADALIAS\": \"\", \"TUITIONUNDEROSS\": \"24873\", \"DEFAULTRATE\": \"5.6\", \"AVGSTULOANDEBT\": \"20269\", \"BOOKS\": \"900\", \"ROOMBRDOFFCAMPUS\": \"8852\", \"RETENTRATE\": \"79\", \"KBYOSS\": \"Yes\"}",
+        "KBYOSS": true
+    },
+    "model": "paying_for_college.school",
+    "pk": 243197
+},
+{
+    "fields": {
         "city": "Fort Wayne",
         "accreditor": "",
         "url": "",

--- a/paying_for_college/tests/test_scripts.py
+++ b/paying_for_college/tests/test_scripts.py
@@ -159,3 +159,7 @@ class TestScripts(unittest.TestCase):
     def test_get_prepped_stats(self):
         stats = nat_stats.get_prepped_stats()
         self.assertTrue(stats['completionRateMedian'] <= 1)
+
+    def test_get_bls_stats(self):
+        stats = nat_stats.get_bls_stats()
+        self.assertTrue(stats['Year'] >= 2014)

--- a/paying_for_college/tests/test_scripts.py
+++ b/paying_for_college/tests/test_scripts.py
@@ -61,10 +61,10 @@ class TestUpdater(django.test.TestCase):
         mock_response.ok = False
         mock_response.reason = "Testing OK == False"
         (FAILED, NO_DATA, endmsg) = update_colleges.update()
-        self.assertTrue(len(FAILED) == 2)
+        self.assertTrue(len(FAILED) == 3)
         mock_requests.status_code = 429
         (FAILED, NO_DATA, endmsg) = update_colleges.update()
-        self.assertTrue(len(FAILED) == 2)
+        self.assertTrue(len(FAILED) == 3)
 
     @mock.patch('paying_for_college.disclosures.scripts.update_colleges.requests.get')
     def test_update_colleges_bad_responses(self, mock_requests):

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -154,22 +154,26 @@ class OfferTest(django.test.TestCase):
         no_oid = '?iped=408039&pid=981&oid='
         bad_school = '?iped=xxxxxx&pid=981&oid=f38283b5b7c939a058889f997949efa566c61'
         bad_program = '?iped=408039&pid=xxx&oid=f38283b5b7c939a058889f997949efa566c616c5'
+        puerto_rico = '?iped=243197&pid=981&oid='
         missing_oid_field = '?iped=408039&pid=981'
         missing_school_id = '?iped='
         resp = client.get(url+qstring)
         self.assertTrue(resp.status_code == 200)
         resp2 = client.get(url+no_oid)
-        self.assertTrue(resp.status_code == 200)
+        self.assertTrue(resp2.status_code == 200)
         resp3 = client.get(url+bad_school)
         self.assertTrue("No school" in resp3.content)
         self.assertTrue(resp3.status_code == 400)
         resp4 = client.get(url+bad_program)
-        self.assertTrue(resp.status_code == 200)
+        self.assertTrue(resp4.status_code == 200)
         resp5 = client.get(url+missing_oid_field)
-        self.assertTrue(resp.status_code == 200)
+        self.assertTrue(resp5.status_code == 200)
         resp6 = client.get(url+missing_school_id)
         self.assertTrue("doesn't contain a school" in resp6.content)
-        self.assertTrue(resp3.status_code == 400)
+        self.assertTrue(resp6.status_code == 400)
+        resp7 = client.get(url+puerto_rico)
+        self.assertTrue("nationalFood" in resp7.content)
+        self.assertTrue(resp7.status_code == 200)
 
 
 class APITests(django.test.TestCase):

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -9,7 +9,7 @@ from django.http import HttpResponse, HttpRequest
 from django.test import Client
 from django.core.urlresolvers import reverse
 from paying_for_college.views import Feedback, EmailLink, school_search_api
-from paying_for_college.views import SchoolRepresentation
+from paying_for_college.views import SchoolRepresentation, get_region
 from paying_for_college.models import School
 from paying_for_college.search_indexes import SchoolIndex
 
@@ -39,6 +39,14 @@ class TestViews(django.test.TestCase):
     feedback_post_data = {'csrfmiddlewaretoken': 'abc',
                           'message': 'test'}
     # '0InrCI5HGbiBEJ1esg6IBi3ax42fwPnL'
+
+    def test_get_region(self):
+        school = School(school_id='123456', state='NE')
+        self.assertTrue(get_region(school) == 'MW')
+
+    def test_get_region_failure(self):
+        school = School(school_id='123456', state='')
+        self.assertTrue(get_region(school) == '')
 
     def test_landing_page_views(self):
         for url_name in self.landing_page_views:

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -61,8 +61,7 @@ def get_region(school):
     for region in REGION_MAP:
         if school.state in REGION_MAP[region]:
             return region
-        else:
-            return ''
+    return ''
 
 
 class BaseTemplateView(TemplateView):

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -45,6 +45,26 @@ else:  # pragma: no cover
 URL_ROOT = 'paying-for-college2'
 
 
+REGION_MAP = {'MW': ['IL', 'IN', 'IA', 'KS', 'MI', 'MN',
+              'MO', 'NE', 'ND', 'OH', 'SD', 'WI'],
+              'NE': ['CT', 'ME', 'MA', 'NH', 'NJ',
+                     'NY', 'PA', 'RI', 'VT'],
+              'SO': ['AL', 'AR', 'DE', 'DC', 'FL', 'GA', 'KY', 'LA', 'MD',
+                     'MS', 'NC', 'OK', 'SC', 'TN', 'TX', 'VA', 'WV'],
+              'WE': ['AK', 'AZ', 'CA', 'CO', 'HI', 'ID', 'MT', 'NV', 'NM',
+                     'OR', 'UT', 'WA', 'WY']
+              }
+
+
+def get_region(school):
+    """return a school's region based on state"""
+    for region in REGION_MAP:
+        if school.state in REGION_MAP[region]:
+            return region
+        else:
+            return ''
+
+
 class BaseTemplateView(TemplateView):
 
     def get_context_data(self, **kwargs):
@@ -78,6 +98,14 @@ class OfferView(TemplateView):
                     program = programs[0]
                     program_data = program.as_json()
             national_stats = nat_stats.get_prepped_stats()
+            BLS_stats = nat_stats.get_bls_stats()
+            if get_region(school) and BLS_stats:
+                region = get_region(school)
+                national_stats['region'] = region
+                categories = BLS_stats.keys()
+                categories.remove('Year')
+                for category in categories:
+                    national_stats['regional{0}'.format(category)] = BLS_stats[category][region]
             return render_to_response('worksheet.html',
                                       {'data_js': "0",
                                        'school': school,

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -46,7 +46,7 @@ URL_ROOT = 'paying-for-college2'
 
 
 REGION_MAP = {'MW': ['IL', 'IN', 'IA', 'KS', 'MI', 'MN',
-              'MO', 'NE', 'ND', 'OH', 'SD', 'WI'],
+                     'MO', 'NE', 'ND', 'OH', 'SD', 'WI'],
               'NE': ['CT', 'ME', 'MA', 'NH', 'NJ',
                      'NY', 'PA', 'RI', 'VT'],
               'SO': ['AL', 'AR', 'DE', 'DC', 'FL', 'GA', 'KY', 'LA', 'MD',
@@ -74,9 +74,8 @@ class BaseTemplateView(TemplateView):
         return context
 
 
-class OfferView(TemplateView):
-    """check for reqired values in querystring and pass school/program data"""
-    # TODO log errors
+class OfferView(TemplateView):  # TODO log errors
+    """consult values in querystring and deliver school/program data"""
 
     def get(self, request):
         if 'iped' in request.GET and request.GET['iped']:

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -101,13 +101,20 @@ class OfferView(TemplateView):  # TODO log errors
                     program_data = program.as_json()
             national_stats = nat_stats.get_prepped_stats()
             BLS_stats = nat_stats.get_bls_stats()
-            if get_region(school) and BLS_stats:
-                region = get_region(school)
-                national_stats['region'] = REGION_NAMES[region]
+            if BLS_stats:
                 categories = BLS_stats.keys()
                 categories.remove('Year')
-                for category in categories:
-                    national_stats['regional{0}'.format(category)] = BLS_stats[category][region]
+                if get_region(school):
+                    region = get_region(school)
+                    national_stats['region'] = REGION_NAMES[region]
+                    for category in categories:
+                        national_stats['regional{0}'.format(category)] = BLS_stats[category][region]
+                else:
+                    national_stats['region'] = "Not available"
+                    for category in categories:
+                        national_stats['national{0}'.format(category)] = BLS_stats[category]["average_annual"]
+
+
             return render_to_response('worksheet.html',
                                       {'data_js': "0",
                                        'school': school,

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -54,6 +54,10 @@ REGION_MAP = {'MW': ['IL', 'IN', 'IA', 'KS', 'MI', 'MN',
               'WE': ['AK', 'AZ', 'CA', 'CO', 'HI', 'ID', 'MT', 'NV', 'NM',
                      'OR', 'UT', 'WA', 'WY']
               }
+REGION_NAMES = {'MW': 'Northwest',
+                'NE': "Northeast",
+                'SO': 'South',
+                'WE': 'West'}
 
 
 def get_region(school):
@@ -99,7 +103,7 @@ class OfferView(TemplateView):  # TODO log errors
             BLS_stats = nat_stats.get_bls_stats()
             if get_region(school) and BLS_stats:
                 region = get_region(school)
-                national_stats['region'] = region
+                national_stats['region'] = REGION_NAMES[region]
                 categories = BLS_stats.keys()
                 categories.remove('Year')
                 for category in categories:

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -54,7 +54,7 @@ REGION_MAP = {'MW': ['IL', 'IN', 'IA', 'KS', 'MI', 'MN',
               'WE': ['AK', 'AZ', 'CA', 'CO', 'HI', 'ID', 'MT', 'NV', 'NM',
                      'OR', 'UT', 'WA', 'WY']
               }
-REGION_NAMES = {'MW': 'Northwest',
+REGION_NAMES = {'MW': 'Midwest',
                 'NE': "Northeast",
                 'SO': 'South',
                 'WE': 'West'}


### PR DESCRIPTION
This adds BLS spending stats to the nationalData object delivered to a worksheet page.
The stats are regional (Northeast, Midwest, South, West), based on school's state.
## Additions
- functions added to nat_stats script and view for delivering BLS stats
- json source file added to fixtures
- tests to cover
## Testing

The browser console on test disclosure page should reveal annual values in the nationalData object:
- .region (Northeast, Midwest, South, or West)
- .regionalRetirement
- .regionalTransportation
- .regionalEntertainment
- .regionalFood
- .regionalHousing
- .regionalHealthcare

If a college is not in the 50 states or DC (e.g. Puerto Rico) or if its state isn't recognized, the app will return national cost averages, like so:
- .region: Not available
- .nationalRetirement
- .nationalTransportation
- .nationalEntertainment
- .nationalFood
- .nationalHousing
- .nationalHealthcare
## Review
- @mistergone @niqjohnson @marteki 
