### PR TITLE
Fixes debt calculations, adds currency formatting, program length dropdown works

### DIFF
--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -1718,7 +1718,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="loanTotal"></span>
+                                        data-financial="borrowingTotal"></span>
                                     </div>
                                 </div>
                                 <div class="line-item">

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -1015,7 +1015,7 @@
                                                     id="contrib__private-loan_0"
                                                     name="contrib__private-loan"
                                                     data-financial="privateLoan"
-                                                    data-private-loan_key="amount"
+                                                    data-private-loan_key="baseAmount"
                                                     autocorrect="off"
                                                     value="0">
                                                 </div>
@@ -1155,7 +1155,7 @@
                                                     id="contrib__private-loan_1"
                                                     name="contrib__private-loan"
                                                     data-financial="privateLoan"
-                                                    data-private-loan_key="amount"
+                                                    data-private-loan_key="baseAmount"
                                                     autocorrect="off"
                                                     value="0">
                                                 </div>
@@ -1295,7 +1295,7 @@
                                                     id="contrib__private-loan_2"
                                                     name="contrib__private-loan"
                                                     data-financial="privateLoan"
-                                                    data-private-loan_key="amount"
+                                                    data-private-loan_key="baseAmount"
                                                     autocorrect="off"
                                                     value="0">
                                                 </div>

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -100,25 +100,25 @@
                                 </p>
                                 <div class="cf-select">
                                     <select id="estimated-years-attending">
-                                        <option>
+                                        <option value="">
                                             Select an option
                                         </option>
-                                        <option>
+                                        <option value="1">
                                             1 year
                                         </option>
-                                        <option>
+                                        <option value="2">
                                             2 years
                                         </option>
-                                        <option>
+                                        <option value="3">
                                             3 years
                                         </option>
-                                        <option>
+                                        <option value="4">
                                             4 years
                                         </option>
-                                        <option>
+                                        <option value="5">
                                             5 years
                                         </option>
-                                        <option>
+                                        <option value="6">
                                             6 years
                                         </option>
                                     </select>

--- a/src/disclosures/js/dispatchers/get-view-values.js
+++ b/src/disclosures/js/dispatchers/get-view-values.js
@@ -10,13 +10,14 @@ var getViewValues = {
   },
 
   getPrivateLoans: function( values ) {
+    console.log( 'called gpl')
     // Note: Only run once, during init()
     var $privateLoans = $( '[data-private-loan]' );
     values.privateLoanMulti = [];
     $privateLoans.each( function() {
       var $ele = $( this ),
           $fields = $ele.find( '[data-private-loan_key]' ),
-          loanObject = { amount: 0, rate: 0, deferPeriod: 0 };
+          loanObject = { amount: 0, baseAmount: 0, rate: 0, deferPeriod: 0 };
       $fields.each( function() {
         var key = $( this ).attr( 'data-private-loan_key' ),
             value = $( this ).val();
@@ -25,8 +26,8 @@ var getViewValues = {
         }
         loanObject[key] = stringToNum( value );
       } );
-      loanObject.amount += loanObject.fees;
-      delete loanObject.fees;
+      loanObject.amount = loanObject.baseAmount + loanObject.fees;
+      console.log( loanObject );
       values.privateLoanMulti.push( loanObject );
     } );
     return values;
@@ -57,7 +58,9 @@ var getViewValues = {
     urlValues.privateLoanRate /= 100;
     urlValues.privateLoanMulti = [ {
       amount: urlValues.privateLoan,
+      baseAmount: urlValues.privateLoan,
       rate: urlValues.privateLoanRate,
+      fees: 0,
       deferPeriod: 0
     } ];
     return urlValues;

--- a/src/disclosures/js/dispatchers/get-view-values.js
+++ b/src/disclosures/js/dispatchers/get-view-values.js
@@ -10,7 +10,6 @@ var getViewValues = {
   },
 
   getPrivateLoans: function( values ) {
-    console.log( 'called gpl')
     // Note: Only run once, during init()
     var $privateLoans = $( '[data-private-loan]' );
     values.privateLoanMulti = [];
@@ -27,7 +26,6 @@ var getViewValues = {
         loanObject[key] = stringToNum( value );
       } );
       loanObject.amount = loanObject.baseAmount + loanObject.fees;
-      console.log( loanObject );
       values.privateLoanMulti.push( loanObject );
     } );
     return values;

--- a/src/disclosures/js/dispatchers/publish-update.js
+++ b/src/disclosures/js/dispatchers/publish-update.js
@@ -10,6 +10,9 @@ var publishUpdate = {
 
   updatePrivateLoan: function( index, prop, val ) {
     financialModel.values.privateLoanMulti[index][prop] = val;
+    financialModel.values.privateLoanMulti[index]['amount'] = 
+        financialModel.values.privateLoanMulti[index]['baseAmount'] +
+        financialModel.values.privateLoanMulti[index]['fees'] ;
     financialModel.calc( financialModel.values );
   },
 

--- a/src/disclosures/js/dispatchers/publish-update.js
+++ b/src/disclosures/js/dispatchers/publish-update.js
@@ -20,6 +20,7 @@ var publishUpdate = {
 
   addPrivateLoan: function() {
     var newLoanObject = { amount: 0,
+                          baseAmount: 0,
                           fees: 0,
                           rate: 0,
                           deferPeriod: 0

--- a/src/disclosures/js/dispatchers/publish-update.js
+++ b/src/disclosures/js/dispatchers/publish-update.js
@@ -10,9 +10,9 @@ var publishUpdate = {
 
   updatePrivateLoan: function( index, prop, val ) {
     financialModel.values.privateLoanMulti[index][prop] = val;
-    financialModel.values.privateLoanMulti[index]['amount'] = 
-        financialModel.values.privateLoanMulti[index]['baseAmount'] +
-        financialModel.values.privateLoanMulti[index]['fees'] ;
+    financialModel.values.privateLoanMulti[index].amount =
+        financialModel.values.privateLoanMulti[index].baseAmount +
+        financialModel.values.privateLoanMulti[index].fees;
     financialModel.calc( financialModel.values );
   },
 

--- a/src/disclosures/js/models/financial-model.js
+++ b/src/disclosures/js/models/financial-model.js
@@ -26,6 +26,7 @@ var financialModel = {
     this.sumScholarships();
     this.values = recalculate( this.values );
     this.sumTotals();
+    this.roundValues();
   },
 
   sumTotals: function() {
@@ -42,6 +43,11 @@ var financialModel = {
       model.monthlyRent + model.monthlyFood +
       model.monthlyTransportation + model.monthlyInsurance +
       model.monthlySavings + model.monthlyOther;
+  },
+
+  roundValues: function() {
+    var model = financialModel.values;
+    model.totalDebt = Math.round( model.totalDebt );
   }
 };
 module.exports = financialModel;

--- a/src/disclosures/js/models/financial-model.js
+++ b/src/disclosures/js/models/financial-model.js
@@ -35,6 +35,8 @@ var financialModel = {
 
     model.costAfterGrants = model.costOfAttendance - model.grantsTotal;
 
+    model.totalProgramDebt = model.borrowingTotal * model.programLength;
+
     // monthly expenses
     model.totalMonthlyExpenses =
       model.monthlyRent + model.monthlyFood +

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -44,7 +44,7 @@ var financialView = {
     this.$elements.not( '[data-private-loan_key]' ).each( function() {
       var $ele = $( this ),
           name = $ele.attr( 'data-financial' ),
-          value = values[name];
+          value = Math.round( values[name] );
       if ( $ele.is( '[data-percentage_value="true"]' ) ) {
         value *= 100;
       }

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -66,7 +66,6 @@ var financialView = {
           name = $ele.attr( 'data-financial' ),
           value = values[name] * 100;
       financialView.updateElement( $ele, value, false );
-      console.log( 'percent updated' );
     } );
     $leftovers.each( function() {
       var $ele = $( this ),
@@ -76,25 +75,25 @@ var financialView = {
         currency = false;
       }
       financialView.updateElement( $ele, values[name], currency );
-      console.log( 'leftover updated' );
     } );
     $privateLoans.each( function() {
       var index = $( this ).index(),
           $fields = $( this ).find( '[data-private-loan_key]' );
       $fields.each( function() {
         var key = $( this ).attr( 'data-private-loan_key' ),
-            val = values.privateLoanMulti[index][key];
+            val = values.privateLoanMulti[index][key],
+            isntCurrentInput = ( $( this ).attr( 'id' ) !== financialView.currentInput );
         if ( $( this ).is( '[data-percentage_value="true"]' ) ) {
           val *= 100;
           $( this ).val( val );
-        } else if ( $( this ).attr( 'id' ) !== financialView.currentInput ) {
+        } else if ( isntCurrentInput && key === 'amount' ) {
           $( this ).val( formatUSD( val, { decimalPlaces: 0 } ) );
         } else {
           $( this ).val( val );
         }
-        console.log( 'private loan key updated' );
       } );
     } );
+    console.log( values );
   },
 
   addPrivateListener: function() {

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -8,6 +8,7 @@ var formatUSD = require( 'format-usd' );
 var financialView = {
   $elements: $( '[data-financial]' ),
   $review: $( '[data-section="review"]' ),
+  $programLength: $( '#estimated-years-attending' ),
   $addPrivateButton: $( '.private-loans_add-btn' ),
   $privateContainer: $( '.private-loans' ),
   $privateLoanClone: $( '[data-private-loan]:first' ).clone(),
@@ -18,7 +19,7 @@ var financialView = {
   init: function() {
     var values = getModelValues.financial();
     this.keyupListener();
-    this.focusListener();
+    this.estimatedYearsListener();
     this.addPrivateListener();
     this.removePrivateListener();
     this.resetPrivateLoanView();
@@ -156,9 +157,12 @@ var financialView = {
     } );
   },
 
-  focusListener: function() {
-    this.$review.on( 'focusout', '[data-financial]', function() {
-
+  estimatedYearsListener: function() {
+    this.$programLength.on( 'change', function() {
+      var programLength = $( this ).val(),
+          values = getModelValues.financial();
+      publish.financialData( 'programLength', programLength );
+    financialView.updateView( values );
     });
   }
 

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -162,7 +162,7 @@ var financialView = {
       var programLength = $( this ).val(),
           values = getModelValues.financial();
       publish.financialData( 'programLength', programLength );
-    financialView.updateView( values );
+      financialView.updateView( values );
     });
   }
 

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -11,7 +11,7 @@ var financialView = {
   $addPrivateButton: $( '.private-loans_add-btn' ),
   $privateContainer: $( '.private-loans' ),
   $privateLoanClone: $( '[data-private-loan]:first' ).clone(),
-  privateLoanKeys: [ 'amount', 'fees', 'rate', 'deferPeriod' ],
+  privateLoanKeys: [ 'baseAmount', 'fees', 'rate', 'deferPeriod' ],
   keyupDelay: null,
   currentInput: null,
 
@@ -23,25 +23,6 @@ var financialView = {
     this.removePrivateListener();
     this.resetPrivateLoanView();
     this.updateView( values );
-  },
-
-  setPrivateLoans: function( values ) {
-    $( '[data-private-loan]' ).each( function() {
-      var index = $( this ).index(),
-          $ele = $( this ),
-          $fields = $ele.find( '[data-private-loan_key]' );
-      $fields.each( function() {
-        var key = $( this ).attr( 'data-private-loan_key' ),
-            val = values.privateLoanMulti[index][key];
-        if ( $( this ).is( '[data-percentage_value="true"]' ) ) {
-          val *= 100;
-          $( this ).val( val );
-        }
-        if ( $( this ).attr( 'id' ) !== financialView.currentInput ) {
-          $( this ).val( formatUSD( val, { decimalPlaces: 0 } ) );
-        }
-      } );
-    } );
   },
 
   updateElement: function ( $ele, value, currency ) {
@@ -86,7 +67,7 @@ var financialView = {
         if ( $( this ).is( '[data-percentage_value="true"]' ) ) {
           val *= 100;
           $( this ).val( val );
-        } else if ( isntCurrentInput && key === 'amount' ) {
+        } else if ( isntCurrentInput && key === 'baseAmount' ) {
           $( this ).val( formatUSD( val, { decimalPlaces: 0 } ) );
         } else {
           $( this ).val( val );

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -405,10 +405,6 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
     // TODO: expect the est. monthly student loan expense is recalculated
   } ); */
 
-  // Private loans and payment plans onload: $8,500
-  // Total debt: $14,500
-  // Remaining cost: $7,526
-
   it( 'should properly update when a private loan is modified', function() {
     page.confirmVerification();
     page.setPrivateLoanAmount( 4000 );
@@ -420,9 +416,9 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
     page.setPrivateLoanGracePeriod( 6 );
     browser.sleep( 600 );
     expect( page.privateLoanInterestRate.getAttribute('value') ).toBeGreaterThan( 0 );
-    expect( page.totalPrivateLoansPaymentPlans.getText() ).toEqual( '7000' );
-    expect( page.totalDebt.getText() ).toEqual( '15500' );
-    expect( page.remainingCostFinal.getText() ).toEqual( '-1474' );
+    expect( page.totalPrivateLoansPaymentPlans.getText() ).toEqual( '7001' );
+    expect( page.totalDebt.getText() ).toEqual( '15501' );
+    expect( page.remainingCostFinal.getText() ).toEqual( '-1475' );
     // expect( page.totalProgramDebt.getText() ).toEqual( '?' );
     // expect( page.totalRepayment.getText() ).toEqual( '?' );
     // TODO: expect the estimated debt burden is recalculated
@@ -470,8 +466,19 @@ it( 'should properly update when more than one private loans is modified', funct
 
   it( 'should properly update when a private loan is removed', function() {
   } );
-
 */
+
+  it( 'should display proper debt values', function() {
+    page.confirmVerification();
+    expect( page.totalProgramDebt.getText() ).toEqual( '58000' );
+    expect( page.totalRepayment.getText() ).toEqual( '63575' );
+  } );
+
+  it( 'should update total borrowing when program length is changed', function() {
+     page.confirmVerification();
+     page.setProgramLength( 2 );
+     expect( page.totalProgramDebt.getText() ).toEqual( '29000' );
+  });
 
   // *** Step 2: Evaluate your offer ***
   // TODO: Uncomment when API values are coming in and JS is fully hooked up

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -30,6 +30,16 @@ settlementAidOfferPage.prototype = Object.create({}, {
         this.incorrectInfoButton.click();
       }
     },
+    programLengthSelect: {
+      get: function() {
+        return element ( by.css( '#estimated-years-attending' ) );
+      }
+    },
+    setProgramLength: {
+      value: function( length ) {
+        return this.programLengthSelect.element( by.css( '[value="' + length + '"]') ).click();
+      }
+    },
     // Step 1: Review your first year offer
     reviewSection: {
       get: function() {
@@ -240,7 +250,7 @@ settlementAidOfferPage.prototype = Object.create({}, {
     // TODO: Refactor this here and in the HTML/CSS for multiple private loans?
     privateLoanAmount: {
       get: function() {
-        return element( by.css( '[data-private-loan] [data-private-loan_key="amount"]' ) );
+        return element( by.css( '[data-private-loan] [data-private-loan_key="baseAmount"]' ) );
       }
     },
     setPrivateLoanAmount: {

--- a/test/js-unit/query-handler-spec.js
+++ b/test/js-unit/query-handler-spec.js
@@ -5,7 +5,7 @@ var queryHandler = require( '../../src/disclosures/js/utils/query-handler.js' );
 describe( 'queryHandler...', function() {
 
   it( '...translates abbreviations into values in returned Object', function() {
-    var queryString = '?tf=100&rb=101&bk=102&tr=103&oe=104',
+    var queryString = '?tuit=100&hous=101&book=102&tran=103&othr=104',
         valuePairs = queryHandler( queryString );
     expect( valuePairs.tuitionFees ).to.equal( 100 );
     expect( valuePairs.roomBoard ).to.equal( 101 );
@@ -15,7 +15,7 @@ describe( 'queryHandler...', function() {
   });
 
   it( '...turns strings in the queryString into numbers where applicable', function() {
-    var queryString = '?tf=100&rb=101&bk=102&tr=103&oe=104',
+    var queryString = '?tuit=100&hous=101&book=102&tran=103&othr=104',
         valuePairs = queryHandler( queryString );
     expect( typeof valuePairs.tuitionFees ).to.equal( "number" );
     expect( typeof valuePairs.roomBoard ).to.equal( "number" );
@@ -25,7 +25,7 @@ describe( 'queryHandler...', function() {
   });
 
   it( '...ignores any key which does not appear in keyMaps' , function() {
-    var queryString = '?tf=100&rb=101&bk=102&tr=103&oe=104&lol=999&hack=true',
+    var queryString = '?tuit=100&hous=101&book=102&tran=103&othr=104&lol=999&hack=true',
         valuePairs = queryHandler( queryString );
     expect( valuePairs.tuitionFees ).to.equal( 100 );
     expect( valuePairs.roomBoard ).to.equal( 101 );


### PR DESCRIPTION
Hey! The debt totals work now, and don't display a number out to six decimals or something. So that's good. In the process, I added currency formatting to the input fields (except the focused input field) where applicable, and added functionality to the program length dropdown. 
## Additions
- added handler for "estimated length of program" (aka `programLength`)
- functional tests for `programLength` dropdown and debt totals 
- added `format-usd` to `package.json`
## Changes
- Refactored `financialView.updateView()` for efficiency and clarity
- Fixed private loans so that "fees" are added to total and preserved
- Fixed broken unit tests
## Testing
- Pull it down
- run `npm install` or possibly `local_setup.sh` (to add `format-usd`)
- Check it out!
## Review
- @marteki and @niqjohnson and @higs4281 
## Todos
- **Step 2 functional tests are still failing!** Out of scope for this PR.
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
## Animated GIF

![byrne-lifetime-dance](https://cloud.githubusercontent.com/assets/1490703/12798726/fd8f5564-ca98-11e5-9025-87aad7194d3e.gif)
