### PR TITLE
Fix to correct monthly loan payment and lifetime loan payment values

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   "dependencies": {
     "format-usd": "^0.2.0",
     "number-to-words": "^1.2.1",
-    "student-debt-calc": "2.2.1"
+    "student-debt-calc": "2.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   "dependencies": {
     "format-usd": "^0.2.0",
     "number-to-words": "^1.2.1",
-    "student-debt-calc": "2.1.0"
+    "student-debt-calc": "2.2.1"
   }
 }

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -1512,7 +1512,7 @@
                                 data-financial="yearsAttending">[XX]</span>
                                 years after interest equals $<span
                                 id="future_total-debt"
-                                data-financial="totalDebt">[XX]</span>.
+                                data-financial="loanLifetime">[XX]</span>.
                             </p>
                             <p>
                                 Some students find themselves struggling to

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -1635,7 +1635,7 @@
                                             $
                                         </span>
                                         <span class="line-item_amount"
-                                        data-financial="totalDebt"
+                                        data-financial="loanLifetime"
                                         id="summary_total-repayment"></span>
                                     </div>
                                 </div>

--- a/src/disclosures/js/models/financial-model.js
+++ b/src/disclosures/js/models/financial-model.js
@@ -62,8 +62,12 @@ var financialModel = {
    * Rounds values for which we do not want to display decimals
    */
   roundValues: function() {
-    var model = financialModel.values;
-    model.totalDebt = Math.round( model.totalDebt );
+    var model = financialModel.values,
+        roundedKeys = [ 'totalDebt', 'loanMonthly', 'loanLifetime' ];
+    for (var x = 0; x < roundedKeys.length; x++ ) {
+      var key = roundedKeys[x];
+      model[key] = Math.round( model[key] );
+    }
   }
 };
 module.exports = financialModel;

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -119,8 +119,6 @@ var financialView = {
     this.updatePercentages( values, $percents );
     this.updateLeftovers( values, $leftovers );
     this.updatePrivateLoans( values, $privateLoans );
-    console.log( values );
-    window.data = values;
   },
 
   /**

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -120,6 +120,7 @@ var financialView = {
     this.updateLeftovers( values, $leftovers );
     this.updatePrivateLoans( values, $privateLoans );
     console.log( values );
+    window.data = values;
   },
 
   /**

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -77,7 +77,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when the housing and meals are modified', function() {
     page.confirmVerification();
     page.setHousingMealsCosts( 2000 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     expect( page.totalCostOfAttendance.getText() ).toEqual( '42626' );
     expect( page.studentTotalCost.getText() ).toEqual( '31026' );
     expect( page.remainingCostFinal.getText() ).toEqual( '-1474' );
@@ -86,7 +86,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when the transportation is modified', function() {
     page.confirmVerification();
     page.setTransportationCosts( 400 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     expect( page.totalCostOfAttendance.getText() ).toEqual( '43526' );
     expect( page.studentTotalCost.getText() ).toEqual( '31926' );
     expect( page.remainingCostFinal.getText() ).toEqual( '-574' );
@@ -95,7 +95,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when the books and supplies are modified', function() {
     page.confirmVerification();
     page.setBooksSuppliesCosts( 750 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     expect( page.totalCostOfAttendance.getText() ).toEqual( '43726' );
     expect( page.studentTotalCost.getText() ).toEqual( '32126' );
     expect( page.remainingCostFinal.getText() ).toEqual( '-374' );
@@ -104,7 +104,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when the other education costs are modified', function() {
     page.confirmVerification();
     page.setOtherEducationCosts( 1000 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     expect( page.totalCostOfAttendance.getText() ).toEqual( '44126' );
     expect( page.studentTotalCost.getText() ).toEqual( '32526' );
     expect( page.remainingCostFinal.getText() ).toEqual( '26' );
@@ -117,7 +117,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when the Federal Pell Grants are modified within the limits', function() {
     page.confirmVerification();
     page.setFederalPellGrants( 5500 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     expect( page.totalGrantsScholarships.getText() ).toEqual( '15600' );
     expect( page.studentTotalCost.getText() ).toEqual( '28026' );
     expect( page.remainingCostFinal.getText() ).toEqual( '-4474' );
@@ -126,12 +126,12 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when the Federal Pell Grants are modified above the Federal limits', function() {
     page.confirmVerification();
     page.setFederalPellGrants( 10000 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     // TODO: expect student is informed about the Pell Grant cap
     // expect( EC.visibilityOf( page.pellGrantCapWarning ) );
-    expect( page.totalGrantsScholarships.getText() ).toEqual( '15830' );
-    expect( page.studentTotalCost.getText() ).toEqual( '27796' );
-    expect( page.remainingCostFinal.getText() ).toEqual( '-4704' );
+    expect( page.totalGrantsScholarships.getText() ).toEqual( '15915' );
+    expect( page.studentTotalCost.getText() ).toEqual( '27711' );
+    expect( page.remainingCostFinal.getText() ).toEqual( '-4789' );
   } );
 
   // TODO: Uncomment this once it's built in the JS code
@@ -183,7 +183,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when the other grants and scholarships are modified', function() {
     page.confirmVerification();
     page.setOtherGrantsScholarships( 1000 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     expect( page.totalGrantsScholarships.getText() ).toEqual( '12500' );
     expect( page.studentTotalCost.getText() ).toEqual( '31126' );
     expect( page.remainingCostFinal.getText() ).toEqual( '-1374' );
@@ -232,7 +232,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when the cash a student will personally provide is modified', function() {
     page.confirmVerification();
     page.setStudentContribution( 1500 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     expect( page.totalContributions.getText() ).toEqual( '19500' );
     expect( page.remainingCostFinal.getText() ).toEqual( '-1974' );
   } );
@@ -241,7 +241,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when the cash a student\'s family will provide is modified', function() {
     page.confirmVerification();
     page.setFamilyContribution( 4000 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     expect( page.totalContributions.getText() ).toEqual( '7000' );
     expect( page.remainingCostFinal.getText() ).toEqual( '10526' );
   } );
@@ -249,7 +249,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when the work study earnings are modified within the allowed limit', function() {
     page.confirmVerification();
     page.setWorkStudyContribution( 2000 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     expect( page.totalContributions.getText() ).toEqual( '17000' );
     expect( page.remainingCostFinal.getText() ).toEqual( '526' );
   } );
@@ -284,7 +284,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when the federal Perkins loans are modified within the allowed limit', function() {
     page.confirmVerification();
     page.setFederalPerkinsLoans( 2000 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     expect( page.totalFederalLoans.getText() ).toEqual( '7500' );
     expect( page.totalDebt.getText() ).toEqual( '13500' );
     expect( page.remainingCostFinal.getText() ).toEqual( '526' );
@@ -297,7 +297,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when the federal Perkins loans are modified above the allowed limit', function() {
     page.confirmVerification();
     page.setFederalPerkinsLoans( 15000 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     // TODO: expect student is informed about the Perkins loan cap
     // expect( EC.visibilityOf( page.perkinsLoanCapWarning ) );
     // expect( page.totalProgramDebt.getText() ).toEqual( '3000' );
@@ -313,7 +313,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when the federal subsidized loans are modified within the allowed limit', function() {
     page.confirmVerification();
     page.setSubsidizedLoans( 3000 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     expect( page.totalFederalLoans.getText() ).toEqual( '8000' );
     expect( page.totalDebt.getText() ).toEqual( '14000' );
     expect( page.remainingCostFinal.getText() ).toEqual( '26' );
@@ -326,7 +326,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when the federal subsidized loans are modified above the allowed limit', function() {
     page.confirmVerification();
     page.setSubsidizedLoans( 15000 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     // TODO: expect student is informed about the subsidized loan cap
     // expect( EC.visibilityOf( page.subsidizedLoanCapWarning ) );
     expect( page.totalFederalLoans.getText() ).toEqual( '8500' );
@@ -341,7 +341,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when the federal unsubsidized loans are modified within the allowed limit', function() {
     page.confirmVerification();
     page.setUnsubsidizedLoans( 3000 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     expect( page.totalFederalLoans.getText() ).toEqual( '9500' );
     expect( page.totalDebt.getText() ).toEqual( '15500' );
     expect( page.remainingCostFinal.getText() ).toEqual( '-1474' );
@@ -354,7 +354,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when the federal unsubsidized loans are modified above the allowed limit', function() {
     page.confirmVerification();
     page.setUnsubsidizedLoans( 15000 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     // TODO: expect student is informed about the unsubsidized loan cap
     // expect( EC.visibilityOf( page.unsussidizedLoanCapWarning ) );
     expect( page.totalFederalLoans.getText() ).toEqual( '12500' );
@@ -413,11 +413,11 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   it( 'should properly update when a private loan is modified', function() {
     page.confirmVerification();
     page.setPrivateLoanAmount( 4000 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     page.setPrivateLoanInterestRate( 4.55 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     page.setPrivateLoanFees( 1 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     expect( page.privateLoanInterestRate.getAttribute('value') ).toBeGreaterThan( 0 );
     expect( page.totalPrivateLoansPaymentPlans.getText() ).toEqual( '7000' );
     expect( page.totalDebt.getText() ).toEqual( '15500' );
@@ -475,7 +475,7 @@ it( 'should properly update when more than one private loans is modified', funct
     browser.sleep( 1000 );
     page.confirmVerification();
     expect( page.totalProgramDebt.getText() ).toEqual( '29000' );
-    expect( page.totalRepayment.getText() ).toEqual( '30989' );
+    expect( page.totalRepayment.getText() ).toEqual( '38897' );
   } );
 
   it( 'should update total borrowing and verbiage when program length is changed', function() {
@@ -490,13 +490,13 @@ it( 'should properly update when more than one private loans is modified', funct
     browser.sleep( 1000 );
     page.confirmVerification();
     page.setFamilyContribution( 10000 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     browser.wait( EC.visibilityOf(page.futurePositiveRemainingCost ), 8000 );
     // TODO: Add expectation about invisibility of negative remaining cost
     expect( page.futurePositiveRemainingCost.getText() ).toEqual( '4526' );
     expect( page.futureTotalLoans.getText() ).toEqual( '14500' );
     expect( page.futureYearsAttending.getText() ).toEqual( 'two' );
-    expect( page.futureTotalDebt.getText() ).toEqual( '30989' );
+    expect( page.futureTotalDebt.getText() ).toEqual( '38897' );
   } );
 
   it( 'should properly describe a future based on covering more of the cost of college that is needed', function() {
@@ -507,19 +507,19 @@ it( 'should properly update when more than one private loans is modified', funct
     expect( page.futurePositiveRemainingCost.getText() ).toEqual( '-474' );
     expect( page.futureTotalLoans.getText() ).toEqual( '14500' );
     expect( page.futureYearsAttending.getText() ).toEqual( 'two' );
-    expect( page.futureTotalDebt.getText() ).toEqual( '30989' );
+    expect( page.futureTotalDebt.getText() ).toEqual( '38897' );
   } );
 
   it( 'should properly describe a future based on covering exactly the cost of college that is needed', function() {
     browser.sleep( 1000 );
     page.confirmVerification();
     page.setFamilyContribution( 14526 );
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     // TODO: Add expectation about invisibility of positive remaining cost
     // TODO: Add expectation about invisibility of negative remaining cost
     expect( page.futureTotalLoans.getText() ).toEqual( '14500' );
     expect( page.futureYearsAttending.getText() ).toEqual( 'two' );
-    expect( page.futureTotalDebt.getText() ).toEqual( '30989' );
+    expect( page.futureTotalDebt.getText() ).toEqual( '38897' );
   } );
 
   // *** Step 2: Evaluate your offer ***
@@ -576,7 +576,7 @@ it( 'should properly update when more than one private loans is modified', funct
   it( 'should link to the school website in a new tab', function() {
     page.confirmVerification();
     page.followSchoolLink();
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     browser.getAllWindowHandles()
       .then( function ( handles ) {
         expect( handles.length ).toBe( 2 );
@@ -587,7 +587,7 @@ it( 'should properly update when more than one private loans is modified', funct
           } )
           .then( function () {
             browser.close();
-            browser.sleep( 600 );
+            browser.sleep( 750 );
             browser.switchTo().window( handles[0] );
           } );
       } );
@@ -596,7 +596,7 @@ it( 'should properly update when more than one private loans is modified', funct
   it( 'should link to the correct College Scorecard search in a new tab', function() {
     page.confirmVerification();
     page.followScorecardLink();
-    browser.sleep( 600 );
+    browser.sleep( 750 );
     browser.getAllWindowHandles()
       .then( function ( handles ) {
         expect( handles.length ).toBe( 2 );
@@ -609,7 +609,7 @@ it( 'should properly update when more than one private loans is modified', funct
           } )
           .then( function () {
             browser.close();
-            browser.sleep( 600 );
+            browser.sleep( 750 );
             browser.switchTo().window( handles[0] );
           } );
       } );


### PR DESCRIPTION
The numbers for "Total cost of repayment with interest" are supposed to represent the total cost of the loans over the repayment period. After a few updates to `student-debt-calc`, I have the values working and live in `college-costs`.
## Additions
- Lifetime loan cost is rounded after calculation, before the view is updated.
## Changes
- Changed the DOM so that the correct variable (`loanLifetime`) is used for total cost of repayment.
- Updated version of `student-debt-calc`
- Updated functional tests to sleep 750 ms (up from 600 ms). This seemed to help with some false positives (or negatives?) where functional tests would fail occasionally for no apparent reason. I assume sometimes the sleep wasn't enough for the calculations to be done and the view updated.
- Updated functional tests to check for correct lifetime loan values.
## Testing
- Pull it down, be sure to run `npm install` to get updates to `student-debt-calc`, and then feel free to try it and run functional tests.
- Six functional tests for Step 2 are failing (as expected)
## Review
- @niqjohnson @marteki @higs4281 
## Checklist
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [ ] New functions include new tests
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged
- [ ] Visually tested in supported browsers and devices 
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
## Animated GIF

Putting out fires is like...

![moss-fire](https://cloud.githubusercontent.com/assets/1490703/13190919/405f62ca-d72e-11e5-98e8-c321c609f8c4.gif)
