### PR TITLE
Grad rate fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## Unreleased
+
+### Changed
+- Use school-level graduation rate if the program-level rate is blank or missing
+
 ## 2.0.0
 ### Added/updated
 - New url for handling querystring offer data

--- a/src/disclosures/js/dispatchers/get-school-values.js
+++ b/src/disclosures/js/dispatchers/get-school-values.js
@@ -54,7 +54,8 @@ var getSchoolValues = {
       gradRate = window.schoolData.gradRate;
     }
     if ( window.hasOwnProperty( 'programData' ) ) {
-      if ( window.programData.completionRate !== 'None' ) {
+      if ( window.programData.completionRate &&
+          window.programData.completionRate !== 'None' ) {
         gradRate = window.programData.completionRate;
       }
     }


### PR DESCRIPTION
Small fix for #114 that uses the school-level graduation rate if the program-level rate is blank or missing
## Changes
- `getSchoolValues.getGradRate` now checks for a truthy program-level grad rate
## Testing
- To test, pull in the `grad-rate-fix` branch and run `gulp`. Fire up the app in standalone or UnityBox as normal.
- Try testing with any non-settlement school with or without a `pid` in the URL, like `iped=153384`. In the `master` branch, the graduation rate graph will show no school data. In this branch, the graph will show the school-level graduation rate.
## Review
- @marteki 
- @mistergone 
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] Visually tested in supported browsers and devices 
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
