### PR TITLE
add API endpoints for national statistics and verifications

### DIFF
--- a/paying_for_college/disclosures/scripts/nat_stats.py
+++ b/paying_for_college/disclosures/scripts/nat_stats.py
@@ -1,6 +1,10 @@
 import json
 import os
 from subprocess import call
+try:
+    from collections import OrderedDict
+except:  # pragma: no cover
+    from ordereddict import OrderedDict
 
 from unipath import Path
 import requests
@@ -77,12 +81,12 @@ def get_prepped_stats(program_length=None):
         default_rate = 0
         default_rate_low = 0
         default_rate_high = 0
-    national_stats_for_page = {
+    natstats = {
+        'completionRateMedian': full_data['completion_rate']['median'],
+        'completionRateMedianLow': full_data['completion_rate']['average_range'][0],
         'loanDefaultRate': default_rate,
         'loanDefaultRateLow': default_rate_low,
         'loanDefaultRateHigh': default_rate_high,
-        'completionRateMedian': full_data['completion_rate']['median'],
-        'completionRateMedianLow': full_data['completion_rate']['average_range'][0],
         'completionRateMedianHigh': full_data['completion_rate']['average_range'][1],
         'earningsMedian': full_data['median_earnings']['median'],
         'earningsMedianLow': full_data['median_earnings']['average_range'][0],
@@ -92,6 +96,9 @@ def get_prepped_stats(program_length=None):
         'retentionRateMedian': full_data['retention_rate']['median'],
         'netPriceMedian': full_data['net_price']['median']
     }
+    national_stats_for_page = OrderedDict()
+    for key in sorted(natstats.keys()):
+        national_stats_for_page[key] = natstats[key]
     if program_length:
         national_stats_for_page['completionRateMedian'] = full_data[LENGTH_MAP['completion'][program_length]]['median']
         national_stats_for_page['completionRateMedianLow'] = full_data[LENGTH_MAP['completion'][program_length]]['average_range'][0]

--- a/paying_for_college/disclosures/urls.py
+++ b/paying_for_college/disclosures/urls.py
@@ -32,7 +32,7 @@ urlpatterns = [
         ConstantsRepresentation.as_view(),
         name='constants-json'),
 
-    url(r'^api/national-stats/(\d+)/$',
+    url(r'^api/national-stats/([^/]+)/$',
         StatsRepresentation.as_view(),
         name='national-stats-json'),
 

--- a/paying_for_college/disclosures/urls.py
+++ b/paying_for_college/disclosures/urls.py
@@ -32,6 +32,10 @@ urlpatterns = [
         ConstantsRepresentation.as_view(),
         name='constants-json'),
 
+    url(r'^api/national-stats/(\d+)/$',
+        StatsRepresentation.as_view(),
+        name='national-stats-json'),
+
     url(r'^api/verify/$',
         VerifyView.as_view(),
         name='verify'),

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -121,7 +121,7 @@ class ConstantCap(models.Model):
 
 
 class Contact(models.Model):
-    """school email account to which we send confirmations"""
+    """school endpoint or email to which we send confirmations"""
     contact = models.CharField(max_length=255, help_text="EMAIL", blank=True)
     endpoint = models.CharField(max_length=255, blank=True)
     name = models.CharField(max_length=255, blank=True)


### PR DESCRIPTION
API additions to maximize http calls
## Additions
- endpoint for /national-stats/ and /verify/
## Changes
- changes schoolDI_programCode combination to use underscores. This pattern is used in the /program/ and /national-stats/ endpoints. 
## Testing

 Try these endpoints:
- understanding-your-financial-aid-offer/api/national-stats/408039_981/
- understanding-your-financial-aid-offer/api/program/408039_981/

Also, the /verify/ endpoint will accept POST requests with verification data. Should return 200.
## Review
- @mistergone @niqjohnson @marteki 
