### PR TITLE
Grad rate

### DIFF
--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -2313,7 +2313,7 @@
                             <p>
                                 <a href="http://www.consumer.ftc.gov/articles/0395-choosing-college-questions-ask">Ask if credits from your school transfer
                                 </a> to degrees earned at other schools.
-                                <span id="option_completion-rate" data-financial="completionRate"
+                                <span id="option_completion-rate" data-financial="gradRate"
                                 data-percentage_value="true">[XX]</span>% of 
                                 students who start at this school finish here.
                                 In the case you decide to finish your

--- a/src/disclosures/js/dispatchers/get-school-values.js
+++ b/src/disclosures/js/dispatchers/get-school-values.js
@@ -10,7 +10,6 @@ var getSchoolValues = {
     values.programLength = this.getProgramLength();
     values.yearsAttending = numberToWords.toWords( values.programLength );
     values.gradRate = this.getGradRate();
-    values.completionRate = this.getCompletionRate();
     values.medianSchoolDebt = this.getMedianSchoolDebt();
     values.defaultRate = this.getDefaultRate();
     values.medianSalary = this.getMedianSalary();
@@ -52,24 +51,15 @@ var getSchoolValues = {
     var gradRate = '';
 
     if ( window.hasOwnProperty( 'schoolData' ) ) {
-      gradRate = window.schoolData.gradRate || '';
+      gradRate = window.schoolData.gradRate;
     }
-
-    return gradRate;
-  },
-
-  getCompletionRate: function() {
-    var completionRate = '';
-
     if ( window.hasOwnProperty( 'programData' ) ) {
-      if ( window.programData.completionRate === 'None' ) {
-        completionRate = '';
-      } else {
-        completionRate = window.programData.completionRate || '';
+      if ( window.programData.completionRate !== 'None' ) {
+        gradRate = window.programData.completionRate;
       }
     }
 
-    return completionRate;
+    return gradRate;
   },
 
   getMedianSchoolDebt: function() {

--- a/test/functional/dd-school-data-spec.js
+++ b/test/functional/dd-school-data-spec.js
@@ -20,7 +20,7 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
   it( 'should dynamically display the completion rate if it\'s available', function() {
      browser.sleep( 600 );
      page.confirmVerification();
-     expect( page.completionRate.getText() ).toEqual( '0' );
+     expect( page.completionRate.getText() ).toEqual( '37' );
   } );
 
   it( 'should dynamically display the median school or program debt if it\'s available', function() {


### PR DESCRIPTION
Fixes the values pulled into the financial model for graduation rate.

`completionRate` is the term used at the program level, while `gradRate` is used at the school level. They are pointing at the same type of metric.
## Testing

Six functional tests failing, as on `master`.
## Review
- @niqjohnson 
