### PR TITLE
Make the content even more dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Update version of student-debt-calc to support multiple private loans
 - Updated dispatchers to handle multiple private loans
 - Updated DOM and JS to display totals properly
+- Update content to be dynamic based on API and offer data
 
 ## 1.1.0 - 2015-10-28
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "format-usd": "^0.2.0",
+    "number-to-words": "^1.2.1",
     "student-debt-calc": "2.1.0"
   }
 }

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -787,7 +787,10 @@
                                         </div>
                                         <div class="offer-part_terms">
                                             <p class="offer-part_term">
-                                                5% interest
+                                                <span
+                                                data-financial="perkinsRate"
+                                                data-percentage_value="true">
+                                                [XX]</span>% interest
                                             </p>
                                             <p class="aid-form_definition">
                                                 Starts accumulating after
@@ -824,7 +827,10 @@
                                         </div>
                                         <div class="offer-part_terms">
                                             <p class="offer-part_term">
-                                                4.29% interest
+                                                <span
+                                                data-financial="subsidizedRate"
+                                                data-percentage_value="true">
+                                                [XX]</span>% interest
                                             </p>
                                             <p class="aid-form_definition">
                                                 Starts accumulating 6 months
@@ -872,7 +878,9 @@
                                         </div>
                                         <div class="offer-part_terms">
                                             <p class="offer-part_term">
-                                                4.29% interest
+                                                <span data-financial="unsubsidizedRate"
+                                                data-percentage_value="true">
+                                                [XX]</span>% interest
                                             </p>
                                             <p class="aid-form_definition">
                                                 Starts accumulating when you
@@ -920,7 +928,10 @@
                                         </div>
                                         <div class="offer-part_terms">
                                             <p class="offer-part_term">
-                                                6.84% interest
+                                                <span
+                                                data-financial="gradplusRate"
+                                                data-percentage_value="true">
+                                                [XX]</span>% interest
                                             </p>
                                             <p class="aid-form_definition">
                                                 Starts accumulating when you

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -918,15 +918,6 @@
                                                 to a $1,000 loan, leaving you
                                                 with $958)
                                             </p>
-                                            <p class="offer-part_term">
-                                                6 month deferment period
-                                            </p>
-                                            <p class="aid-form_definition">
-                                                You can apply to postpone
-                                                repayment until six months
-                                                after you graduate, leave
-                                                school, or drop below half-time
-                                            </p>
                                         </div>
                                     </div>
                                     <div class="aid-form_inline-subtotal">

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -2160,8 +2160,7 @@
                                     graduate with $<span
                                     data-financial="medianSchoolDebt">[XX]
                                     </span> of debt (includes part-time,
-                                    full-time, and transfer students),
-                                    compared with a national average of $[XX].
+                                    full-time, and transfer students).
                                     The lower your total debt, the lower your
                                     debt burden will be.</p>
                                 <p>

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -1799,12 +1799,10 @@
                                             Estimated expenses
                                         </h4>
                                         <p class="aid-form_caption">
-                                            Monthly living expenses for single
-                                            person based on <span
-                                            id="expenses__datatype"
+                                            Monthly living expenses based on
+                                            <span id="expenses__datatype"
                                             data-financial="BLSAverage">
-                                            national</span> averages
-                                        </p> 
+                                            national</span> averages </p>
                                     </div>
                                     <div class="form-group_item">
                                         <label class="form-label__wrapped">

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -1644,7 +1644,7 @@
                                 As you can see in the summary, the total cost
                                 of these loans after <span
                                 id="future_years-attending"
-                                data-numeric="yearsAttending">[XX]</span>
+                                data-financial="yearsAttending">[XX]</span>
                                 years after interest equals $<span
                                 id="future_total-debt"
                                 data-financial="totalDebt">[XX]</span>.
@@ -1749,7 +1749,7 @@
                                 <div class="line-item">
                                     <div class="line-item_title">
                                         Loans for <span
-                                        data-numeric="yearsAttending">[XX]
+                                        data-financial="yearsAttending">[XX]
                                         </span> years (program length)
                                     </div>
                                     <div class="line-item_value">
@@ -1936,8 +1936,11 @@
                                         <p class="aid-form_caption">
                                             Monthly living expenses for single
                                             person based on <span
-                                            id="expenses__datatype">national
-                                            </span> averages </p> </div>
+                                            id="expenses__datatype"
+                                            data-financial="BLSAverage">
+                                            national</span> averages
+                                        </p> 
+                                    </div>
                                     <div class="form-group_item">
                                         <label class="form-label__wrapped">
                                             <span

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -2304,9 +2304,11 @@
                             </h3>
                             <p>
                                 <a href="http://www.consumer.ftc.gov/articles/0395-choosing-college-questions-ask">Ask if credits from your school transfer
-                                </a> to degrees earned at other schools. Only
-                                X% of students who start at this school finish
-                                here. In the case you decide to finish your
+                                </a> to degrees earned at other schools.
+                                <span data-financial="completionRate"
+                                data-percentage_value="true">[XX]</span>% of 
+                                students who start at this school finish here.
+                                In the case you decide to finish your
                                 education somewhere else, it’s important to
                                 know if the hard work you’ve put into your
                                 degree will be honored at another school.

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -2352,19 +2352,6 @@
                                         your overall debt.
                                     </p>
                                 </div>
-                                <div class="followup__yes">
-                                    <h3 class="option__take-action-header">
-                                        If you want to make a change
-                                    </h3>
-                                    <p>
-                                        Using some of the strategies outlined
-                                        above in the evaluation, try adjusting
-                                        some of the offer amounts in the tool.
-                                        For instance, you can try reducing the
-                                        amount of federal or private loans to
-                                        see how it affects your overall debt.
-                                    </p>
-                                </div>
                             </div>
                         </section>
                     </div>

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -1736,6 +1736,7 @@
                                 <p>
                                     Keep in mind your school has a job
                                     placement rate of <span
+                                    id="criteria_job-placement-rate"
                                     data-financial="jobRate"
                                     data-percentage_value="true">[X.X]</span>%
                                     for students who graduate and get a job in
@@ -2021,6 +2022,7 @@
                                     data-financial="totalDebt">[XX]</span>. On
                                     average, students from your school
                                     graduate with $<span
+                                    id="criteria_median-school-debt"
                                     data-financial="medianSchoolDebt">[XX]
                                     </span> of debt (includes part-time,
                                     full-time, and transfer students).
@@ -2305,7 +2307,7 @@
                             <p>
                                 <a href="http://www.consumer.ftc.gov/articles/0395-choosing-college-questions-ask">Ask if credits from your school transfer
                                 </a> to degrees earned at other schools.
-                                <span data-financial="completionRate"
+                                <span id="option_completion-rate" data-financial="completionRate"
                                 data-percentage_value="true">[XX]</span>% of 
                                 students who start at this school finish here.
                                 In the case you decide to finish your

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -1870,7 +1870,9 @@
                                 </p>
                                 <p>
                                     Keep in mind your school has a job
-                                    placement rate of [X.X]%
+                                    placement rate of <span
+                                    data-financial="jobRate"
+                                    data-percentage_value="true">[X.X]</span>%
                                     for students who graduate and get a job in
                                     their field. In reality, you could be
                                     making even less than the average salaries

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -796,16 +796,6 @@
                                                 Starts accumulating after
                                                 leaving school
                                             </p>
-                                            <p class="offer-part_term">
-                                                9 month grace period
-                                            </p>
-                                            <p class="aid-form_definition">
-                                                The amount of time after you
-                                                graduate, leave school, or
-                                                drop below half-time
-                                                enrollment before you must
-                                                begin repayment
-                                            </p>
                                         </div>
                                     </div>
                                     <div class="content_line loans_line"></div>
@@ -847,16 +837,6 @@
                                                 fee is added to a $1,000 loan
                                                 but you still receive $1,000)
                                             </p>
-                                            <p class="offer-part_term">
-                                                6 month grace period
-                                            </p>
-                                            <p class="aid-form_definition">
-                                                The amount of time after you
-                                                graduate, leave school, or
-                                                drop below half-time
-                                                enrollment before you must
-                                                begin repayment
-                                            </p>
                                         </div>
                                     </div>
                                     <div class="content_line loans_line"></div>
@@ -896,16 +876,6 @@
                                                 the same (for example, a $17
                                                 fee is added to a $1,000 loan
                                                 but you still receive $1,000)
-                                            </p>
-                                            <p class="offer-part_term">
-                                                6 month grace period
-                                            </p>
-                                            <p class="aid-form_definition">
-                                                The amount of time after you
-                                                graduate, leave school, or
-                                                drop below half-time
-                                                enrollment before you must
-                                                begin repayment
                                             </p>
                                         </div>
                                     </div>
@@ -1102,38 +1072,6 @@
                                                     </span>
                                                 </div>
                                             </div>
-                                            <div class="form-group_item">
-                                                <div
-                                                class="aid-form_label-wrapper">
-                                                    <label class="form-label"
-                                                    for="contrib__private-loan-grace-period">
-                                                        Grace period
-                                                    </label>
-                                                    <p
-                                                    class="aid-form_definition">
-                                                        The amount of time
-                                                        before you must begin
-                                                        repayment
-                                                    </p>
-                                                </div>
-                                                <div
-                                                class="aid-form_input-wrapper">
-                                                    <input
-                                                    class="aid-form_input
-                                                    aid-form_input__time"
-                                                    type="text"
-                                                    id="contrib__private-loan-grace-period_0"
-                                                    name="contrib__private-loan-grace-period"
-                                                    data-financial="privateLoanGracePeriod"
-                                                    data-private-loan_key="deferPeriod"
-                                                    autocorrect="off"
-                                                    value="0">
-                                                    <span
-                                                    class="aid-form_unit">
-                                                        months
-                                                    </span>
-                                                </div>
-                                            </div>
                                         </div>
                                         <div class="private-loans_loan" data-private-loan="true">
                                             <div class="private-loans_heading">
@@ -1243,38 +1181,6 @@
                                                     </span>
                                                 </div>
                                             </div>
-                                            <div class="form-group_item">
-                                                <div
-                                                class="aid-form_label-wrapper">
-                                                    <label class="form-label"
-                                                    for="contrib__private-loan-grace-period">
-                                                        Grace period
-                                                    </label>
-                                                    <p
-                                                    class="aid-form_definition">
-                                                        The amount of time
-                                                        before you must begin
-                                                        repayment
-                                                    </p>
-                                                </div>
-                                                <div
-                                                class="aid-form_input-wrapper">
-                                                    <input
-                                                    class="aid-form_input
-                                                    aid-form_input__time"
-                                                    type="text"
-                                                    id="contrib__private-loan-grace-period_1"
-                                                    name="contrib__private-loan-grace-period"
-                                                    data-financial="privateLoanGracePeriod"
-                                                    data-private-loan_key="deferPeriod"
-                                                    autocorrect="off"
-                                                    value="0">
-                                                    <span
-                                                    class="aid-form_unit">
-                                                        months
-                                                    </span>
-                                                </div>
-                                            </div>
                                         </div>
                                         <div class="private-loans_loan" data-private-loan="true">
                                             <div class="private-loans_heading">
@@ -1381,38 +1287,6 @@
                                                     <span
                                                     class="aid-form_unit">
                                                         %
-                                                    </span>
-                                                </div>
-                                            </div>
-                                            <div class="form-group_item">
-                                                <div
-                                                class="aid-form_label-wrapper">
-                                                    <label class="form-label"
-                                                    for="contrib__private-loan-grace-period">
-                                                        Grace period
-                                                    </label>
-                                                    <p
-                                                    class="aid-form_definition">
-                                                        The amount of time
-                                                        before you must begin
-                                                        repayment
-                                                    </p>
-                                                </div>
-                                                <div
-                                                class="aid-form_input-wrapper">
-                                                    <input
-                                                    class="aid-form_input
-                                                    aid-form_input__time"
-                                                    type="text"
-                                                    id="contrib__private-loan-grace-period_2"
-                                                    name="contrib__private-loan-grace-period"
-                                                    data-financial="privateLoanGracePeriod"
-                                                    data-private-loan_key="deferPeriod"
-                                                    autocorrect="off"
-                                                    value="0">
-                                                    <span
-                                                    class="aid-form_unit">
-                                                        months
                                                     </span>
                                                 </div>
                                             </div>

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -2152,14 +2152,15 @@
                                 <p>
                                     Your total estimated debt, according to
                                     the amounts entered above, is $<span
-                                    data-financial="totalDebt"></span>. On
+                                    data-financial="totalDebt">[XX]</span>. On
                                     average, students from your school
-                                    graduate with $[XX] of debt (includes
-                                    part-time, full-time, and transfer
-                                    students), compared with a national
-                                    average of $[XX]. The lower your total
-                                    debt, the lower your debt burden will be.
-                                </p>
+                                    graduate with $<span
+                                    data-financial="medianSchoolDebt">[XX]
+                                    </span> of debt (includes part-time,
+                                    full-time, and transfer students),
+                                    compared with a national average of $[XX].
+                                    The lower your total debt, the lower your
+                                    debt burden will be.</p>
                                 <p>
                                     If your debt burden is too high, it
                                     increases the chances of defaulting on

--- a/src/disclosures/js/dispatchers/get-school-values.js
+++ b/src/disclosures/js/dispatchers/get-school-values.js
@@ -28,9 +28,9 @@ var getSchoolValues = {
       // Rounds up to the nearest number of years.
       // Might need to change later, to address 18 month or 30 month programs.
       programLength = Math.ceil( window.programData.programLength / 12
-        ) || null;
+        ) || 0;
     } else {
-      programLength = null;
+      programLength = 0;
     }
 
     return programLength;

--- a/src/disclosures/js/dispatchers/get-school-values.js
+++ b/src/disclosures/js/dispatchers/get-school-values.js
@@ -10,6 +10,7 @@ var getSchoolValues = {
     values.medianDebt = this.getMedianDebt();
     values.defaultRate = this.getDefaultRate();
     values.medianSalary = this.getMedianSalary();
+    values.jobRate = Number( window.programData.jobRate );
 
     return values;
   },
@@ -24,18 +25,21 @@ var getSchoolValues = {
     if ( window.programData.completionRate === 'None' ) {
       schoolValues.gradRate = window.schoolData.gradRate;
     } else {
-      schoolValues.gradRate = window.programData.completionRate || window.schoolData.gradRate;
+      schoolValues.gradRate = window.programData.completionRate ||
+      window.schoolData.gradRate;
     }
 
     return schoolValues;
   },
 
   getMedianDebt: function() {
-    return window.programData.medianStudentLoanCompleters || window.schoolData.medianMonthlyDebt;
+    return window.programData.medianStudentLoanCompleters ||
+    window.schoolData.medianMonthlyDebt;
   },
 
   getDefaultRate: function() {
-    return window.programData.defaultRate / 100 || window.schoolData.defaultRate;
+    return window.programData.defaultRate / 100 ||
+    window.schoolData.defaultRate;
   },
 
   getMedianSalary: function() {

--- a/src/disclosures/js/dispatchers/get-school-values.js
+++ b/src/disclosures/js/dispatchers/get-school-values.js
@@ -39,8 +39,6 @@ var getSchoolValues = {
     var jobRate;
 
     if ( window.hasOwnProperty( 'programData' ) ) {
-      // Rounds up to the nearest number of years.
-      // Might need to change later, to address 18 month or 30 month programs.
       jobRate = Number( window.programData.jobRate ) || '';
     } else {
       jobRate = '';
@@ -51,24 +49,26 @@ var getSchoolValues = {
 
   getGradRate: function() {
     var gradRate = '';
-    var schoolAndProgramData = window.hasOwnProperty( 'programData' ) &&
-      window.hasOwnProperty( 'schoolData' );
-    var schoolNotProgramData = !window.hasOwnProperty( 'programData' ) &&
-      window.hasOwnProperty( 'schoolData' );
 
-    if ( schoolAndProgramData ) {
-      if ( window.programData.completionRate === 'None' ) {
-        gradRate = window.schoolData.gradRate;
-      } else {
-        gradRate = window.programData.completionRate ||
-        window.schoolData.gradRate;
-      }
-    }
-    if ( schoolNotProgramData ) {
-      gradRate = window.schoolData.gradRate;
+    if ( window.hasOwnProperty( 'schoolData' ) ) {
+      gradRate = window.schoolData.gradRate || '';
     }
 
     return gradRate;
+  },
+
+  getCompletionRate: function() {
+    var completionRate = '';
+
+    if ( window.hasOwnProperty( 'programData' ) ) {
+      if ( window.programData.completionRate === 'None' ) {
+        completionRate = '';
+      } else {
+        completionRate = window.programData.completionRate || '';
+      }
+    }
+
+    return completionRate;
   },
 
   getMedianSchoolDebt: function() {

--- a/src/disclosures/js/dispatchers/get-school-values.js
+++ b/src/disclosures/js/dispatchers/get-school-values.js
@@ -1,15 +1,20 @@
 'use strict';
 
+var numberToWords = require( 'number-to-words' );
+
 var getSchoolValues = {
 
   init: function( ) {
     var values = {};
 
     values.programLength = this.getProgramLength();
+    values.yearsAttending = numberToWords.toWords( values.programLength );
     values.gradRate = this.getGradRate();
     values.medianSchoolDebt = this.getMedianSchoolDebt();
     values.defaultRate = this.getDefaultRate();
     values.medianSalary = this.getMedianSalary();
+    values.monthlySalary = this.setMonthlySalary( values.medianSalary );
+    values = this.getBLSExpenses( values );
     values.jobRate = this.getJobRate();
 
     return values;
@@ -112,6 +117,50 @@ var getSchoolValues = {
     }
 
     return medianSalary;
+  },
+
+  setMonthlySalary: function( medianSalary ) {
+    var monthlySalary;
+
+    if ( medianSalary === '' ) {
+      monthlySalary = 0;
+    } else {
+      monthlySalary = Math.round( Number( medianSalary ) / 12 ).toFixed( 0 );
+    }
+
+    return monthlySalary;
+  },
+
+  getBLSExpenses: function( values ) {
+
+    // BLS expense data is delivered as annual values.
+    // The tool displays monthly expenses.
+
+    if ( window.hasOwnProperty( 'nationalData' ) ) {
+      if ( window.nationalData.region === 'Not available' ) {
+        values.BLSAverage = 'national';
+        values.monthlyRent = window.nationalData.nationalHousing / 12;
+        values.monthlyFood = window.nationalData.nationalFood / 12;
+        values.monthlyTransportation =
+          window.nationalData.nationalTransportation / 12;
+        values.monthlyInsurance = window.nationalData.nationalHealthcare / 12;
+        values.monthlySavings = window.nationalData.nationalRetirement / 12;
+        values.monthlyOther =
+          window.nationalData.nationalEntertainment / 12;
+      } else {
+        values.BLSAverage = window.nationalData.region + ' regional';
+        values.monthlyRent = window.nationalData.regionalHousing / 12;
+        values.monthlyFood = window.nationalData.regionalFood / 12;
+        values.monthlyTransportation =
+          window.nationalData.regionalTransportation / 12;
+        values.monthlyInsurance = window.nationalData.regionalHealthcare / 12;
+        values.monthlySavings = window.nationalData.regionalRetirement / 12;
+        values.monthlyOther =
+          window.nationalData.regionalEntertainment / 12;
+      }
+    }
+
+    return values;
   }
 
 };

--- a/src/disclosures/js/dispatchers/get-school-values.js
+++ b/src/disclosures/js/dispatchers/get-school-values.js
@@ -7,7 +7,7 @@ var getSchoolValues = {
 
     values.programLength = this.getProgramLength();
     values = this.getGradRate( values );
-    values.medianDebt = this.getMedianDebt();
+    values.medianSchoolDebt = this.getMedianSchoolDebt();
     values.defaultRate = this.getDefaultRate();
     values.medianSalary = this.getMedianSalary();
     values.jobRate = Number( window.programData.jobRate );
@@ -32,9 +32,9 @@ var getSchoolValues = {
     return schoolValues;
   },
 
-  getMedianDebt: function() {
+  getMedianSchoolDebt: function() {
     return window.programData.medianStudentLoanCompleters ||
-    window.schoolData.medianMonthlyDebt;
+    window.schoolData.medianTotalDebt;
   },
 
   getDefaultRate: function() {

--- a/src/disclosures/js/dispatchers/get-school-values.js
+++ b/src/disclosures/js/dispatchers/get-school-values.js
@@ -6,44 +6,112 @@ var getSchoolValues = {
     var values = {};
 
     values.programLength = this.getProgramLength();
-    values = this.getGradRate( values );
+    values.gradRate = this.getGradRate();
     values.medianSchoolDebt = this.getMedianSchoolDebt();
     values.defaultRate = this.getDefaultRate();
     values.medianSalary = this.getMedianSalary();
-    values.jobRate = Number( window.programData.jobRate );
+    values.jobRate = this.getJobRate();
 
     return values;
   },
 
   getProgramLength: function() {
-    // Rounds up to the nearest number of years.
-    // Might need to change later, to address 18 month or 30 month programs.
-    return Math.ceil( window.programData.programLength / 12 ) || '';
-  },
+    var programLength;
 
-  getGradRate: function( schoolValues ) {
-    if ( window.programData.completionRate === 'None' ) {
-      schoolValues.gradRate = window.schoolData.gradRate;
+    if ( window.hasOwnProperty( 'programData' ) ) {
+      // Rounds up to the nearest number of years.
+      // Might need to change later, to address 18 month or 30 month programs.
+      programLength = Math.ceil( window.programData.programLength / 12
+        ) || null;
     } else {
-      schoolValues.gradRate = window.programData.completionRate ||
-      window.schoolData.gradRate;
+      programLength = null;
     }
 
-    return schoolValues;
+    return programLength;
+  },
+
+  getJobRate: function() {
+    var jobRate;
+
+    if ( window.hasOwnProperty( 'programData' ) ) {
+      // Rounds up to the nearest number of years.
+      // Might need to change later, to address 18 month or 30 month programs.
+      jobRate = Number( window.programData.jobRate ) || '';
+    } else {
+      jobRate = '';
+    }
+
+    return jobRate;
+  },
+
+  getGradRate: function() {
+    var gradRate = '';
+    var schoolAndProgramData = window.hasOwnProperty( 'programData' ) &&
+      window.hasOwnProperty( 'schoolData' );
+    var schoolNotProgramData = !window.hasOwnProperty( 'programData' ) &&
+      window.hasOwnProperty( 'schoolData' );
+
+    if ( schoolAndProgramData ) {
+      if ( window.programData.completionRate === 'None' ) {
+        gradRate = window.schoolData.gradRate;
+      } else {
+        gradRate = window.programData.completionRate ||
+        window.schoolData.gradRate;
+      }
+    }
+    if ( schoolNotProgramData ) {
+      gradRate = window.schoolData.gradRate;
+    }
+
+    return gradRate;
   },
 
   getMedianSchoolDebt: function() {
-    return window.programData.medianStudentLoanCompleters ||
-    window.schoolData.medianTotalDebt;
+    var medianSchoolDebt;
+
+    if ( window.hasOwnProperty( 'programData' ) &&
+      window.hasOwnProperty( 'schoolData' ) ) {
+      medianSchoolDebt = window.programData.medianStudentLoanCompleters ||
+        window.schoolData.medianTotalDebt;
+    } else if ( window.hasOwnProperty( 'schoolData' ) ) {
+      medianSchoolDebt = window.schoolData.medianTotalDebt;
+    } else {
+      medianSchoolDebt = '';
+    }
+
+    return medianSchoolDebt;
   },
 
   getDefaultRate: function() {
-    return window.programData.defaultRate / 100 ||
-    window.schoolData.defaultRate;
+    var defaultRate;
+
+    if ( window.hasOwnProperty( 'programData' ) &&
+      window.hasOwnProperty( 'schoolData' ) ) {
+      defaultRate = window.programData.defaultRate / 100 ||
+        window.schoolData.defaultRate;
+    } else if ( window.hasOwnProperty( 'schoolData' ) ) {
+      defaultRate = window.schoolData.defaultRate;
+    } else {
+      defaultRate = '';
+    }
+
+    return defaultRate;
   },
 
   getMedianSalary: function() {
-    return window.programData.salary || window.schoolData.medianAnnualPay;
+    var medianSalary;
+
+    if ( window.hasOwnProperty( 'programData' ) &&
+      window.hasOwnProperty( 'schoolData' ) ) {
+      medianSalary = window.programData.salary ||
+        window.schoolData.medianAnnualPay;
+    } else if ( window.hasOwnProperty( 'schoolData' ) ) {
+      medianSalary = window.schoolData.medianAnnualPay;
+    } else {
+      medianSalary = '';
+    }
+
+    return medianSalary;
   }
 
 };

--- a/src/disclosures/js/dispatchers/get-school-values.js
+++ b/src/disclosures/js/dispatchers/get-school-values.js
@@ -10,6 +10,7 @@ var getSchoolValues = {
     values.programLength = this.getProgramLength();
     values.yearsAttending = numberToWords.toWords( values.programLength );
     values.gradRate = this.getGradRate();
+    values.completionRate = this.getCompletionRate();
     values.medianSchoolDebt = this.getMedianSchoolDebt();
     values.defaultRate = this.getDefaultRate();
     values.medianSalary = this.getMedianSalary();

--- a/src/disclosures/js/dispatchers/get-view-values.js
+++ b/src/disclosures/js/dispatchers/get-view-values.js
@@ -2,11 +2,12 @@
 
 var stringToNum = require( '../utils/handle-string-input' );
 var queryHandler = require( '../utils/query-handler' );
+var getSchoolValues = require( '../dispatchers/get-school-values' );
 
 var getViewValues = {
 
   init: function( apiValues ) {
-    return $.extend( this.inputs(), this.url(), apiValues );
+    return $.extend( this.inputs(), this.url(), this.school(), apiValues );
   },
 
   getPrivateLoans: function( values ) {
@@ -53,6 +54,11 @@ var getViewValues = {
       urlValues = queryHandler( location.search );
     }
     return urlValues;
+  },
+
+  school: function() {
+    var schoolValues;
+    return getSchoolValues.init();
   }
 
 };

--- a/src/disclosures/js/dispatchers/get-view-values.js
+++ b/src/disclosures/js/dispatchers/get-view-values.js
@@ -6,6 +6,9 @@ var queryHandler = require( '../utils/query-handler' );
 var getViewValues = {
 
   init: function( apiValues ) {
+    for ( var key in apiValues ) {
+      apiValues[key] = Number( apiValues[key] );       
+    }
     return $.extend( this.inputs(), this.url(), apiValues );
   },
 

--- a/src/disclosures/js/dispatchers/get-view-values.js
+++ b/src/disclosures/js/dispatchers/get-view-values.js
@@ -7,7 +7,7 @@ var getSchoolValues = require( '../dispatchers/get-school-values' );
 var getViewValues = {
 
   init: function( apiValues ) {
-    return $.extend( this.inputs(), this.url(), this.school(), apiValues );
+    return $.extend( this.inputs(), this.url(), getSchoolValues.init(), apiValues );
   },
 
   getPrivateLoans: function( values ) {
@@ -54,11 +54,6 @@ var getViewValues = {
       urlValues = queryHandler( location.search );
     }
     return urlValues;
-  },
-
-  school: function() {
-    var schoolValues;
-    return getSchoolValues.init();
   }
 
 };

--- a/src/disclosures/js/models/financial-model.js
+++ b/src/disclosures/js/models/financial-model.js
@@ -50,9 +50,12 @@ var financialModel = {
 
     // monthly expenses
     model.totalMonthlyExpenses =
-      model.monthlyRent + model.monthlyFood +
+      Math.round( model.monthlyRent + model.monthlyFood +
       model.monthlyTransportation + model.monthlyInsurance +
-      model.monthlySavings + model.monthlyOther;
+      model.monthlySavings + model.monthlyOther ).toFixed( 0 );
+
+    model.monthlyLeftover = Math.round( model.monthlySalary -
+      model.totalMonthlyExpenses - model.monthlyLoanPayment ).toFixed( 0 );
   },
 
   /**

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -5,6 +5,7 @@ var getSchoolValues = require( '../dispatchers/get-school-values' );
 var publish = require( '../dispatchers/publish-update' );
 var stringToNum = require( '../utils/handle-string-input' );
 var formatUSD = require( 'format-usd' );
+var numberToWords = require( 'number-to-words' );
 
 var financialView = {
   $elements: $( '[data-financial]' ),
@@ -236,8 +237,10 @@ var financialView = {
   estimatedYearsListener: function() {
     this.$programLength.on( 'change', function() {
       var programLength = Number( $( this ).val() ),
-          values = getModelValues.financial();
+          values = getModelValues.financial(),
+          yearsAttending = numberToWords.toWords( programLength );
       publish.financialData( 'programLength', programLength );
+      publish.financialData( 'yearsAttending', yearsAttending );
       financialView.updateView( values );
     } );
   }

--- a/src/disclosures/js/views/links-view.js
+++ b/src/disclosures/js/views/links-view.js
@@ -28,24 +28,20 @@ var linksView = {
   },
 
   setScorecardSearch: function() {
-    if ( window.hasOwnProperty( 'programData' ) ) {
-      var pcip = window.programData.cipCode ? window.programData.cipCode.slice( 0, 2 ) : '',
-          zip = window.schoolData.zip5 || '',
-          // We're using a 50-mile radius, the most common Scorecard search
-          radius = '50',
-          scorecardURL = this.$scorecardLink.attr( 'href' ),
-          scorecardQuery = constructScorecardSearch( pcip, zip, radius );
-      this.$scorecardLink.attr( 'href', scorecardURL + scorecardQuery );      
-    }
-  },
-
-  setScorecardSearch: function() {
-    var pcip = window.programData.cipCode ? window.programData.cipCode.slice( 0, 2 ) : '',
-        zip = window.schoolData.zip5 || '',
+    var pcip = '',
+        zip = '',
         // We're using a 50-mile radius, the most common Scorecard search
         radius = '50',
         scorecardURL = this.$scorecardLink.attr( 'href' ),
-        scorecardQuery = constructScorecardSearch( pcip, zip, radius );
+        scorecardQuery;
+
+    if ( window.hasOwnProperty( 'programData' ) ) {
+      pcip = window.programData.cipCode ? window.programData.cipCode.slice( 0, 2 ) : '';
+    }
+    if ( window.hasOwnProperty( 'schoolData' ) ) {
+      zip = window.schoolData.zip5 || '';
+    }
+    scorecardQuery = constructScorecardSearch( pcip, zip, radius );
     this.$scorecardLink.attr( 'href', scorecardURL + scorecardQuery );
   }
 

--- a/src/disclosures/js/views/links-view.js
+++ b/src/disclosures/js/views/links-view.js
@@ -40,13 +40,15 @@ var linksView = {
   },
 
   setScorecardSearch: function() {
-    var pcip = window.programData.cipCode ? window.programData.cipCode.slice( 0, 2 ) : '',
-        zip = window.schoolData.zip5 || '',
-        // We're using a 50-mile radius, the most common Scorecard search
-        radius = '50',
-        scorecardURL = this.$scorecardLink.attr( 'href' ),
-        scorecardQuery = constructScorecardSearch( pcip, zip, radius );
-    this.$scorecardLink.attr( 'href', scorecardURL + scorecardQuery );
+    if ( window.hasOwnProperty( 'programData' ) ) {
+      var pcip = window.programData.cipCode ? window.programData.cipCode.slice( 0, 2 ) : '',
+          zip = window.schoolData.zip5 || '',
+          // We're using a 50-mile radius, the most common Scorecard search
+          radius = '50',
+          scorecardURL = this.$scorecardLink.attr( 'href' ),
+          scorecardQuery = constructScorecardSearch( pcip, zip, radius );
+      this.$scorecardLink.attr( 'href', scorecardURL + scorecardQuery );
+    }
   }
 
 };

--- a/test/functional/conf.js
+++ b/test/functional/conf.js
@@ -2,7 +2,7 @@ exports.config = {
 	framework: 'jasmine2',
   	seleniumAddress: 'http://localhost:4444/wd/hub',
  	capabilities: { 'browserName': 'chrome' },
- 	specs: ['dd-functional-settlement-spec.js', 'dd-feedback-spec.js', 'dd-school-data-spec.js'],
+ 	specs: ['dd-interactions-spec.js'],
 
  	onPrepare:function(){
  		browser.ignoreSynchronization = true;

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -478,10 +478,11 @@ it( 'should properly update when more than one private loans is modified', funct
     expect( page.totalRepayment.getText() ).toEqual( '30989' );
   } );
 
-  it( 'should update total borrowing when program length is changed', function() {
+  it( 'should update total borrowing and verbiage when program length is changed', function() {
      page.confirmVerification();
      page.setProgramLength( 4 );
      browser.sleep( 1000 );
+     expect( page.futureYearsAttending.getText() ).toEqual( 'four' );
      expect( page.totalProgramDebt.getText() ).toEqual( '58000' );
   });
 

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -418,8 +418,6 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
     browser.sleep( 600 );
     page.setPrivateLoanFees( 1 );
     browser.sleep( 600 );
-    page.setPrivateLoanGracePeriod( 6 );
-    browser.sleep( 600 );
     expect( page.privateLoanInterestRate.getAttribute('value') ).toBeGreaterThan( 0 );
     expect( page.totalPrivateLoansPaymentPlans.getText() ).toEqual( '7000' );
     expect( page.totalDebt.getText() ).toEqual( '15500' );
@@ -458,7 +456,6 @@ it( 'should properly update when more than one private loans is modified', funct
     page.setPrivateLoanAmount( 3000 );
     page.setPrivateLoanInterestRate( 4.55 );
     page.setPrivateLoanFees( 1 );
-    page.setPrivateLoanGracePeriod( 6 );
     expect( page.privateLoanInterestRate.getAttribute('value') ).toBeGreaterThan( 0 );
     expect( page.totalPrivateLoansPaymentPlans.getText() ).toEqual( '3000' );
     expect( page.totalDebt.getText() ).toEqual( '12000' );
@@ -497,7 +494,7 @@ it( 'should properly update when more than one private loans is modified', funct
     // TODO: Add expectation about invisibility of negative remaining cost
     expect( page.futurePositiveRemainingCost.getText() ).toEqual( '4526' );
     expect( page.futureTotalLoans.getText() ).toEqual( '14500' );
-    expect( page.futureYearsAttending.getText() ).toEqual( '[XX]' );
+    expect( page.futureYearsAttending.getText() ).toEqual( 'two' );
     expect( page.futureTotalDebt.getText() ).toEqual( '30989' );
   } );
 
@@ -508,7 +505,7 @@ it( 'should properly update when more than one private loans is modified', funct
     // TODO: Add expectation about invisibility of positive remaining cost
     expect( page.futurePositiveRemainingCost.getText() ).toEqual( '-474' );
     expect( page.futureTotalLoans.getText() ).toEqual( '14500' );
-    expect( page.futureYearsAttending.getText() ).toEqual( '[XX]' );
+    expect( page.futureYearsAttending.getText() ).toEqual( 'two' );
     expect( page.futureTotalDebt.getText() ).toEqual( '30989' );
   } );
 
@@ -520,74 +517,59 @@ it( 'should properly update when more than one private loans is modified', funct
     // TODO: Add expectation about invisibility of positive remaining cost
     // TODO: Add expectation about invisibility of negative remaining cost
     expect( page.futureTotalLoans.getText() ).toEqual( '14500' );
-    expect( page.futureYearsAttending.getText() ).toEqual( '[XX]' );
+    expect( page.futureYearsAttending.getText() ).toEqual( 'two' );
     expect( page.futureTotalDebt.getText() ).toEqual( '30989' );
   } );
 
   // *** Step 2: Evaluate your offer ***
-  // TODO: Uncomment when API values are coming in and JS is fully hooked up
+  
+  // TODO: Change monthly left over when student loan payment is added
+  it( 'should properly display estimated monthly expenses', function() {
+    page.confirmVerification();
+    expect( page.totalMonthlyExpenses.getText() ).toEqual( '3726' );
+    expect( page.totalMonthlyLeftOver.getText() ).toEqual( '-1809' );
+  } );
 
   it( 'should properly update when estimated monthly mortage or rent is modified', function() {
     page.confirmVerification();
-    page.setMonthlyRent( 1150 );
-    // expect( page.averageMonthlySalary.getText() ).toEqual( '3200' );
-    expect( page.totalMonthlyExpenses.getText() ).toEqual( '1150' );
-    // expect( page.totalMonthlyLeftOver.getText() ).toEqual( '1850' );
+    page.setMonthlyRent( 1151 );
+    expect( page.totalMonthlyExpenses.getText() ).toEqual( '3526' );
+    expect( page.totalMonthlyLeftOver.getText() ).toEqual( '-1609' );
   } );
 
   it( 'should properly update when estimated monthly food is modified', function() {
     page.confirmVerification();
-    page.setMonthlyRent( 1150 );
-    page.setMonthlyFood( 400 );
-    // expect( page.averageMonthlySalary.getText() ).toEqual( '3200' );
-    expect( page.totalMonthlyExpenses.getText() ).toEqual( '1550' );
-    // expect( page.totalMonthlyLeftOver.getText() ).toEqual( '1450' );
+    page.setMonthlyFood( 675 );
+    expect( page.totalMonthlyExpenses.getText() ).toEqual( '3826' );
+    expect( page.totalMonthlyLeftOver.getText() ).toEqual( '-1909' );
   } );
 
   it( 'should properly update when estimated monthly transportation is modified', function() {
     page.confirmVerification();
-    page.setMonthlyRent( 1150 );
-    page.setMonthlyFood( 400 );
-    page.setMonthlyTransportation( 500 );
-    // expect( page.averageMonthlySalary.getText() ).toEqual( '3200' );
-    expect( page.totalMonthlyExpenses.getText() ).toEqual( '2050' );
-    // expect( page.totalMonthlyLeftOver.getText() ).toEqual( '1350' );
+    page.setMonthlyTransportation( 634 );
+    expect( page.totalMonthlyExpenses.getText() ).toEqual( '3626' );
+    expect( page.totalMonthlyLeftOver.getText() ).toEqual( '-1709' );
   } );
 
   it( 'should properly update when estimated monthly insurance is modified', function() {
     page.confirmVerification();
-    page.setMonthlyRent( 1150 );
-    page.setMonthlyFood( 400 );
-    page.setMonthlyTransportation( 500 );
-    page.setMonthlyInsurance( 200 );
-    // expect( page.averageMonthlySalary.getText() ).toEqual( '3200' );
-    expect( page.totalMonthlyExpenses.getText() ).toEqual( '2250' );
-    // expect( page.totalMonthlyLeftOver.getText() ).toEqual( '2100' );
+    page.setMonthlyInsurance( 667 );
+    expect( page.totalMonthlyExpenses.getText() ).toEqual( '4026' );
+    expect( page.totalMonthlyLeftOver.getText() ).toEqual( '-2109' );
   } );
 
   it( 'should properly update when estimated monthly retirement and savings are modified', function() {
     page.confirmVerification();
-    page.setMonthlyRent( 1150 );
-    page.setMonthlyFood( 400 );
-    page.setMonthlyTransportation( 500 );
-    page.setMonthlyInsurance( 200 );
-    page.setMonthlyRetirement( 100 );
-    // expect( page.averageMonthlySalary.getText() ).toEqual( '3200' );
-    expect( page.totalMonthlyExpenses.getText() ).toEqual( '2350' );
-    // expect( page.totalMonthlyLeftOver.getText() ).toEqual( '2100' );
+    page.setMonthlyRetirement( 169 );
+    expect( page.totalMonthlyExpenses.getText() ).toEqual( '3426' );
+    expect( page.totalMonthlyLeftOver.getText() ).toEqual( '-1509' );
   } );
 
   it( 'should properly update when estimated monthly other expenses are modified', function() {
     page.confirmVerification();
-    page.setMonthlyRent( 1150 );
-    page.setMonthlyFood( 400 );
-    page.setMonthlyTransportation( 500 );
-    page.setMonthlyInsurance( 200 );
-    page.setMonthlyRetirement( 100 );
-    page.setMonthlyOther( 500 );
-    // expect( page.averageMonthlySalary.getText() ).toEqual( '3200' );
-    expect( page.totalMonthlyExpenses.getText() ).toEqual( '2850' );
-    // expect( page.totalMonthlyLeftOver.getText() ).toEqual( '2100' );
+    page.setMonthlyOther( 630 );
+    expect( page.totalMonthlyExpenses.getText() ).toEqual( '4126' );
+    expect( page.totalMonthlyLeftOver.getText() ).toEqual( '-2209' );
   } );
 
   it( 'should link to the school website in a new tab', function() {

--- a/test/functional/dd-interactions-spec.js
+++ b/test/functional/dd-interactions-spec.js
@@ -19,15 +19,30 @@ fdescribe( 'The college costs worksheet page', function() {
   // Private Loan Interactions
 
   it( 'should add a private loan entry when the add button is clicked', function() {
+    var count;
     page.confirmVerification();
-    element.all( by.css( '.private-loans .private-loans_loan' ) ).count()
-    .then( function( total ) {
-      page.addPrivateLoanButton.click();
-      element.all( by.css( '.private-loans .private-loans_loan' ) ).count()
-      .then( function( newTotal ) {
-        expect( newTotal ).toBe( total + 1 );
-      } );
-    } );
+    page.addPrivateLoanButton.click();
+    count = element.all( by.css( '.private-loans .private-loans_loan' ) ).count();
+    expect( count ).toBe( 2 );
+  } );
+
+  it( 'should remove a private loan entry when the loan\'s remove button is clicked', function() {
+    var count;
+    page.confirmVerification();
+    element.all( by.css( '.private-loans .private-loans_loan'))
+      .last().all( by.css( '.private-loans_remove-btn' ) ).click();
+    count = element.all( by.css( '.private-loans .private-loans_loan' ) ).count();
+    expect( count ).toBe( 0 );
+  } );
+
+  it( 'should add a private loan even after the last private loan is removed', function() {
+    var count;
+    page.confirmVerification();
+    element.all( by.css( '.private-loans .private-loans_loan'))
+      .last().all( by.css( '.private-loans_remove-btn' ) ).click();
+    page.addPrivateLoanButton.click();
+    count = element.all( by.css( '.private-loans .private-loans_loan' ) ).count();
+    expect( count ).toBe( 1 );
   } );
 
 } );

--- a/test/functional/dd-interactions-spec.js
+++ b/test/functional/dd-interactions-spec.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var SettlementPage = require( './settlementAidOfferPage.js' );
+
+fdescribe( 'The college costs worksheet page', function() {
+  var page;
+  var EC = protractor.ExpectedConditions;
+
+  beforeEach(function() {
+    var url = 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/';
+    page = new SettlementPage( url );
+    browser.driver.wait( function() {
+      return browser.driver.getCurrentUrl( function( url ) {
+        return /activity/.test( url );
+      });
+    });
+  } );
+
+  // Private Loan Interactions
+
+  it( 'should add a private loan entry when the add button is clicked', function() {
+    page.confirmVerification();
+    element.all( by.css( '.private-loans .private-loans_loan' ) ).count()
+    .then( function( total ) {
+      page.addPrivateLoanButton.click();
+      element.all( by.css( '.private-loans .private-loans_loan' ) ).count()
+      .then( function( newTotal ) {
+        expect( newTotal ).toBe( total + 1 );
+      } );
+    } );
+  } );
+
+} );

--- a/test/functional/dd-school-data-spec.js
+++ b/test/functional/dd-school-data-spec.js
@@ -17,4 +17,28 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
      expect( page.totalProgramDebt.getText() ).toEqual( '29000' );
   } );
 
+  it( 'should dynamically display the completion rate if it\'s available', function() {
+     browser.sleep( 600 );
+     page.confirmVerification();
+     expect( page.completionRate.getText() ).toEqual( '0' );
+  } );
+
+  it( 'should dynamically display the median school or program debt if it\'s available', function() {
+     browser.sleep( 600 );
+     page.confirmVerification();
+     expect( page.medianSchoolDebt.getText() ).toEqual( '24500' );
+  } );
+
+  it( 'should dynamically display the expected monthly salary if it\'s available', function() {
+     browser.sleep( 600 );
+     page.confirmVerification();
+     expect( page.averageMonthlySalary.getText() ).toEqual( '1917');
+  } );
+
+  it( 'should dynamically display the job rate if it\'s available', function() {
+     browser.sleep( 600 );
+     page.confirmVerification();
+     expect( page.jobRate.getText() ).toEqual( '18' );
+  } );
+
 } );

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -286,17 +286,6 @@ settlementAidOfferPage.prototype = Object.create({}, {
         return this.privateLoanFees.sendKeys(privatefees);
       }
     },
-    privateLoanGracePeriod: {
-      get: function() {
-        return element( by.css( '[data-private-loan] [data-private-loan_key="deferPeriod"]' ) );
-      }
-    },
-    setPrivateLoanGracePeriod: {
-      value: function( privategrace ) {
-        this.privateLoanGracePeriod.clear();
-        return this.privateLoanGracePeriod.sendKeys(privategrace);
-      }
-    },
     addPrivateLoanButton: {
       get: function() {
         return element( by.css( 'a[title="Add another private loan"]' ) );

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -1,7 +1,12 @@
 'use strict';
 
-var settlementAidOfferPage = function() {
-    browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=981&oid=f38283b5b7c939a058889f997949efa566c616c5&tuit=38976&hous=3000&book=650&tran=500&othr=500&pelg=1500&schg=2000&stag=2000&othg=100&ta=3000&mta=3000&gib=3000&wkst=3000&parl=14000&perl=3000&subl=15000&unsl=2000&ppl=1000&gpl=1000&prvl=3000&prvi=4.55&insl=3000&insi=4.55' );
+var settlementAidOfferPage = function( url ) {
+    if ( typeof url !== 'undefined' ) {
+      browser.get( url )
+    }
+    else {
+      browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=981&oid=f38283b5b7c939a058889f997949efa566c616c5&tuit=38976&hous=3000&book=650&tran=500&othr=500&pelg=1500&schg=2000&stag=2000&othg=100&ta=3000&mta=3000&gib=3000&wkst=3000&parl=14000&perl=3000&subl=15000&unsl=2000&ppl=1000&gpl=1000&prvl=3000&prvi=4.55&insl=3000&insi=4.55' );
+    }
 };
 
 settlementAidOfferPage.prototype = Object.create({}, {
@@ -299,7 +304,7 @@ settlementAidOfferPage.prototype = Object.create({}, {
     },
     addPrivateLoanButton: {
       get: function() {
-        return element( by.css( 'a[title="Add another private loan"]' ) );
+        return element( by.css( 'button.private-loans_add-btn' ) );
       }
     },
     paymentPlanAmount: {

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -372,6 +372,22 @@ settlementAidOfferPage.prototype = Object.create({}, {
         return element( by.id( 'future_total-debt' ) );
       }
     },
+    // Metrics
+    completionRate: {
+      get: function() {
+        return element( by.id( 'option_completion-rate' ) );
+      }
+    },
+    medianSchoolDebt: {
+      get: function() {
+        return element( by.id( 'criteria_median-school-debt' ) );
+      }
+    },
+    jobRate: {
+      get: function() {
+        return element( by.id( 'criteria_job-placement-rate' ) );
+      }
+    },
     // Step 2: Evaluate your offer
     evaluateSection: {
       get: function() {


### PR DESCRIPTION
Makes it so that values in the textual page content are dynamic for many things, and removes several items from loans that aren't going to be included in the tool.
## Additions
- Pulls the school and program data from the Django-delivered on-page JS into the main model.
- Include completion rate as something separate from graduation rate
## Removals
- Content about national debt average
- UI for loan grace and deferment periods, as well as functional tests
- Content about BLS expenses being "for a single person"
- Content in step 3 tied to header "If you want to make a change"
## Changes
- As wisely pointed out by @mistergone, checks for window.\* property existence before trying to check the values of attributes on said properties
- Pull the following items from data instead of being hard-coded:
  - federal loan rates
  - total median debt at school
  - job placement rate
  - default rate
  - median salary for program or school
  - BLS monthly expenses
- Change the following wording depending on data:
  - program length in words ("two" instead of 2)
  - "National" vs. "[specific region] regional" displayed for BLS expenses
## Testing
- To test: pull in the `dynamic-content` branch. Run `npm install` (to pull in the newly added number-to-words package), then run `gulp`. Fire up the app in standalone or UnityBox as normal.
- Six Part 2 tests are still failing, because the total monthly estimated values are not being updated. :cry:  You should see something similar to:

> 48 specs, 6 failures
> Finished in 77.683 seconds
## Review
- @mistergone @niqjohnson @higs4281 and @kurzn 
## Todos
- Remove paragraphs or sentences based on no data being passed (completion rate, job placement rate, etc.)
- Show or hide paragraphs based on offer calculations
- Pull in default private loan rate of 7.9% (in model, but not being transferred to inputs properly) and default private loan fee of 4.9% (not in model)
## Checklist
- [x] CHANGELOG has been updated
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [x] New functions include new tests
- [x] Placeholder code is flagged
