### PR TITLE
Add link to College Scorecard search

### DIFF
--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -2425,9 +2425,14 @@
                                 Review your total cost of attendance and
                                 determine if a less expensive school option
                                 (such as a community college) might also meet
-                                your educational needs. <a href="#">See all
-                                schools</a> that offer the same type of
-                                program in your area.
+                                your educational needs.
+                                <a href="https://collegescorecard.ed.gov/"
+                                class="scorecard-link"
+                                target="_blank">
+                                    See all schools
+                                </a>
+                                that offer the same type of program in your
+                                area.
                             </p>
                         </section>
                         <section class="option option__take-action column-well

--- a/src/disclosures/js/utils/construct-scorecard-search.js
+++ b/src/disclosures/js/utils/construct-scorecard-search.js
@@ -10,7 +10,7 @@
  */
 function constructScorecardSearch( pcip, zip, radius ) {
   var searchParameters = [],
-      searchRadius = radius || '25',
+      searchRadius = radius || '50',
       pcipData = {
         '01': {
           label:  'Agriculture, Agriculture Operations, and Related Sciences',
@@ -175,7 +175,7 @@ function constructScorecardSearch( pcip, zip, radius ) {
     searchParameters.push( 'zip=' + zip );
     searchParameters.push( 'distance=' + searchRadius );
   }
-  return '/search/?' + searchParameters.join( '&amp;' );
+  return 'search/?' + searchParameters.join( '&' );
 }
 
 module.exports = constructScorecardSearch;

--- a/src/disclosures/js/utils/construct-scorecard-search.js
+++ b/src/disclosures/js/utils/construct-scorecard-search.js
@@ -10,6 +10,7 @@
  */
 function constructScorecardSearch( pcip, zip, radius ) {
   var searchParameters = [],
+      // Use a 50-mile radius, the most common Scorecard search, as a default
       searchRadius = radius || '50',
       pcipData = {
         '01': {

--- a/src/disclosures/js/utils/construct-scorecard-search.js
+++ b/src/disclosures/js/utils/construct-scorecard-search.js
@@ -1,0 +1,181 @@
+'use strict';
+
+/**
+ * Constructs a search query to append to a link to College Scorecard that looks
+ * for schools that offer a given program near a given ZIP.
+ * @param {string} pcip The given program's two-digit PCIP code
+ * @param {string} zip A five-digit ZIP code to search near
+ * @param {string} radius Radius in miles to search around the given ZIP
+ * @returns {string} The search query (or false if PCIP and ZIP are missing)
+ */
+function constructScorecardSearch( pcip, zip, radius ) {
+  var searchParameters = [],
+      searchRadius = radius || '25',
+      pcipData = {
+        '01': {
+          label:  'Agriculture, Agriculture Operations, and Related Sciences',
+          urlKey: 'agriculture'
+        },
+        '03': {
+          label:  'Natural Resources and Conservation',
+          urlKey: 'resources'
+        },
+        '04': {
+          label:  'Architecture and Related Services',
+          urlKey: 'architecture'
+        },
+        '05': {
+          label:  'Area, Ethnic, Cultural, Gender, and Group Studies',
+          urlKey: 'ethnic_cultural_gender'
+        },
+        '09': {
+          label:  'Communication, Journalism, and Related Programs',
+          urlKey: 'communication'
+        },
+        '10': {
+          label:  'Communications Technologies/Technicians and Support Services',
+          urlKey: 'communications_technology'
+        },
+        '11': {
+          label:  'Computer and Information Sciences and Support Services',
+          urlKey: 'computer'
+        },
+        '12': {
+          label:  'Personal and Culinary Services',
+          urlKey: 'personal_culinary'
+        },
+        '13': {
+          label:  'Education',
+          urlKey: 'education'
+        },
+        '14': {
+          label:  'Engineering',
+          urlKey: 'engineering'
+        },
+        '15': {
+          label:  'Engineering Technologies and Engineering-Related Fields',
+          urlKey: 'engineering_technology'
+        },
+        '16': {
+          label:  'Foreign Languages, Literatures, and Linguistics',
+          urlKey: 'language'
+        },
+        '19': {
+          label:  'Family and Consumer Sciences/Human Sciences',
+          urlKey: 'family_consumer_science'
+        },
+        '22': {
+          label:  'Legal Professions and Studies',
+          urlKey: 'legal'
+        },
+        '23': {
+          label:  'English Language and Literature/Letters',
+          urlKey: 'english'
+        },
+        '24': {
+          label:  'Liberal Arts and Sciences, General Studies and Humanities',
+          urlKey: 'humanities'
+        },
+        '25': {
+          label:  'Library Science',
+          urlKey: 'library'
+        },
+        '26': {
+          label:  'Biological and Biomedical Sciences',
+          urlKey: 'biological'
+        },
+        '27': {
+          label:  'Mathematics and Statistics',
+          urlKey: 'mathematics'
+        },
+        '29': {
+          label:  'Military Technologies and Applied Sciences',
+          urlKey: 'military'
+        },
+        '30': {
+          label:  'Multi/Interdisciplinary Studies',
+          urlKey: 'multidiscipline'
+        },
+        '31': {
+          label:  'Parks, Recreation, Leisure, and Fitness Studies',
+          urlKey: 'parks_recreation_fitness'
+        },
+        '38': {
+          label:  'Philosophy and Religious Studies',
+          urlKey: 'philosophy_religious'
+        },
+        '39': {
+          label:  'Theology and Religious Vocations',
+          urlKey: 'theology_religious_vocation'
+        },
+        '40': {
+          label:  'Physical Sciences',
+          urlKey: 'physical_science'
+        },
+        '41': {
+          label:  'Science Technologies/Technicians',
+          urlKey: 'science_technology'
+        },
+        '42': {
+          label:  'Psychology',
+          urlKey: 'psychology'
+        },
+        '43': {
+          label:  'Homeland Security, Law Enforcement, Firefighting and Related Protective Services',
+          urlKey: 'security_law_enforcement'
+        },
+        '44': {
+          label:  'Public Administration and Social Service Professions',
+          urlKey: 'public_administration_social_service'
+        },
+        '45': {
+          label:  'Social Sciences',
+          urlKey: 'social_science'
+        },
+        '46': {
+          label:  'Construction Trades',
+          urlKey: 'construction'
+        },
+        '47': {
+          label:  'Mechanic and Repair Technologies/Technicians',
+          urlKey: 'mechanic_repair_technology'
+        },
+        '48': {
+          label:  'Precision Production',
+          urlKey: 'precision_production'
+        },
+        '49': {
+          label:  'Transportation and Materials Moving',
+          urlKey: 'transportation'
+        },
+        '50': {
+          label:  'Visual and Performing Arts',
+          urlKey: 'visual_performing'
+        },
+        '51': {
+          label:  'Health Professions and Related Programs',
+          urlKey: 'health'
+        },
+        '52': {
+          label:  'Business, Management, Marketing, and Related Support Services',
+          urlKey: 'business_marketing'
+        },
+        '54': {
+          label:  'History',
+          urlKey: 'history'
+        }
+      };
+  if ( !pcip && !zip ) {
+    return false;
+  }
+  if ( pcipData[pcip] ) {
+    searchParameters.push( 'major=' + pcipData[pcip].urlKey );
+  }
+  if ( zip ) {
+    searchParameters.push( 'zip=' + zip );
+    searchParameters.push( 'distance=' + searchRadius );
+  }
+  return '/search/?' + searchParameters.join( '&amp;' );
+}
+
+module.exports = constructScorecardSearch;

--- a/src/disclosures/js/views/links-view.js
+++ b/src/disclosures/js/views/links-view.js
@@ -1,12 +1,15 @@
 'use strict';
 
 var formatURL = require( '../utils/format-url' );
+var constructScorecardSearch = require( '../utils/construct-scorecard-search' );
 
 var linksView = {
   $schoolLinkText: $( '.school-link' ),
+  $scorecardLink: $( '.scorecard-link' ),
 
   init: function() {
     this.setSchoolLink();
+    this.setScorecardSearch();
   },
 
   setSchoolLink: function() {
@@ -20,6 +23,15 @@ var linksView = {
         .text( this.$schoolLinkText.text() );
       this.$schoolLinkText.replaceWith( $schoolLink );
     }
+  },
+
+  setScorecardSearch: function() {
+    var pcip = window.programData.cipCode.slice( 0, 2 ),
+        zip = window.schoolData.zip5,
+        radius = '50',
+        scorecardURL = this.$scorecardLink.attr( 'href' ),
+        scorecardQuery = constructScorecardSearch( pcip, zip, radius );
+    this.$scorecardLink.attr( 'href', scorecardURL + scorecardQuery );
   }
 
 };

--- a/src/disclosures/js/views/links-view.js
+++ b/src/disclosures/js/views/links-view.js
@@ -28,6 +28,7 @@ var linksView = {
   setScorecardSearch: function() {
     var pcip = window.programData.cipCode.slice( 0, 2 ),
         zip = window.schoolData.zip5,
+        // We're using a 50-mile radius, the most common Scorecard search
         radius = '50',
         scorecardURL = this.$scorecardLink.attr( 'href' ),
         scorecardQuery = constructScorecardSearch( pcip, zip, radius );

--- a/src/disclosures/js/views/links-view.js
+++ b/src/disclosures/js/views/links-view.js
@@ -26,8 +26,8 @@ var linksView = {
   },
 
   setScorecardSearch: function() {
-    var pcip = window.programData.cipCode.slice( 0, 2 ),
-        zip = window.schoolData.zip5,
+    var pcip = window.programData.cipCode ? window.programData.cipCode.slice( 0, 2 ) : '',
+        zip = window.schoolData.zip5 || '',
         // We're using a 50-mile radius, the most common Scorecard search
         radius = '50',
         scorecardURL = this.$scorecardLink.attr( 'href' ),

--- a/test/functional/dd-feedback-spec.js
+++ b/test/functional/dd-feedback-spec.js
@@ -19,6 +19,7 @@ fdescribe( 'The "Was this tool helpful?" section', function() {
   it( 'should open the feedback form in a new tab', function() {
     page.confirmVerification();
     page.followFeedbackLink();
+    browser.sleep( 600 );
     browser.getAllWindowHandles()
       .then( function ( handles ) {
         expect( handles.length ).toBe( 2 );
@@ -28,6 +29,7 @@ fdescribe( 'The "Was this tool helpful?" section', function() {
           } )
           .then( function () {
             browser.close();
+            browser.sleep( 600 );
             browser.switchTo().window( handles[0] );
           } );;
       } );

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -52,7 +52,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   //  Cost of attendance: $43,626
   //  Grants and scholarships: $11,600
   //  Total Contributions: $18,000 (includes ParentPLUS loan, parent loan)
-  //  Total Borrowing: $14,500 
+  //  Total Borrowing: $14,500
   //  Total cost: $36,026
   //  Remaining cost (before loans): $14,026
   //  Remaining cost (after loans): -$474
@@ -542,6 +542,7 @@ it( 'should properly update when more than one private loans is modified', funct
   it( 'should link to the school website in a new tab', function() {
     page.confirmVerification();
     page.followSchoolLink();
+    browser.sleep( 600 );
     browser.getAllWindowHandles()
       .then( function ( handles ) {
         expect( handles.length ).toBe( 2 );
@@ -552,6 +553,7 @@ it( 'should properly update when more than one private loans is modified', funct
           } )
           .then( function () {
             browser.close();
+            browser.sleep( 600 );
             browser.switchTo().window( handles[0] );
           } );
       } );
@@ -560,6 +562,7 @@ it( 'should properly update when more than one private loans is modified', funct
   it( 'should link to the correct College Scorecard search in a new tab', function() {
     page.confirmVerification();
     page.followScorecardLink();
+    browser.sleep( 600 );
     browser.getAllWindowHandles()
       .then( function ( handles ) {
         expect( handles.length ).toBe( 2 );
@@ -572,6 +575,7 @@ it( 'should properly update when more than one private loans is modified', funct
           } )
           .then( function () {
             browser.close();
+            browser.sleep( 600 );
             browser.switchTo().window( handles[0] );
           } );
       } );

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -557,4 +557,24 @@ it( 'should properly update when more than one private loans is modified', funct
       } );
   } );
 
+  it( 'should link to the correct College Scorecard search in a new tab', function() {
+    page.confirmVerification();
+    page.followScorecardLink();
+    browser.getAllWindowHandles()
+      .then( function ( handles ) {
+        expect( handles.length ).toBe( 2 );
+        browser.switchTo().window( handles[1] )
+          .then( function () {
+            browser.wait( EC.titleContains( 'College Scorecard' ), 8000, 'Page title did not contain "College Scorecard" within 8 seconds' );
+            expect( element( by.id( 'major' ) ).getAttribute( 'value' ) ).toBe( 'health' );
+            expect( element( by.id( 'zip-code' ) ).getAttribute( 'value' ) ).toBe( '46805' );
+            expect( element( by.id( 'search-radius' ) ).getAttribute( 'value' ) ).toBe( '50' );
+          } )
+          .then( function () {
+            browser.close();
+            browser.switchTo().window( handles[0] );
+          } );
+      } );
+  } );
+
 });

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -446,6 +446,16 @@ settlementAidOfferPage.prototype = Object.create({}, {
         this.schoolLink.click();
       }
     },
+    scorecardLink: {
+      get: function() {
+        return element( by.css( '.scorecard-link' ) );
+      }
+    },
+    followScorecardLink: {
+      value: function() {
+        this.scorecardLink.click();
+      }
+    },
     //Feedback
     feedbackLink: {
       get: function() {

--- a/test/js-unit/construct-scorecard-search-spec.js
+++ b/test/js-unit/construct-scorecard-search-spec.js
@@ -12,16 +12,18 @@ describe( 'construct-scorecard-search', function() {
     expect( searchQuery ).to.equal( 'search/?major=library&zip=20552&distance=83' );
   });
 
-  it( 'returns a program-only search', function() {
+  it( 'returns a program-only search if no ZIP is given', function() {
     var pcip = '25',
-        searchQuery = scorecardSearch( pcip );
+        zip = '',
+        searchQuery = scorecardSearch( pcip, zip );
     expect( searchQuery ).to.equal( 'search/?major=library' );
   });
 
-  it( 'returns a location-only search', function() {
-    var zip = '20552',
+  it( 'returns a location-only search if no PCIP is given', function() {
+    var pcip = '',
+        zip = '20552',
         radius = '83',
-        searchQuery = scorecardSearch( '', zip, radius );
+        searchQuery = scorecardSearch( pcip, zip, radius );
     expect( searchQuery ).to.equal( 'search/?zip=20552&distance=83' );
   });
 

--- a/test/js-unit/construct-scorecard-search-spec.js
+++ b/test/js-unit/construct-scorecard-search-spec.js
@@ -1,0 +1,64 @@
+var chai = require( 'chai' );
+var expect = chai.expect;
+var scorecardSearch = require( '../../src/disclosures/js/utils/construct-scorecard-search' );
+
+describe( 'construct-scorecard-search', function() {
+
+  it( 'returns a program + location search', function() {
+    var pcip = '25',
+        zip = '20552',
+        radius = '83',
+        searchQuery = scorecardSearch( pcip, zip, radius );
+    expect( searchQuery ).to.equal( 'search/?major=library&zip=20552&distance=83' );
+  });
+
+  it( 'returns a program-only search', function() {
+    var pcip = '25',
+        searchQuery = scorecardSearch( pcip );
+    expect( searchQuery ).to.equal( 'search/?major=library' );
+  });
+
+  it( 'returns a location-only search', function() {
+    var zip = '20552',
+        radius = '83',
+        searchQuery = scorecardSearch( '', zip, radius );
+    expect( searchQuery ).to.equal( 'search/?zip=20552&distance=83' );
+  });
+
+  it( 'returns a location-only search for unknown PCIPs', function() {
+    var pcip = '99',
+        zip = '20552',
+        radius = '83',
+        searchQuery = scorecardSearch( '', zip, radius );
+    expect( searchQuery ).to.equal( 'search/?zip=20552&distance=83' );
+  });
+
+  it( 'defaults to a radius of 50 if radius is not specified', function() {
+    var pcip = '25',
+        zip = '20552',
+        searchQuery = scorecardSearch( pcip, zip );
+    expect( searchQuery ).to.equal( 'search/?major=library&zip=20552&distance=50' );
+  });
+
+  it( 'returns false if PCIP and ZIP are blank', function() {
+    var pcip = '',
+        zip = '',
+        searchQuery = scorecardSearch( pcip, zip );
+    expect( searchQuery ).to.equal( false );
+  });
+
+  it( 'returns false if PCIP and ZIP are undefined', function() {
+    var pcip = undefined,
+        zip = undefined,
+        searchQuery = scorecardSearch( pcip, zip );
+    expect( searchQuery ).to.equal( false );
+  });
+
+  it( 'returns false if PCIP and ZIP are null', function() {
+    var pcip = null,
+        zip = null,
+        searchQuery = scorecardSearch( pcip, zip );
+    expect( searchQuery ).to.equal( false );
+  });
+
+});


### PR DESCRIPTION
Adds a link to a College Scorecard search for schools that offer similar programs as the one selected and are within 50 miles of the selected school's ZIP.
## Additions
- Utility function, `constructScorecardSearch`, to create the Scorecard search query
- Unit tests for `constructScorecardSearch`
- New function in `links-view`, `setScorecardSearch`, to append any query returned by `constructScorecardSearch` to the base Scorecard URL
- Functional tests
- 600 ms delay to functional tests that open and close tabs to account for failures caused by the test running before the tab was ready
## Testing

To test, pull in the `scorecard-link` branch and run `gulp`. Fire up the app in standalone or UnityBox as normal. You can test with our usual test URL:

```
?iped=408039&pid=981&oid=f38283b5b7c939a058889f997949efa566c616c5&tuit=38976&hous=3000&book=650&tran=500&othr=500&pelg=1500&schg=2000&stag=2000&othg=100&ta=3000&mta=3000&gib=3000&wkst=3000&parl=10000&perl=3000&subl=15000&unsl=2000&ppl=1000&gpl=1000&prvl=3000&prvi=4.55&insl=3000&insi=4.55
```

You can also try testing with other IPED IDs to see that (a) the ZIP in the search changes and (b) there's no program in the search (since we don't have program data for those schools). Like Yale (130794), KU (155317), or USC (123961).
### Other testing notes
- The link should open the Scorecard search in a new tab
- I've tested this in IE8/Win7, IE9/Win7, IE10/Win7, IE11/Win7, Firefox/Win7, Chrome/Mac, Safari/Mac, Mobile Safari/iPhone6, and everything seems to be looking good with these caveats: 
  - In IE8, there's an unrelated JS error (present in `master`, too) preventing any of the page's JS from executing
  - In IE9, the link will open correctly, but College Scorecard displays an "update your browser" error and shows no results
  - In IE10, the link will open correctly, but College Scorecard shows no results (it only supports the latest IE, it seems)
  - In IE11 in Sauce Labs, **sometimes** College Scorecard shows an "Error: Forbidden" message; I have no idea why
- This branch is currently failing the same unit and functional tests as `master` is right now. The changes here should add no additional failures.
## Review
- @marteki
- @higs4281: Will CIP codes like "01.0803" always be formatted with the leading zero? The JS is translating CIP code to a general program by taking the first two characters of the CIP code, so if codes like "01.0803" could come through as "1.0803", I can make a change to check for the leading zero.
- @mistergone: Does all the JS structure look OK?
## Screenshots

![scorecard-link](https://cloud.githubusercontent.com/assets/1862695/12799298/132d3280-ca9c-11e5-9dca-42546ba8c31c.png)
## Checklist
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [X] Placeholder code is flagged
- [X] Visually tested in supported browsers and devices
