### PR TITLE
add validation for OID; now allows only hex characters 0-9 a-f

### DIFF
--- a/paying_for_college/disclosures/urls.py
+++ b/paying_for_college/disclosures/urls.py
@@ -40,11 +40,11 @@ urlpatterns = [
         SchoolRepresentation.as_view(),
         name='school-json'),
 
-    url(r'^api/worksheet/([1-z0-9-]*).json$',
-        DataStorageView.as_view(),
-        name='api-worksheet'),
+    # url(r'^api/worksheet/([1-z0-9-]*).json$',
+    #     DataStorageView.as_view(),
+    #     name='api-worksheet'),
 
-    url(r'^api/worksheet/$',
-        CreateWorksheetView.as_view(),
-        name='create_worksheet')
+    # url(r'^api/worksheet/$',
+    #     CreateWorksheetView.as_view(),
+    #     name='create_worksheet')
 ]

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -354,14 +354,15 @@ class Program(models.Model):
                                        null=True,
                                        max_digits=5,
                                        decimal_places=2)
-    salary = models.IntegerField(blank=True, null=True)
+    salary = models.IntegerField(blank=True, null=True,
+                                 help_text='MEDIAN SALARY')
     program_length = models.IntegerField(blank=True,
                                          null=True,
                                          help_text="IN MONTHS")
     tuition = models.IntegerField(blank=True,
-                                       null=True)
+                                  null=True)
     fees = models.IntegerField(blank=True,
-                                       null=True)
+                               null=True)
     housing = models.IntegerField(blank=True,
                                   null=True,
                                   help_text="HOUSING & MEALS")
@@ -377,7 +378,7 @@ class Program(models.Model):
                                    decimal_places=2,
                                    help_text="COMPLETERS WHO GET RELATED JOB")
     job_note = models.TextField(blank=True,
-                                      help_text="EXPLANATION FROM SCHOOL")
+                                help_text="EXPLANATION FROM SCHOOL")
 
     def __unicode__(self):
         return u"%s (%s)" % (self.program_name, unicode(self.institution))

--- a/paying_for_college/tests/test_validators.py
+++ b/paying_for_college/tests/test_validators.py
@@ -52,18 +52,18 @@ class UUIDValidatorTestCase(TestCase):
 
 class WorkSheetValidatorTestCase(TestCase):
 
-    def test_valid_worksheet_data(self):
-        result = validate_worksheet(VALID_WORKSHEET_DATA)
-        self.assertTrue('Jayhawks' in result)
+    # def test_valid_worksheet_data(self):
+    #     result = validate_worksheet(VALID_WORKSHEET_DATA)
+    #     self.assertTrue('Jayhawks' in result)
 
-    def test_invalid_worksheet_data(self):
-        self.assertRaises(ValidationError,
-                          validate_worksheet,
-                          INVALID_WORKSHEET_DATA)
+    # def test_invalid_worksheet_data(self):
+    #     self.assertRaises(ValidationError,
+    #                       validate_worksheet,
+    #                       INVALID_WORKSHEET_DATA)
 
-    def test_dirty_worksheet_data(self):
-        result = validate_worksheet(DIRTY_WORKSHEET_DATA)
-        self.assertFalse('<' in result)
+    # def test_dirty_worksheet_data(self):
+    #     result = validate_worksheet(DIRTY_WORKSHEET_DATA)
+    #     self.assertFalse('<' in result)
 
     def test_clean_integer(self):
         self.assertTrue(clean_integer(1) == 1)

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -240,45 +240,45 @@ class APITests(django.test.TestCase):
         self.assertTrue('books' in resp.content)
 
 
-# NO-DATA WORKSHEET POST
-# /paying-for-college/understanding-financial-aid-offers/api/worksheet/
-class CreateWorksheetTest(django.test.TestCase):
+# # NO-DATA WORKSHEET POST
+# # /paying-for-college/understanding-financial-aid-offers/api/worksheet/
+# class CreateWorksheetTest(django.test.TestCase):
 
-    fixtures = ['test_fixture.json']
-    mock_worksheet_data = {'1': {'netpriceok': '12964',
-                                 'oncampusavail': 'Yes',
-                                 'badkey': 'badinfo',
-                                 'tuitiongradoss': '',
-                                 'control': 'Public',
-                                 'offerba': 'Yes',
-                                 'books': 900,
-                                 'instate': False,
-                                 'retentrate': 0.12,
-                                 'online': 'No',
-                                 'school_id': '155317',
-                                 'state': 'KS',
-                                 'school': 'University of Kansas'}}
+#     fixtures = ['test_fixture.json']
+#     mock_worksheet_data = {'1': {'netpriceok': '12964',
+#                                  'oncampusavail': 'Yes',
+#                                  'badkey': 'badinfo',
+#                                  'tuitiongradoss': '',
+#                                  'control': 'Public',
+#                                  'offerba': 'Yes',
+#                                  'books': 900,
+#                                  'instate': False,
+#                                  'retentrate': 0.12,
+#                                  'online': 'No',
+#                                  'school_id': '155317',
+#                                  'state': 'KS',
+#                                  'school': 'University of Kansas'}}
 
-    def test_create_worksheet(self):
-        """generating a worksheet ID via api."""
+#     def test_create_worksheet(self):
+#         """generating a worksheet ID via api."""
 
-        url = reverse('disclosures:create_worksheet')
-        resp = client.post(url)
-        self.assertTrue('id' in resp.content)
-        data = json.loads(resp.content)
-        self.assertTrue(len(data['id']) == 36)
+#         url = reverse('disclosures:create_worksheet')
+#         resp = client.post(url)
+#         self.assertTrue('id' in resp.content)
+#         data = json.loads(resp.content)
+#         self.assertTrue(len(data['id']) == 36)
 
-    # SAVE POST
-    # /paying-for-college/understanding-financial-aid-offers/api/worksheet/00470019-e077-4fc3-9dbb-4a595fe976e6.json
-    def test_save_worksheet(self):
-        """saving a worksheet via api."""
+#     # SAVE POST
+#     # /paying-for-college/understanding-financial-aid-offers/api/worksheet/00470019-e077-4fc3-9dbb-4a595fe976e6.json
+#     def test_save_worksheet(self):
+#         """saving a worksheet via api."""
 
-        url = reverse('disclosures:api-worksheet',
-                      args=['00470019-e077-4fc3-9dbb-4a595fe976e6'])
-        resp = client.post(url,
-                           data=json.dumps(self.mock_worksheet_data),
-                           content_type="application/x-www-form-urlencoded; charset=UTF-8")
-        self.assertTrue(resp.status_code == 200)
+#         url = reverse('disclosures:api-worksheet',
+#                       args=['00470019-e077-4fc3-9dbb-4a595fe976e6'])
+#         resp = client.post(url,
+#                            data=json.dumps(self.mock_worksheet_data),
+#                            content_type="application/x-www-form-urlencoded; charset=UTF-8")
+#         self.assertTrue(resp.status_code == 200)
 
 
 class VerifyViewTest(django.test.TestCase):

--- a/paying_for_college/validators.py
+++ b/paying_for_college/validators.py
@@ -189,31 +189,31 @@ def validate_uuid4(value):
             raise ValidationError('%s is not a valid uuid4' % value)
 
 
-def validate_worksheet(worksheet_json):
-    """
-    check worksheet data to accept only whitelisted keys,
-    enforce data types and clean strings.
-    """
-    try:
-        data = json.loads(worksheet_json)
-        for schoolkey in data:
-            school = data[schoolkey]
-            for key in school.keys():
-                if key not in WHITELIST_KEYS:
-                    del(school[key])
-            for key in school.keys():
-                if WHITELIST_KEYS[key] == 'integer':
-                    school[key] = clean_integer(school[key])
-                if WHITELIST_KEYS[key] == 'string':
-                    school[key] = clean_string(school[key])
-                if WHITELIST_KEYS[key] == 'boolean':
-                    school[key] = clean_boolean(school[key])
-                elif WHITELIST_KEYS[key] == 'yes-no':
-                    school[key] = clean_yes_no(school[key])
-                elif WHITELIST_KEYS[key] == 'float':
-                    school[key] = clean_float(school[key])
-    except ValueError:
-        # raise ValidationError("Worksheet data is invalid json")
-        raise ValidationError("Invalid json")
-    else:
-        return json.dumps(data)
+# def validate_worksheet(worksheet_json):
+#     """
+#     check worksheet data to accept only whitelisted keys,
+#     enforce data types and clean strings.
+#     """
+#     try:
+#         data = json.loads(worksheet_json)
+#         for schoolkey in data:
+#             school = data[schoolkey]
+#             for key in school.keys():
+#                 if key not in WHITELIST_KEYS:
+#                     del(school[key])
+#             for key in school.keys():
+#                 if WHITELIST_KEYS[key] == 'integer':
+#                     school[key] = clean_integer(school[key])
+#                 if WHITELIST_KEYS[key] == 'string':
+#                     school[key] = clean_string(school[key])
+#                 if WHITELIST_KEYS[key] == 'boolean':
+#                     school[key] = clean_boolean(school[key])
+#                 elif WHITELIST_KEYS[key] == 'yes-no':
+#                     school[key] = clean_yes_no(school[key])
+#                 elif WHITELIST_KEYS[key] == 'float':
+#                     school[key] = clean_float(school[key])
+#     except ValueError:
+#         # raise ValidationError("Worksheet data is invalid json")
+#         raise ValidationError("Invalid json")
+#     else:
+#         return json.dumps(data)

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -1,6 +1,8 @@
 import os
 import json
 import uuid
+import re
+
 try:
     from collections import OrderedDict
 except:  # pragma: no cover
@@ -60,6 +62,18 @@ REGION_NAMES = {'MW': 'Midwest',
                 'WE': 'West'}
 
 
+def validate_oid(oid):
+    """
+    make sure an oid contains only hex values 0-9 a-f A-F
+    return True if the oid is valid
+    """
+    find_illegal = re.search('[^0-9a-fA-F]+', oid)
+    if find_illegal:
+        return False
+    else:
+        return True
+
+
 def get_region(school):
     """return a school's region based on state"""
     for region in REGION_MAP:
@@ -108,6 +122,9 @@ class OfferView(TemplateView):  # TODO log errors
                 OID = request.GET['oid']
             else:
                 OID = ''
+            if OID and validate_oid(OID) is False:
+                return HttpResponseBadRequest("Offer ID has illegal characters;\
+                    only 0-9 and a-f are allowed.")
             program_data = json.dumps({})
             program = ''
             if 'pid' in request.GET and request.GET['pid']:

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -27,7 +27,7 @@ from haystack.query import SearchQuerySet
 
 from models import School, Worksheet, Feedback, Notification
 from models import Program, ConstantCap, ConstantRate
-from validators import validate_worksheet, validate_uuid4
+from validators import validate_uuid4  # ,validate_worksheet
 from paying_for_college.disclosures.scripts import nat_stats
 
 # from models import BAHRate
@@ -337,29 +337,29 @@ class EmailLink(View):
         return HttpResponse(json.dumps(document),
                             content_type='application/json')
 
+# # SAVING WORKSHEETS HAS BEEN REMOVED FROM PROJECT REQUIREMENTS
 
-class CreateWorksheetView(View):
-    def post(self, request):
-        worksheet_guid = str(uuid.uuid4())
-        worksheet = Worksheet(guid=worksheet_guid,
-                              saved_data=json.dumps({'id': worksheet_guid})
-                              )
-        worksheet.save()
-        response = HttpResponse(worksheet.saved_data, status=201)
-        return response
+# class CreateWorksheetView(View):
+#     def post(self, request):
+#         worksheet_guid = str(uuid.uuid4())
+#         worksheet = Worksheet(guid=worksheet_guid,
+#                               saved_data=json.dumps({'id': worksheet_guid})
+#                               )
+#         worksheet.save()
+#         response = HttpResponse(worksheet.saved_data, status=201)
+#         return response
 
 
-class DataStorageView(View):
-    def post(self, request, guid):
-        if validate_uuid4(guid) == None:  # we have a valid uuid
-            worksheet = Worksheet.objects.get(guid=guid)
-        if worksheet and request.body:
-            validated_json = validate_worksheet(request.body)
-            if validated_json:
-                worksheet.saved_data = validated_json
-                worksheet.save()
-
-        return HttpResponse(worksheet.saved_data)
+# class DataStorageView(View):
+#     def post(self, request, guid):
+#         if validate_uuid4(guid) == None:  # we have a valid uuid
+#             worksheet = Worksheet.objects.get(guid=guid)
+#         if worksheet and request.body:
+#             validated_json = validate_worksheet(request.body)
+#             if validated_json:
+#                 worksheet.saved_data = validated_json
+#                 worksheet.save()
+#         return HttpResponse(worksheet.saved_data)
 
 
 # def bah_lookup_api(request):


### PR DESCRIPTION
This adds validation to the oid so malicious strings can't be passed to the page.
the oid now can only contain hex characters 0-9 a-f (case insensitive), so angle brackets or any other letters or characters won't be passed.

It also removes code for saving worksheets.
## Deletions
- Removes urls, views, validators and tests for saving worksheets, which is now outside project scope
## Testing
- Sending an oid with anything but hex characters will return an error message:
  "Offer ID has illegal characters; only 0-9 and a-f are allowed."  
## Review
- @OrlandoSoto @lfatty
