### PR TITLE
Data tweaks

### DIFF
--- a/paying_for_college/disclosures/scripts/nat_stats.py
+++ b/paying_for_college/disclosures/scripts/nat_stats.py
@@ -14,6 +14,8 @@ FIXTURES_DIR = Path(__file__).ancestor(3)
 NAT_DATA_FILE = '{0}/fixtures/national_stats.json'.format(FIXTURES_DIR)
 BACKUP_FILE = '{0}/fixtures/national_stats_backup.json'.format(FIXTURES_DIR)
 BLS_FILE = '{0}/fixtures/bls_data.json'.format(FIXTURES_DIR)
+LENGTH_MAP = {'earnings': {2: 'median_earnings_l4', 4: 'median_earnings_4'},
+              'completion': {2: 'completion_rate_l4', 4: 'completion_rate_4'}}
 
 
 def get_bls_stats():
@@ -63,7 +65,7 @@ def get_national_stats(update=False):
         return json.loads(f.read())
 
 
-def get_prepped_stats():
+def get_prepped_stats(program_length=None):
     """deliver only the national stats we need for worksheets"""
     full_data = get_national_stats()
     try:
@@ -79,4 +81,7 @@ def get_prepped_stats():
         'retentionRateMedian': full_data['retention_rate']['median'],
         'netPriceMedian': full_data['net_price']['median']
     }
+    if program_length:
+        national_stats_for_page['completionRateMedian'] = full_data[LENGTH_MAP['completion'][program_length]]['median']
+        national_stats_for_page['earningsMedian'] = full_data[LENGTH_MAP['earnings'][program_length]]['median']
     return national_stats_for_page

--- a/paying_for_college/fixtures/test_fixture.json
+++ b/paying_for_college/fixtures/test_fixture.json
@@ -23,7 +23,7 @@
         "url": "",
         "ope6_id": 40513,
         "ope8_id": 4051322,
-        "degrees_predominant": "",
+        "degrees_predominant": "3",
         "degrees_highest": "3",
         "state": "IN",
         "operating": true,

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -203,6 +203,7 @@ class School(models.Model):
             'medianAnnualPay': str(self.median_annual_pay),
             'medianMonthlyDebt': "{0}".format(self.median_monthly_debt),
             'medianTotalDebt': "{0}".format(self.median_total_debt),
+            'nicknames': ", ".join([nick.nickname for nick in self.nickname_set.all()]),
             'offerAA': jdata['OFFERAA'],
             'offerBA': jdata['OFFERBA'],
             'offerGrad': jdata['OFFERGRAD'],
@@ -211,6 +212,7 @@ class School(models.Model):
             'otherOffCampus': jdata['OTHEROFFCAMPUS'],
             'otherOnCampus': jdata['OTHERONCAMPUS'],
             'otherWFamily': jdata['OTHERWFAMILY'],
+            'predominantDegree': self.get_predominant_degree(),
             'repay3yr': "{0}".format(self.repay_3yr),
             'roomBrdOffCampus': jdata['ROOMBRDOFFCAMPUS'],
             'roomBrdOnCampus': jdata['ROOMBRDONCAMPUS'],
@@ -232,6 +234,12 @@ class School(models.Model):
 
     def __unicode__(self):
         return self.primary_alias + u" (%s)" % self.school_id
+
+    def get_predominant_degree(self):
+        predominant = ''
+        if self.degrees_predominant and self.degrees_predominant in HIGHEST_DEGREES:
+            predominant = HIGHEST_DEGREES[self.degrees_predominant]
+        return predominant
 
     def get_highest_degree(self):
         highest = ''

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -10,7 +10,7 @@ from string import Template
 import requests
 from django.core.mail import send_mail
 
-HIGHEST_DEGREES = {  # highest-awarded values from Ed API
+HIGHEST_DEGREES = {  # highest-awarded values from Ed API and our CSV spec
     '0': "Non-degree-granting",
     '1': 'Certificate degree',
     '2': "Associate degree",
@@ -31,7 +31,6 @@ LEVELS = {  # Dept. of Ed classification of post-secondary degree levels
     '18': "Doctor's degree-professional practice",
     '19': "Doctor's degree-other"
 }
-
 
 NOTIFICATION_TEMPLATE = Template("""Disclosure notification for offer ID $oid\n\
     timestamp: $time\n\
@@ -198,6 +197,7 @@ class School(models.Model):
             'control': self.control,
             'defaultRate': "{0}".format(self.default_rate),
             'gradRate': "{0}".format(self.grad_rate),
+            'highestDegree': self.get_highest_degree(),
             'indicatorGroup': jdata['INDICATORGROUP'],
             'KBYOSS': self.KBYOSS,
             'medianAnnualPay': str(self.median_annual_pay),
@@ -376,8 +376,8 @@ class Program(models.Model):
 
     def get_level(self):
         level = ''
-        if self.level and self.level in LEVELS:
-            level = LEVELS[self.level]
+        if self.level and str(self.level) in HIGHEST_DEGREES:
+            level = HIGHEST_DEGREES[str(self.level)]
         return level
 
     def as_json(self):

--- a/paying_for_college/tests/test_models.py
+++ b/paying_for_college/tests/test_models.py
@@ -46,7 +46,7 @@ class SchoolModelsTest(TestCase):
     def create_program(self, school):
         return Program.objects.create(institution=school,
                                       program_name='Hacking',
-                                      level='5')
+                                      level='3')
 
     def create_disclosure(self, school):
         return Disclosure.objects.create(institution=school,

--- a/paying_for_college/tests/test_models.py
+++ b/paying_for_college/tests/test_models.py
@@ -25,6 +25,7 @@ class SchoolModelsTest(TestCase):
                                      data_json=data_json,
                                      accreditor=accreditor,
                                      degrees_highest=degrees_highest,
+                                     degrees_predominant=degrees_highest,
                                      city=city,
                                      state=state,
                                      ope6_id=ope6,

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -10,7 +10,8 @@ from django.test import Client
 from django.core.urlresolvers import reverse
 from paying_for_college.views import Feedback, EmailLink, school_search_api
 from paying_for_college.views import SchoolRepresentation, get_region
-from paying_for_college.models import School
+from paying_for_college.views import get_program_length
+from paying_for_college.models import School, Program
 from paying_for_college.search_indexes import SchoolIndex
 
 client = Client()
@@ -39,6 +40,19 @@ class TestViews(django.test.TestCase):
     feedback_post_data = {'csrfmiddlewaretoken': 'abc',
                           'message': 'test'}
     # '0InrCI5HGbiBEJ1esg6IBi3ax42fwPnL'
+
+    def test_get_program_length(self):
+        school = School(school_id='123456', degrees_highest='2')
+        program = Program(institution=school, level='2')
+        test1 = get_program_length(program=program, school=school)
+        self.assertTrue(test1 == 2)
+        test2 = get_program_length(program='', school=school)
+        self.assertTrue(test2 == 2)
+        test3 = get_program_length(program='', school='')
+        self.assertTrue(test3 is None)
+        program.level = '3'
+        test4 = get_program_length(program=program, school='')
+        self.assertTrue(test4 == 4)
 
     def test_get_region(self):
         school = School(school_id='123456', state='NE')

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -68,6 +68,21 @@ def get_region(school):
     return ''
 
 
+def get_program_length(program, school):
+    if program and program.level:
+        LEVEL = program.level
+    elif school and school.degrees_highest:
+        LEVEL = school.degrees_highest
+    else:
+        return None
+    if LEVEL in ['0', '1', '2']:
+            return 2
+    elif LEVEL in ['3', '4']:
+        return 4
+    else:
+        return None
+
+
 class BaseTemplateView(TemplateView):
 
     def get_context_data(self, **kwargs):
@@ -99,7 +114,7 @@ class OfferView(TemplateView):  # TODO log errors
                 if programs:
                     program = programs[0]
                     program_data = program.as_json()
-            national_stats = nat_stats.get_prepped_stats()
+            national_stats = nat_stats.get_prepped_stats(program_length=get_program_length(program, school))
             BLS_stats = nat_stats.get_bls_stats()
             if BLS_stats:
                 categories = BLS_stats.keys()

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -71,6 +71,8 @@ def get_region(school):
 def get_program_length(program, school):
     if program and program.level:
         LEVEL = program.level
+    elif school and school.degrees_predominant:
+        LEVEL = school.degrees_predominant
     elif school and school.degrees_highest:
         LEVEL = school.degrees_highest
     else:


### PR DESCRIPTION
In our attempt to compare apples, this tries to match national earnings and completion rate values with length of program:
- trying first by program level,
- then trying by school predominant degree,
- then trying by school highest degree,
- then falling back to overall national average as last resort
## Additions
- Adds predominantDegree to the schoolData object.
## Fixes
- Our test program object's level value didn't match its program_length, nor our CSV spec. This changes a value in the database, so the fix requires a loaddata command:
  - standalone: `./manage.py loaddata collegedata.json`
  - UnityBox: `./manage.py loaddata collegedata.json --settings=cfpb_django.settings.no_haystack`
## Test
- The schoolObject should now deliver a `predominantDegree` value, which can differ from the `highestDegree` value.
- You should see different national earnings and completion values for 2- and 4-year programs if the app can detect program length:
  - [brown-mackie (408039)](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=981&oid=f38283b5b7c939a058889f997949efa566c616c5&tuit=38976&hous=3000&book=650&tran=500&othr=500&pelg=1500&schg=2000&stag=2000&othg=100&ta=3000&mta=3000&gib=3000&wkst=3000&parl=10000&perl=3000&subl=15000&unsl=2000&ppl=1000&gpl=1000&prvl=3000&prvi=4.55&insl=3000&insi=4.55) should have a nationalData object with completionRateMedian: 0.3393 and earningsMedian: 31080 -- values for programs of less than 4 years
  - [yale (130794)](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=130794) should have a nationalData object with completionRateMedian: 0.4778 and earningsMedian: 42051 -- the 4-year program values
## Review
- @marteki @niqjohnson @mistergone  
