### PR TITLE
deliver school median salary value consistently

### DIFF
--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -200,7 +200,7 @@ class School(models.Model):
             'highestDegree': self.get_highest_degree(),
             'indicatorGroup': jdata['INDICATORGROUP'],
             'KBYOSS': self.KBYOSS,
-            'medianAnnualPay': str(self.median_annual_pay),
+            'medianAnnualPay': self.median_annual_pay,
             'medianMonthlyDebt': "{0}".format(self.median_monthly_debt),
             'medianTotalDebt': "{0}".format(self.median_total_debt),
             'nicknames': ", ".join([nick.nickname for nick in self.nickname_set.all()]),


### PR DESCRIPTION
Makes salary value consistent when there is no value; API will return either a number or null, which will avoid NaN.
## Review
- @mistergone @niqjohnson @marteki any or all; a minor change but should cut down oddities.
## Screenshots

<img width="414" alt="null_value" src="https://cloud.githubusercontent.com/assets/515885/13150272/0f1b823a-d633-11e5-93fa-7e50f5b3bb4c.png">
