### PR TITLE
Hide ms-clear pseudo-element in IE10+

### DIFF
--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -12,6 +12,11 @@
 .understanding-financial-aid-offer {
   .webfont-regular();
 
+  // Hide the clear-input "helper" in IE10+; it throws off calculations
+  input::-ms-clear {
+    display: none;
+  }
+
   input[type="text"],
   input[type="search"],
   input[type="email"],


### PR DESCRIPTION
Removes the `ms-clear` pseudo-element in IE10+ (the little "X" you can click in focused inputs that clears the inputs and throws off our calculations). Fixes #94.
## Additions
- Style to hide the `ms-clear` pseudo-element
## Testing
- To test, pull in the `ms-clear` branch and run `gulp`. Fire up the app in standalone or UnityBox as normal.
- The little "X" that appears in IE10+ when an input is focused should no longer appear.
- I've tested this in IE8/Win7, IE9/Win7, IE10/Win7, IE11/Win7, Firefox/Win7, Chrome/Mac, Safari/Mac, Mobile Safari/iPhone6, and everything looks good.
## Review
- @mistergone
## Screenshots

No more "X"!

![no-clear](https://cloud.githubusercontent.com/assets/1862695/12854179/223602a0-cc06-11e5-8c93-1a62c758a739.png)
## Checklist
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [X] Passes all existing automated tests
- [X] Placeholder code is flagged
- [X] Visually tested in supported browsers and devices
