### PR TITLE
Display school and national data in bar graphs

### DIFF
--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -1808,18 +1808,21 @@
                                         Percentage of full-time students who
                                         graduate from a college or university
                                     </p>
-                                    <div class="bar-graph">
+                                    <div class="bar-graph"
+                                    data-metric="gradRate"
+                                    data-national-metric="completionRateMedian"
+                                    data-incoming-format="decimal-percent"
+                                    data-graph-min="0"
+                                    data-graph-max="1">
                                         <div class="bar-graph_bar"></div>
                                         <div class="bar-graph_point
                                         bar-graph_point__you u-clearfix">
                                             <div class="bar-graph_label">
-                                                Your school
+                                                This school
                                             </div>
                                             <div class="bar-graph_line"></div>
                                             <div class="bar-graph_value">
-                                                <div class="bar-graph_number">
-                                                    92%
-                                                </div>
+                                                <div class="bar-graph_number"></div>
                                             </div>
                                         </div>
                                         <div class="bar-graph_point
@@ -1829,9 +1832,7 @@
                                             </div>
                                             <div class="bar-graph_line"></div>
                                             <div class="bar-graph_value">
-                                                <div class="bar-graph_number">
-                                                    86%
-                                                </div>
+                                                <div class="bar-graph_number"></div>
                                             </div>
                                         </div>
                                     </div>
@@ -1876,17 +1877,21 @@
                                         taxes) after graduating from your
                                         program
                                     </p>
-                                    <div class="bar-graph">
+                                    <div class="bar-graph"
+                                    data-metric="medianSalary"
+                                    data-national-metric="earningsMedian"
+                                    data-incoming-format="currency"
+                                    data-graph-min="0"
+                                    data-graph-max="100000">
+                                        <div class="bar-graph_bar"></div>
                                         <div class="bar-graph_point
                                         bar-graph_point__you u-clearfix">
                                             <div class="bar-graph_label">
-                                                Your school
+                                                This school
                                             </div>
                                             <div class="bar-graph_line"></div>
                                             <div class="bar-graph_value">
-                                                <div class="bar-graph_number">
-                                                    $26,000
-                                                </div>
+                                                <div class="bar-graph_number"></div>
                                             </div>
                                         </div>
                                         <div class="bar-graph_point
@@ -1896,9 +1901,7 @@
                                             </div>
                                             <div class="bar-graph_line"></div>
                                             <div class="bar-graph_value">
-                                                <div class="bar-graph_number">
-                                                    $34,000
-                                                </div>
+                                                <div class="bar-graph_number"></div>
                                             </div>
                                         </div>
                                     </div>
@@ -2268,18 +2271,21 @@
                                         Percentage of students who default on
                                         loans after entering repayment
                                     </p>
-                                    <div class="bar-graph">
+                                    <div class="bar-graph"
+                                    data-metric="defaultRate"
+                                    data-national-metric="loanDefaultRate"
+                                    data-incoming-format="decimal-percent"
+                                    data-graph-min="0"
+                                    data-graph-max="1">
                                         <div class="bar-graph_bar"></div>
                                         <div class="bar-graph_point
                                         bar-graph_point__you u-clearfix">
                                             <div class="bar-graph_label">
-                                                Your school
+                                                This school
                                             </div>
                                             <div class="bar-graph_line"></div>
                                             <div class="bar-graph_value">
-                                                <div class="bar-graph_number">
-                                                    72%
-                                                </div>
+                                                <div class="bar-graph_number"></div>
                                             </div>
                                         </div>
                                         <div class="bar-graph_point
@@ -2289,9 +2295,7 @@
                                             </div>
                                             <div class="bar-graph_line"></div>
                                             <div class="bar-graph_value">
-                                                <div class="bar-graph_number">
-                                                    32%
-                                                </div>
+                                                <div class="bar-graph_number"></div>
                                             </div>
                                         </div>
                                     </div>

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -1883,6 +1883,9 @@
                                     data-incoming-format="currency"
                                     data-graph-min="0"
                                     data-graph-max="100000">
+                                        <div class="bar-graph_top-label">
+                                            $100,000
+                                        </div>
                                         <div class="bar-graph_bar"></div>
                                         <div class="bar-graph_point
                                         bar-graph_point__you u-clearfix">

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -1076,6 +1076,10 @@
       top: unit( (@bar-graph-average-font-size + @bar-graph-line-top-cheat) / 2, px);
     }
   }
+
+  &__equal &_point__average {
+    display: none;
+  }
 }
 
 /* ==========================================================================

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -1102,6 +1102,10 @@
     display: none;
   }
 
+  &__high-point &_top-label {
+    display: none;
+  }
+
   // Median salary graph needs room above it for the top-label
   &[data-metric="medianSalary"] {
     border-top: @bar-graph-top-label-height solid transparent;

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -994,6 +994,8 @@
   @bar-graph-you-font-size:        18px;
   @bar-graph-average-font-size:    16px;
   @bar-graph-line-overhang:         6px;
+  @bar-graph-top-label-width:      70px;
+  @bar-graph-top-label-height:     20px;
   // A little cheat to make the line look vertically centered
   @bar-graph-line-top-cheat:        3px;
 
@@ -1056,6 +1058,17 @@
     });
   }
 
+  &_top-label {
+    width: @bar-graph-top-label-width;
+    margin-left: -(@bar-graph-top-label-width - @bar-graph-width) / 2 - @bar-graph-line-overhang;
+    position: absolute;
+    top: unit(-@bar-graph-top-label-height / @small-font-size-px, em);
+    left: 50%;
+    z-index: 100;
+    font-size: unit(@small-font-size-px / @base-font-size-px, em);
+    text-align: center;
+  }
+
   &_point__you {
     .webfont-medium();
     font-size: unit(@bar-graph-you-font-size / @base-font-size-px, em);
@@ -1087,6 +1100,11 @@
 
   &__missing-average &_point__average {
     display: none;
+  }
+
+  // Median salary graph needs room above it for the top-label
+  &[data-metric="medianSalary"] {
+    border-top: @bar-graph-top-label-height solid transparent;
   }
 }
 

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -1080,6 +1080,14 @@
   &__equal &_point__average {
     display: none;
   }
+
+  &__missing-you &_point__you {
+    display: none;
+  }
+
+  &__missing-average &_point__average {
+    display: none;
+  }
 }
 
 /* ==========================================================================

--- a/src/disclosures/js/index.js
+++ b/src/disclosures/js/index.js
@@ -19,7 +19,7 @@ var app = {
       financialModel.init( resp );
       financialView.init();
       // Placeholder to set bar graphs
-      metricView.demo();
+      metricView.init();
       linksView.init();
     } );
   }

--- a/src/disclosures/js/views/metric-view.js
+++ b/src/disclosures/js/views/metric-view.js
@@ -6,57 +6,80 @@ var formatUSD = require( 'format-usd' );
 var metricView = {
 
   init: function() {
-    var $graphs = $( '.bar-graph' );
+    var $graphs = $( '.bar-graph' ),
+        schoolValues = schoolModel.values,
+        nationalValues = window.nationalData || {};
     $graphs.each( function() {
       var $graph = $( this ),
           metricKey = $graph.attr( 'data-metric' ),
           nationalKey = $graph.attr( 'data-national-metric' ),
-          schoolValues = schoolModel.values,
-          nationalValues = window.nationalData || {},
+          graphFormat = $graph.attr( 'data-incoming-format' ),
           schoolAverage = parseFloat( schoolValues[metricKey] ),
-          nationalAverage = parseFloat( nationalValues[nationalKey] );
-      metricView.setGraph( $graph, schoolAverage, nationalAverage );
+          schoolAverageFormatted = metricView.formatValue( graphFormat, schoolAverage ),
+          nationalAverage = parseFloat( nationalValues[nationalKey] ),
+          nationalAverageFormatted = metricView.formatValue( graphFormat, nationalAverage );
+      metricView.setGraphValues( $graph, schoolAverageFormatted, nationalAverageFormatted );
+      metricView.setGraphPositions( $graph, schoolAverage, nationalAverage );
     } );
   },
 
-  calculateBottom: function( graphHeight, maxValue, minValue, bottomOffset, value ) {
-    return ( ( ( graphHeight - bottomOffset ) / ( maxValue - minValue ) ) * ( value - minValue ) ) + bottomOffset;
+  calculateBottoms: function( $graph, graphHeight, schoolValue, nationalValue, $schoolPoint, $nationalPoint ) {
+    var minValue = $graph.attr( 'data-graph-min' ),
+        maxValue = $graph.attr( 'data-graph-max' ),
+        bottoms = {},
+        // Lines fall off the bottom of the graph if they sit right at the base
+        bottomOffset = 20,
+        schoolPointHeight = $schoolPoint.find( '.bar-graph_label' ).height(),
+        nationalPointHeight = $nationalPoint.find( '.bar-graph_label' ).height();
+    bottoms.school = ( graphHeight - bottomOffset ) / ( maxValue - minValue ) * ( schoolValue - minValue ) + bottomOffset;
+    bottoms.national = ( graphHeight - bottomOffset ) / ( maxValue - minValue ) * ( nationalValue - minValue ) + bottomOffset;
+    // If the national point overlaps the school point, move the higher point up
+    // out of the way. The national point is never so high that moving the
+    // school point above it will push the school point off the graph, so no
+    // need to worry about that case.
+    if ( bottoms.national <= bottoms.school + schoolPointHeight && bottoms.national + nationalPointHeight >= bottoms.school ) {
+      if ( bottoms.school > bottoms.national ) {
+        bottoms.school = bottoms.national + nationalPointHeight;
+      } else {
+        bottoms.national = bottoms.school + schoolPointHeight;
+      }
+    }
+    return bottoms;
   },
 
-  formatValues: function( valueType, rawValue ) {
+  formatValue: function( valueType, rawValue ) {
     var formattedValue = '';
     if ( valueType === 'decimal-percent' ) {
       formattedValue = Math.round( rawValue * 100 ).toString() + '%';
     }
     if ( valueType === 'currency' ) {
-      formattedValue = formatUSD( rawValue, {decimalPlaces: 0} );
+      formattedValue = formatUSD( rawValue, { decimalPlaces: 0 } );
     }
     return formattedValue;
   },
 
-  setGraph: function( $graph, schoolAverage, nationalAverage ) {
-    var minValue = $graph.attr( 'data-graph-min' ),
-        maxValue = $graph.attr( 'data-graph-max' ),
-        graphHeight = $graph.height(),
-        // Graph lines fall off the design if they sit right at the bottom of the graph
-        bottomOffset = 20,
-        graphFormat = $graph.attr( 'data-incoming-format' ),
-        $schoolPoint = $graph.find( '.bar-graph_point__you' ),
-        schoolPointBottom = this.calculateBottom( graphHeight, maxValue, minValue, bottomOffset, schoolAverage ),
-        $schoolPointNumber = $schoolPoint.find( '.bar-graph_number' ),
-        schoolAverageFormatted = this.formatValues( graphFormat, schoolAverage ),
-        $nationalPoint = $graph.find( '.bar-graph_point__average' ),
-        nationalPointBottom = this.calculateBottom( graphHeight, maxValue, minValue, bottomOffset, nationalAverage ),
-        $nationalPointNumber = $nationalPoint.find( '.bar-graph_number' ),
-        nationalAverageFormatted = this.formatValues( graphFormat, nationalAverage );
+  setGraphValues: function( $graph, schoolAverageFormatted, nationalAverageFormatted ) {
+    var $schoolPointNumber = $graph.find( '.bar-graph_point__you .bar-graph_number' ),
+        $nationalPointNumber = $graph.find( '.bar-graph_point__average .bar-graph_number' );
     $schoolPointNumber.text( schoolAverageFormatted );
     $nationalPointNumber.text( nationalAverageFormatted );
-    $schoolPoint.css( 'bottom', schoolPointBottom );
-    $nationalPoint.css( 'bottom', nationalPointBottom );
-    // Set bottom offset
-    // Set bottom positions
-    // Stop lines from overlapping
-    // Figure out what to do if lines are exactly the same
+    if ( schoolAverageFormatted === nationalAverageFormatted ) {
+      $graph.addClass( 'bar-graph__equal' );
+    }
+  },
+
+  setGraphPositions: function( $graph, schoolAverage, nationalAverage ) {
+    var graphHeight = $graph.height(),
+        $schoolPoint = $graph.find( '.bar-graph_point__you' ),
+        $nationalPoint = $graph.find( '.bar-graph_point__average' ),
+        bottoms = this.calculateBottoms( $graph, graphHeight, schoolAverage, nationalAverage, $schoolPoint, $nationalPoint );
+    // A few outlier schools have very high average salaries, so we need to
+    // prevent those values from falling off the top of the graph
+    if ( bottoms.school > graphHeight ) {
+      bottoms.school = graphHeight;
+    }
+    $schoolPoint.css( 'bottom', bottoms.school );
+    $nationalPoint.css( 'bottom', bottoms.national );
   }
 
 };
@@ -64,7 +87,10 @@ var metricView = {
 module.exports = metricView;
 
 /* To do
+  - Handle identical values (i.e. fully overlapping points): hide the national average line and value, add a class to the graph that pushes the school label up
   - Handle missing data
-  - Refactor to split setGraph into smaller pieces?
+  - metricView.setAlert (call right after setGraph in init)
+  - Handle no JS?
   - Refactor all graph vars into an object: getGraphVariables?
+  - iped=239169 has crazy high salary and no grad rate!
 */

--- a/src/disclosures/js/views/metric-view.js
+++ b/src/disclosures/js/views/metric-view.js
@@ -1,17 +1,70 @@
 'use strict';
 
+var schoolModel = require( '../models/school-model' );
+var formatUSD = require( 'format-usd' );
+
 var metricView = {
 
-  // Placeholder to set bar graphs
-  demo: function() {
-    $( '.graduation-rate .bar-graph_point__you' ).css( 'top', '5px' );
-    $( '.graduation-rate .bar-graph_point__average' ).css( 'top', '30px' );
-    $( '.average-salary .bar-graph_point__you' ).css( 'top', '80px' );
-    $( '.average-salary .bar-graph_point__average' ).css( 'top', '40px' );
-    $( '.loan-default-rates .bar-graph_point__you' ).css( 'top', '25px' );
-    $( '.loan-default-rates .bar-graph_point__average' ).css( 'top', '70px' );
+  init: function() {
+    var $graphs = $( '.bar-graph' );
+    $graphs.each( function() {
+      var $graph = $( this ),
+          metricKey = $graph.attr( 'data-metric' ),
+          nationalKey = $graph.attr( 'data-national-metric' ),
+          schoolValues = schoolModel.values,
+          nationalValues = window.nationalData || {},
+          schoolAverage = parseFloat( schoolValues[metricKey] ),
+          nationalAverage = parseFloat( nationalValues[nationalKey] );
+      metricView.setGraph( $graph, schoolAverage, nationalAverage );
+    } );
+  },
+
+  calculateBottom: function( graphHeight, maxValue, minValue, bottomOffset, value ) {
+    return ( ( ( graphHeight - bottomOffset ) / ( maxValue - minValue ) ) * ( value - minValue ) ) + bottomOffset;
+  },
+
+  formatValues: function( valueType, rawValue ) {
+    var formattedValue = '';
+    if ( valueType === 'decimal-percent' ) {
+      formattedValue = Math.round( rawValue * 100 ).toString() + '%';
+    }
+    if ( valueType === 'currency' ) {
+      formattedValue = formatUSD( rawValue, {decimalPlaces: 0} );
+    }
+    return formattedValue;
+  },
+
+  setGraph: function( $graph, schoolAverage, nationalAverage ) {
+    var minValue = $graph.attr( 'data-graph-min' ),
+        maxValue = $graph.attr( 'data-graph-max' ),
+        graphHeight = $graph.height(),
+        // Graph lines fall off the design if they sit right at the bottom of the graph
+        bottomOffset = 20,
+        graphFormat = $graph.attr( 'data-incoming-format' ),
+        $schoolPoint = $graph.find( '.bar-graph_point__you' ),
+        schoolPointBottom = this.calculateBottom( graphHeight, maxValue, minValue, bottomOffset, schoolAverage ),
+        $schoolPointNumber = $schoolPoint.find( '.bar-graph_number' ),
+        schoolAverageFormatted = this.formatValues( graphFormat, schoolAverage ),
+        $nationalPoint = $graph.find( '.bar-graph_point__average' ),
+        nationalPointBottom = this.calculateBottom( graphHeight, maxValue, minValue, bottomOffset, nationalAverage ),
+        $nationalPointNumber = $nationalPoint.find( '.bar-graph_number' ),
+        nationalAverageFormatted = this.formatValues( graphFormat, nationalAverage );
+    $schoolPointNumber.text( schoolAverageFormatted );
+    $nationalPointNumber.text( nationalAverageFormatted );
+    $schoolPoint.css( 'bottom', schoolPointBottom );
+    $nationalPoint.css( 'bottom', nationalPointBottom );
+    // Set bottom offset
+    // Set bottom positions
+    // Stop lines from overlapping
+    // Figure out what to do if lines are exactly the same
   }
 
 };
 
 module.exports = metricView;
+
+/* To do
+  - Handle missing data
+  - Refactor to split setGraph into smaller pieces?
+  - Refactor all graph vars into an object: getGraphVariables?
+*/

--- a/src/disclosures/js/views/metric-view.js
+++ b/src/disclosures/js/views/metric-view.js
@@ -64,6 +64,9 @@ var metricView = {
 
   formatValue: function( valueType, rawValue ) {
     var formattedValue = '';
+    if ( isNaN( rawValue ) ) {
+      return false;
+    }
     if ( valueType === 'decimal-percent' ) {
       formattedValue = Math.round( rawValue * 100 ).toString() + '%';
     }
@@ -76,8 +79,16 @@ var metricView = {
   setGraphValues: function( $graph, schoolAverageFormatted, nationalAverageFormatted ) {
     var $schoolPointNumber = $graph.find( '.bar-graph_point__you .bar-graph_number' ),
         $nationalPointNumber = $graph.find( '.bar-graph_point__average .bar-graph_number' );
-    $schoolPointNumber.text( schoolAverageFormatted );
-    $nationalPointNumber.text( nationalAverageFormatted );
+    if ( schoolAverageFormatted ) {
+      $schoolPointNumber.text( schoolAverageFormatted );
+    } else {
+      $graph.addClass( 'bar-graph__missing-you' );
+    }
+    if ( nationalAverageFormatted ) {
+      $nationalPointNumber.text( nationalAverageFormatted );
+    } else {
+      $graph.addClass( 'bar-graph__missing-average' );
+    }
   },
 
   setGraphPositions: function( $graph, schoolAverage, nationalAverage, $schoolPoint, $nationalPoint ) {

--- a/src/disclosures/js/views/metric-view.js
+++ b/src/disclosures/js/views/metric-view.js
@@ -98,7 +98,9 @@ module.exports = metricView;
 
 /* To do
   - Handle identical values: hide the national average line, change the alert
-  - Handle missing data: hide the school line, change the alert
+  - Handle missing school data: hide the school line, change the alert
+  - Handle missing national data? Can that ever happen?
+  - Figure out salary graph scale
   - metricView.setAlert (call right after setGraph in init)
   - Handle no JS?
   - Refactor all graph vars into an object: getGraphVariables?

--- a/src/disclosures/js/views/metric-view.js
+++ b/src/disclosures/js/views/metric-view.js
@@ -5,6 +5,9 @@ var formatUSD = require( 'format-usd' );
 
 var metricView = {
 
+  /**
+   * Initiates the object
+   */
   init: function() {
     var $graphs = $( '.bar-graph' ),
         schoolValues = schoolModel.values,
@@ -26,6 +29,14 @@ var metricView = {
     } );
   },
 
+  /**
+   * Calculates the CSS bottom positions of each point on a bar graph
+   * @param {object} $graph jQuery object of the graph containing the points
+   * @param {number} graphHeight Height of the graph
+   * @param {number} schoolValue Value reported by the school
+   * @param {number} nationalValue Average national value
+   * @returns {object} Object with CSS bottom positions for each point
+   */
   calculateBottoms: function( $graph, graphHeight, schoolValue, nationalValue ) {
     var minValue = $graph.attr( 'data-graph-min' ),
         maxValue = $graph.attr( 'data-graph-max' ),
@@ -37,6 +48,14 @@ var metricView = {
     return bottoms;
   },
 
+  /**
+   * Fixes overlapping points on a bar graph
+   * @param {object} $graph jQuery object of the graph containing the points
+   * @param {string} schoolAverageFormatted Text of the graph's school point
+   * @param {string} nationalAverageFormatted Text of the graph's school point
+   * @param {object} $schoolPoint jQuery object of the graph's school point
+   * @param {object} $nationalPoint jQuery object of the graph's national point
+   */
   fixOverlap: function( $graph, schoolAverageFormatted, nationalAverageFormatted, $schoolPoint, $nationalPoint ) {
     var schoolPointHeight = $schoolPoint.find( '.bar-graph_label' ).height(),
         schoolPointTop = $schoolPoint.position().top,
@@ -62,6 +81,13 @@ var metricView = {
     }
   },
 
+  /**
+   * Formats a raw number for display
+   * @param {string} valueType Type of value to format (percent or currency)
+   * @param {number|string} rawValue Value to format
+   * @returns {boolean|string} False if rawValue is not a number, a formatted
+   * string otherwise
+   */
   formatValue: function( valueType, rawValue ) {
     var formattedValue = '';
     if ( isNaN( rawValue ) ) {
@@ -76,6 +102,12 @@ var metricView = {
     return formattedValue;
   },
 
+  /**
+   * Sets text of each point on a bar graph (or a class if a point is missing)
+   * @param {object} $graph jQuery object of the graph containing the points
+   * @param {string} schoolAverageFormatted Text of the graph's school point
+   * @param {string} nationalAverageFormatted Text of the graph's school point
+   */
   setGraphValues: function( $graph, schoolAverageFormatted, nationalAverageFormatted ) {
     var $schoolPointNumber = $graph.find( '.bar-graph_point__you .bar-graph_number' ),
         $nationalPointNumber = $graph.find( '.bar-graph_point__average .bar-graph_number' );
@@ -91,6 +123,14 @@ var metricView = {
     }
   },
 
+  /**
+   * Sets the position of each point on a bar graph
+   * @param {object} $graph jQuery object of the graph containing the points
+   * @param {number} schoolAverage Value reported by the school
+   * @param {number} nationalAverage Average national value
+   * @param {object} $schoolPoint jQuery object of the graph's school point
+   * @param {object} $nationalPoint jQuery object of the graph's national point
+   */
   setGraphPositions: function( $graph, schoolAverage, nationalAverage, $schoolPoint, $nationalPoint ) {
     var graphHeight = $graph.height(),
         bottoms = this.calculateBottoms( $graph, graphHeight, schoolAverage, nationalAverage );
@@ -106,14 +146,3 @@ var metricView = {
 };
 
 module.exports = metricView;
-
-/* To do
-  - Handle identical values: hide the national average line, change the alert
-  - Handle missing school data: hide the school line, change the alert
-  - Handle missing national data? Can that ever happen?
-  - Figure out salary graph scale
-  - metricView.setAlert (call right after setGraph in init)
-  - Handle no JS?
-  - Refactor all graph vars into an object: getGraphVariables?
-  - iped=239169 has crazy high salary and no grad rate!
-*/

--- a/src/disclosures/js/views/metric-view.js
+++ b/src/disclosures/js/views/metric-view.js
@@ -123,8 +123,9 @@ var metricView = {
         bottoms = this.calculateBottoms( minValue, maxValue, graphHeight, schoolAverage, nationalAverage );
     // A few outlier schools have very high average salaries, so we need to
     // prevent those values from falling off the top of the graph
-    if ( bottoms.school > graphHeight ) {
+    if ( schoolAverage > maxValue ) {
       bottoms.school = graphHeight;
+      $graph.addClass( 'bar-graph__high-point' );
     }
     $schoolPoint.css( 'bottom', bottoms.school );
     $nationalPoint.css( 'bottom', bottoms.national );

--- a/test/functional/dd-school-data-spec.js
+++ b/test/functional/dd-school-data-spec.js
@@ -17,4 +17,30 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
      expect( page.totalProgramDebt.getText() ).toEqual( '29000' );
   } );
 
+  it( 'should graph graudation rates', function() {
+    page.confirmVerification();
+    expect( page.schoolGradRatePoint.getCssValue( 'bottom' ) ).toEqual( '60.7px' );
+    expect( page.schoolGradRateValue.getText() ).toEqual( '37%' );
+    expect( page.nationalGradRatePoint.getCssValue( 'bottom' ) ).toEqual( '57.323px' );
+    // Checking for z-index lets us know an overlap is being handled correctly
+    expect( page.nationalGradRatePoint.getCssValue( 'z-index' ) ).toEqual( '100' );
+    expect( page.nationalGradRateValue.getText() ).toEqual( '34%' );
+  } );
+
+  it( 'should graph average salary', function() {
+    page.confirmVerification();
+    expect( page.schoolSalaryPoint.getCssValue( 'bottom' ) ).toEqual( '45.3px' );
+    expect( page.schoolSalaryValue.getText() ).toEqual( '$23,000' );
+    expect( page.nationalSalaryPoint.getCssValue( 'bottom' ) ).toEqual( '54.188px' );
+    expect( page.nationalSalaryValue.getText() ).toEqual( '$31,080' );
+  } );
+
+  it( 'should graph loan default rates', function() {
+    page.confirmVerification();
+    expect( page.schoolDefaultRatePoint.getCssValue( 'bottom' ) ).toEqual( '80.5px' );
+    expect( page.schoolDefaultRateValue.getText() ).toEqual( '55%' );
+    expect( page.nationalDefaultRatePoint.getCssValue( 'bottom' ) ).toEqual( '35.07px' );
+    expect( page.nationalDefaultRateValue.getText() ).toEqual( '14%' );
+  } );
+
 } );

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -389,6 +389,66 @@ settlementAidOfferPage.prototype = Object.create({}, {
         return element( by.css( '.evaluate' ) );
       }
     },
+    schoolGradRatePoint: {
+      get: function() {
+        return element( by.css( '.metric.graduation-rate .bar-graph_point__you' ) );
+      }
+    },
+    schoolGradRateValue: {
+      get: function() {
+        return element( by.css( '.metric.graduation-rate .bar-graph_point__you .bar-graph_value' ) );
+      }
+    },
+    nationalGradRatePoint: {
+      get: function() {
+        return element( by.css( '.metric.graduation-rate .bar-graph_point__average' ) );
+      }
+    },
+    nationalGradRateValue: {
+      get: function() {
+        return element( by.css( '.metric.graduation-rate .bar-graph_point__average .bar-graph_value' ) );
+      }
+    },
+    schoolSalaryPoint: {
+      get: function() {
+        return element( by.css( '.metric.average-salary .bar-graph_point__you' ) );
+      }
+    },
+    schoolSalaryValue: {
+      get: function() {
+        return element( by.css( '.metric.average-salary .bar-graph_point__you .bar-graph_value' ) );
+      }
+    },
+    nationalSalaryPoint: {
+      get: function() {
+        return element( by.css( '.metric.average-salary .bar-graph_point__average' ) );
+      }
+    },
+    nationalSalaryValue: {
+      get: function() {
+        return element( by.css( '.metric.average-salary .bar-graph_point__average .bar-graph_value' ) );
+      }
+    },
+    schoolDefaultRatePoint: {
+      get: function() {
+        return element( by.css( '.metric.loan-default-rates .bar-graph_point__you' ) );
+      }
+    },
+    schoolDefaultRateValue: {
+      get: function() {
+        return element( by.css( '.metric.loan-default-rates .bar-graph_point__you .bar-graph_value' ) );
+      }
+    },
+    nationalDefaultRatePoint: {
+      get: function() {
+        return element( by.css( '.metric.loan-default-rates .bar-graph_point__average' ) );
+      }
+    },
+    nationalDefaultRateValue: {
+      get: function() {
+        return element( by.css( '.metric.loan-default-rates .bar-graph_point__average .bar-graph_value' ) );
+      }
+    },
     monthlyRent: {
       get: function() {
         return element( by.id( 'expenses__rent' ) );

--- a/test/js-unit/metric-view-spec.js
+++ b/test/js-unit/metric-view-spec.js
@@ -1,0 +1,65 @@
+var chai = require( 'chai' );
+var expect = chai.expect;
+var metricView = require( '../../src/disclosures/js/views/metric-view' );
+
+describe( 'metric-view', function() {
+
+  it( 'calculates graph point bottom positions for percent data', function() {
+    var minValue = 0,
+        maxValue = 1,
+        graphHeight = 130,
+        schoolValue = 0.55,
+        nationalValue = 0.137,
+        bottoms = metricView.calculateBottoms( minValue, maxValue, graphHeight, schoolValue, nationalValue );
+    expect( bottoms.school ).to.equal( 80.5 );
+    expect( bottoms.national ).to.equal( 35.07 );
+  });
+
+  it( 'calculates graph point bottom positions for salary data', function() {
+    var minValue = 0,
+        maxValue = 100000,
+        graphHeight = 130,
+        schoolValue = 23000,
+        nationalValue = 31080,
+        bottoms = metricView.calculateBottoms( minValue, maxValue, graphHeight, schoolValue, nationalValue );
+    expect( bottoms.school ).to.equal( 45.3 );
+    expect( bottoms.national ).to.equal( 54.188 );
+  });
+
+  it( 'formats percents', function() {
+    var valueType = 'decimal-percent',
+        rawValue = 0.137,
+        formattedValue = metricView.formatValue( valueType, rawValue );
+    expect( formattedValue ).to.equal( '14%' );
+  });
+
+  it( 'formats currencies', function() {
+    var valueType = 'currency',
+        rawValue = 31080,
+        formattedValue = metricView.formatValue( valueType, rawValue );
+    expect( formattedValue ).to.equal( '$31,080' );
+  });
+
+  it( 'does not try to format values that cannot be parsed into numbers', function() {
+    var valueType = 'decimal-percent',
+        rawValues = {
+          'string': 'None',
+          'empty': '',
+          'space': ' ',
+          'null': null,
+          'undefined': undefined
+        },
+        formattedValues = {};
+    for ( var valueType in rawValues ) {
+      var rawValue = rawValues[valueType],
+          parsedValue = parseFloat( rawValue );
+      formattedValues[valueType] = metricView.formatValue( valueType, parsedValue )
+    }
+    expect( formattedValues['string'] ).to.equal( false );
+    expect( formattedValues['empty'] ).to.equal( false );
+    expect( formattedValues['space'] ).to.equal( false );
+    expect( formattedValues['null'] ).to.equal( false );
+    expect( formattedValues['undefined'] ).to.equal( false );
+  });
+
+});


### PR DESCRIPTION
Bar graphs that show real data (and handle all the edge cases that come with showing real data)
## Additions
- `data` attributes in bar graph HTML to set graph parameters
- `metric-view` to handle setting all the graphs
- Unit tests
- Functional tests
- Top label ("$100,000") in the salary graph
## Changes
- "Your school" graph labels now say "This school"
## Testing
- To test, pull in the `bar-graphs` branch and run `gulp`. Fire up the app in standalone or UnityBox as normal.
- Try testing with our usual example school, good old `iped=408039`. The graphs should look like the screen shots below.
- Try testing with any other schools you like. The graphs should show the values in `window.schoolData` and `window.nationalData`. A particularly good outlier is `iped=239169`: it has no reported graduation rate, a 0% default rate, and a $250,000 average salary! In that example, the school point in the graduation graph and the "$100,000" label in the salary graph should both be gone.
- If you test other schools, note that this PR **does not** include getting the alerts below each graph working, so don't worry about those for now.
- If anyone knows of a school where the school's average is exactly the same as the national average, that graph should only show the school point.
- I've tested this in IE8/Win7, IE9/Win7, IE10/Win7, IE11/Win7, Firefox/Win7, Chrome/Mac, Safari/Mac, Mobile Safari/iPhone6. Everything seems to be looking good except for IE8, where an unrelated JS error is still preventing an scripts from running.
## Review
- @marteki 
- @mistergone: How's all the JS and testing look?
- @higs4281 
- @ascott1: Totally optional, but if you want to give the JS and testing another look, let me know if you see anything that needs improvement.
## Screenshots

(Not all the screen sizes, but you get the idea)

| 600px and below | 1230 px and above |
| --- | --- |
| ![graphs-small](https://cloud.githubusercontent.com/assets/1862695/13132376/170c35b6-d5c0-11e5-8549-366eb85e0f97.png) | ![graphs-large](https://cloud.githubusercontent.com/assets/1862695/13132378/1b3df188-d5c0-11e5-9ac8-78eaeae7ba2e.png) |
## Todos
- Add functional test for edge case schools
- Change "This school" labels to "This program" in graphs where program data is used
- Update project documentation
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Visually tested in supported browsers and devices 
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
