### PR TITLE
Display debt burden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Changed url for "about this tool" page to /about-this-tool/
 - Added "About this tool" section and content
 - Updated content to pre-clearance version for settlement students
-
+- Added debt burden calculations and notifications
 
 ## 2.0.0
 ### Added/updated

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -2173,8 +2173,10 @@
                                         </div>
                                         <div
                                         class="debt-burden_projection-value">
-                                            $XX,XXX / yr.<br>
-                                            $X,XXX / mo.
+                                            <span data-debt-burden="annual-salary"></span>
+                                            / yr.<br>
+                                            <span data-debt-burden="monthly-salary"></span>
+                                            / mo.
                                         </div>
                                     </div>
                                     <div class="debt-burden_projection">
@@ -2184,14 +2186,15 @@
                                         </div>
                                         <div
                                         class="debt-burden_projection-value">
-                                            $XXX / mo.
+                                            <span data-debt-burden="monthly-payment"></span>
+                                            / mo.
                                         </div>
                                     </div>
                                     <div class="debt-equation u-clearfix">
                                         <div class="debt-equation_part
                                         debt-equation_part__loan">
                                             <div class="debt-equation_number">
-                                                $XXX
+                                                <span data-debt-burden="monthly-payment"></span>
                                             </div>
                                             <div class="debt-equation_label">
                                                 loan payment
@@ -2203,7 +2206,7 @@
                                         <div class="debt-equation_part
                                         debt-equation_part__income">
                                             <div class="debt-equation_number">
-                                                $X,XXX
+                                                <span data-debt-burden="monthly-salary"></span>
                                             </div>
                                             <div class="debt-equation_label">
                                                 monthly salary
@@ -2215,7 +2218,7 @@
                                         <div class="debt-equation_part
                                         debt-equation_part__percent">
                                             <div class="debt-equation_number">
-                                                XX%
+                                                <span data-debt-burden="debt-burden"></span>
                                             </div>
                                             <div class="debt-equation_label">
                                                 of your income

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -6,6 +6,7 @@ var stringToNum = require( '../utils/handle-string-input' );
 var formatUSD = require( 'format-usd' );
 var numberToWords = require( 'number-to-words' );
 var linksView = require( '../views/links-view' );
+var metricView = require( '../views/metric-view' );
 
 var financialView = {
   $elements: $( '[data-financial]' ),
@@ -135,6 +136,7 @@ var financialView = {
     this.updateLeftovers( values, $leftovers );
     this.updatePrivateLoans( values, $privateLoans );
     this.updateRemainingCostContent();
+    metricView.updateDebtBurdenDisplay( values, window.nationalData );
   },
 
   /**

--- a/src/disclosures/js/views/metric-view.js
+++ b/src/disclosures/js/views/metric-view.js
@@ -236,7 +236,7 @@ var metricView = {
   updateDebtBurdenDisplay: function( schoolValues, nationalValues ) {
     var annualSalary = Number( schoolValues.medianSalary ) || Number( nationalValues.earningsMedian ),
         monthlySalary = this.calculateMonthlySalary( annualSalary ),
-        monthlyLoanPayment = schoolValues.loanMonthly,
+        monthlyLoanPayment = schoolValues.loanMonthly || 0,
         debtBurden = this.calculateDebtBurden( monthlyLoanPayment, monthlySalary ),
         annualSalaryFormatted = this.formatValue( 'currency', annualSalary ),
         monthlySalaryFormatted = this.formatValue( 'currency', monthlySalary ),

--- a/src/disclosures/js/views/metric-view.js
+++ b/src/disclosures/js/views/metric-view.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var schoolModel = require( '../models/school-model' );
 var getModelValues = require( '../dispatchers/get-model-values' );
 var formatUSD = require( 'format-usd' );
 
@@ -11,7 +10,7 @@ var metricView = {
    */
   init: function() {
     var $graphs = $( '.bar-graph' ),
-        schoolValues = schoolModel.values,
+        schoolValues = getModelValues.financial(),
         nationalValues = window.nationalData || {};
     this.initGraphs( $graphs, schoolValues, nationalValues );
     // updateDebtBurdenDisplay is called in financialView.updateView, not here,
@@ -170,7 +169,9 @@ var metricView = {
    * @param {string} notificationClasses Classes to add to the notification
    */
   setNotificationClasses: function( $notification, notificationClasses ) {
-    $notification.addClass( notificationClasses );
+    $notification
+      .attr( 'class', 'metric_notification' )
+      .addClass( notificationClasses );
   },
 
   /**
@@ -235,8 +236,7 @@ var metricView = {
   updateDebtBurdenDisplay: function( schoolValues, nationalValues ) {
     var annualSalary = Number( schoolValues.medianSalary ) || Number( nationalValues.earningsMedian ),
         monthlySalary = this.calculateMonthlySalary( annualSalary ),
-        financialValues = getModelValues.financial(),
-        monthlyLoanPayment = financialValues.loanMonthly,
+        monthlyLoanPayment = schoolValues.loanMonthly,
         debtBurden = this.calculateDebtBurden( monthlyLoanPayment, monthlySalary ),
         annualSalaryFormatted = this.formatValue( 'currency', annualSalary ),
         monthlySalaryFormatted = this.formatValue( 'currency', monthlySalary ),
@@ -258,7 +258,6 @@ var metricView = {
     $monthlySalaryElement.text( monthlySalaryFormatted );
     $monthlyPaymentElement.text( monthlyLoanPaymentFormatted );
     $debtBurdenElement.text( debtBurdenFormatted );
-    $notification.attr( 'class', 'metric_notification' );
     this.setNotificationClasses( $notification, notificationClasses );
   }
 

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -296,7 +296,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
     expect( page.remainingCostFinal.getText() ).toEqual( '526' );
     // expect( page.totalProgramDebt.getText() ).toEqual( '3000' );
     // expect( page.totalRepayment.getText() ).toEqual( '10000' );
-    // TODO: expect the estimated debt burden is recalculated
+    expect( page.debtBurdenPercent.getText() ).toEqual( '15%' );
     // TODO: expect the est. monthly student loan expense is recalculated
   } );
 
@@ -312,7 +312,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
     expect( page.remainingCostFinal.getText() ).toEqual( '-2974' );
     // expect( page.totalProgramDebt.getText() ).toEqual( '3000' );
     // expect( page.totalRepayment.getText() ).toEqual( '10000' );
-    // TODO: expect the estimated debt burden is recalculated
+    expect( page.debtBurdenPercent.getText() ).toEqual( '19%' );
     // TODO: expect the est. monthly student loan expense is recalculated
   } );
 
@@ -325,7 +325,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
     expect( page.remainingCostFinal.getText() ).toEqual( '26' );
     // expect( page.totalProgramDebt.getText() ).toEqual( '3000' );
     // expect( page.totalRepayment.getText() ).toEqual( '10000' );
-    // TODO: expect the estimated debt burden is recalculated
+    expect( page.debtBurdenPercent.getText() ).toEqual( '16%' );
     // TODO: expect the est. monthly student loan expense is recalculated
   } );
 
@@ -340,7 +340,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
     expect( page.remainingCostFinal.getText() ).toEqual( '-474' );
     // expect( page.totalProgramDebt.getText() ).toEqual( '3000' );
     // expect( page.totalRepayment.getText() ).toEqual( '10000' );
-    // TODO: expect the estimated debt burden is recalculated
+    expect( page.debtBurdenPercent.getText() ).toEqual( '16%' );
     // TODO: expect the est. monthly student loan expense is recalculated
   } );
 
@@ -353,7 +353,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
     expect( page.remainingCostFinal.getText() ).toEqual( '-1474' );
     // expect( page.totalProgramDebt.getText() ).toEqual( '3000' );
     // expect( page.totalRepayment.getText() ).toEqual( '10000' );
-    // TODO: expect the estimated debt burden is recalculated
+    expect( page.debtBurdenPercent.getText() ).toEqual( '18%' );
     // TODO: expect the est. monthly student loan expense is recalculated
   } );
 
@@ -368,7 +368,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
     expect( page.remainingCostFinal.getText() ).toEqual( '-4474' );
     // expect( page.totalProgramDebt.getText() ).toEqual( '3000' );
     // expect( page.totalRepayment.getText() ).toEqual( '10000' );
-    // TODO: expect the estimated debt burden is recalculated
+    expect( page.debtBurdenPercent.getText() ).toEqual( '21%' );
     // TODO: expect the est. monthly student loan expense is recalculated
   } );
 
@@ -436,7 +436,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
     expect( page.remainingCostFinal.getText() ).toEqual( '-1474' );
     // expect( page.totalProgramDebt.getText() ).toEqual( '?' );
     // expect( page.totalRepayment.getText() ).toEqual( '?' );
-    // TODO: expect the estimated debt burden is recalculated
+    expect( page.debtBurdenPercent.getText() ).toEqual( '18%' );
     // TODO: expect the est. monthly student loan expense is recalculated
   } );
 

--- a/test/functional/dd-school-data-spec.js
+++ b/test/functional/dd-school-data-spec.js
@@ -74,6 +74,19 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
     expect( page.salaryNotification.getAttribute( 'class' ) ).toEqual( 'metric_notification metric_notification__worse cf-notification cf-notification__error' );
   } );
 
+  it( 'should calculate debt burden', function() {
+    page.confirmVerification();
+    expect( page.debtBurdenPayment.getText() ).toEqual( '$314' );
+    expect( page.debtBurdenSalary.getText() ).toEqual( '$1,917' );
+    expect( page.debtBurdenPercent.getText() ).toEqual( '16%' );
+  } );
+
+  it( 'should display the correct debt burden notification', function() {
+    page.confirmVerification();
+    expect( page.debtBurdenNotification.getText() ).toEqual( 'Loan payment is higher than recommended 8% of salary' );
+    expect( page.debtBurdenNotification.getAttribute( 'class' ) ).toEqual( 'metric_notification metric_notification__worse cf-notification cf-notification__error' );
+  } );
+
   it( 'should graph loan default rates', function() {
     page.confirmVerification();
     expect( page.schoolDefaultRatePoint.getCssValue( 'bottom' ) ).toEqual( '80.5px' );

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -449,6 +449,26 @@ settlementAidOfferPage.prototype = Object.create({}, {
         return element( by.css( '.metric.average-salary .metric_notification' ) );
       }
     },
+    debtBurdenPayment: {
+      get: function() {
+        return element( by.css( '.debt-equation [data-debt-burden="monthly-payment"]' ) );
+      }
+    },
+    debtBurdenSalary: {
+      get: function() {
+        return element( by.css( '.debt-equation [data-debt-burden="monthly-salary"]' ) );
+      }
+    },
+    debtBurdenPercent: {
+      get: function() {
+        return element( by.css( '.debt-equation [data-debt-burden="debt-burden"]' ) );
+      }
+    },
+    debtBurdenNotification: {
+      get: function() {
+        return element( by.css( '.metric.debt-burden .metric_notification' ) );
+      }
+    },
     schoolDefaultRatePoint: {
       get: function() {
         return element( by.css( '.metric.loan-default-rates .bar-graph_point__you' ) );

--- a/test/js-unit/metric-view-spec.js
+++ b/test/js-unit/metric-view-spec.js
@@ -152,4 +152,17 @@ describe( 'metric-view', function() {
     expect( notificationClasses ).to.equal( '' );
   });
 
+  it( 'calculates monthly salary', function() {
+    var annualSalary = 34300,
+        monthlySalary = metricView.calculateMonthlySalary( annualSalary );
+    expect( monthlySalary.toFixed( 4 ) ).to.equal( '2858.3333' );
+  });
+
+  it( 'calculates debt burden', function() {
+    var monthlyLoanPayment = 240,
+        monthlySalary = 2858,
+        debtBurden = metricView.calculateDebtBurden( monthlyLoanPayment, monthlySalary );
+    expect( debtBurden.toFixed( 4 ) ).to.equal( '0.0840' );
+  });
+
 });


### PR DESCRIPTION
Displays the debt burden calculation and notification
## Additions
- JS to calculate, display, and update debt burden and the corresponding notification
- Unit and functional tests
## Changes
- `metricView.setNotificationClasses` now resets a notification's classes before adding new classes (to handle cases where the debt burden notification changes from a "too high" alert box to an "a-ok" message or vice versa)
## Testing
- To test, pull in the `debt-burden` branch and run `gulp`. Fire up the app in standalone or UnityBox as normal.
- Try testing with our usual example school, good old `iped=408039&pid=981`. The debt burden should look like the screenshot below if you use the [typical testing URL](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=981&oid=f38283b5b7c939a058889f997949efa566c616c5&tuit=38976&hous=3000&book=650&tran=500&othr=500&pelg=1500&schg=2000&stag=2000&othg=100&ta=3000&mta=3000&gib=3000&wkst=3000&parl=10000&perl=3000&subl=15000&unsl=2000&ppl=1000&gpl=1000&prvl=3000&prvi=4.55&insl=3000&insi=4.55#info-right). You can test with our new example school, `iped=449898&pid=1509`, too.
- Try adjusting the various loan amounts on the page. The debt burden numbers should udpate accordingly.
- If you really want to get fancy, try changing line 237 in `metric-view.js` to something like `var annualSalary = Number( 'None' ) || Number( nationalValues.earningsMedian ),` to simulate a school with no salary data. The debt burden calculation should pick up the national average salary shown in the salary graph.
- Try testing either of our test schools without any offer numbers in the URL. The debt burden should correctly show a $0 loan payment and a 0% debt burden.
- Try anything else! It'll probably maybe work?
## Review
- @marteki 
- @higs4281 
- @mistergone: All the JS look OK?
## Screenshots

![debt-burden](https://cloud.githubusercontent.com/assets/1862695/13340565/4990822c-dbff-11e5-9f1e-30248432ca5e.png)
## Todos
- Refactor `metric-view.js` to stop using `window.nationalData` and start using the model now that it contains all the national average values
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Visually tested in supported browsers and devices
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
