### PR TITLE
fix truncated scorecard zipcodes before entry

### DIFF
--- a/paying_for_college/disclosures/scripts/update_colleges.py
+++ b/paying_for_college/disclosures/scripts/update_colleges.py
@@ -37,9 +37,11 @@ def fix_json(jstring):
 
 
 def fix_zip5(zip5):
-    """add a leading zero if it has been stripped by the scorecard db"""
+    """add leading zeros if they have been stripped by the scorecard db"""
     if len(zip5) == 4:
         return "0{0}".format(zip5)
+    if len(zip5) == 3:
+        return "00{0}".format(zip5)
     else:
         return zip5
 

--- a/paying_for_college/disclosures/scripts/update_colleges.py
+++ b/paying_for_college/disclosures/scripts/update_colleges.py
@@ -36,6 +36,14 @@ def fix_json(jstring):
         return {}
 
 
+def fix_zip5(zip5):
+    """add a leading zero if it has been stripped by the scorecard db"""
+    if len(zip5) == 4:
+        return "0{0}".format(zip5)
+    else:
+        return zip5
+
+
 def update(exclude_ids=[], single_school=None):
     """update college-level data for current year"""
     print("This job is paced to be kind to the Ed API;\n\
@@ -99,6 +107,7 @@ def update(exclude_ids=[], single_school=None):
                     if updated is True:
                         update_count += 1
                         school.data_json = json.dumps(data_dict)
+                        school.zip5 = fix_zip5(school.zip5)
                         school.save()
                 else:
                     sys.stdout.write('-')

--- a/paying_for_college/tests/test_scripts.py
+++ b/paying_for_college/tests/test_scripts.py
@@ -45,6 +45,8 @@ class TestUpdater(django.test.TestCase):
                  }
 
     def test_fix_zip5(self):
+        fixzip3 = update_colleges.fix_zip5('501')
+        self.assertTrue(fixzip3 == '00501')
         fixzip4 = update_colleges.fix_zip5('5501')
         self.assertTrue(fixzip4 == '05501')
         testzip5 = update_colleges.fix_zip5('55105')

--- a/paying_for_college/tests/test_scripts.py
+++ b/paying_for_college/tests/test_scripts.py
@@ -44,6 +44,12 @@ class TestUpdater(django.test.TestCase):
                  'metadata': {'page': 0}
                  }
 
+    def test_fix_zip5(self):
+        fixzip4 = update_colleges.fix_zip5('5501')
+        self.assertTrue(fixzip4 == '05501')
+        testzip5 = update_colleges.fix_zip5('55105')
+        self.assertTrue(testzip5 == '55105')
+
     @mock.patch('paying_for_college.disclosures.scripts.update_colleges.requests.get')
     def test_update_colleges(self, mock_requests):
         mock_response = mock.Mock()


### PR DESCRIPTION
zipcodes with a leading zero get truncated in the scorecard database because they're stored there as integers. we store as strings, so this isn't a problem locally. 

this fix prevents 4-digit zips from being imported.
### Review

@niqjohnson 
