### PR TITLE
add script to ping EDMC with test notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Changed url for "about this tool" page to /about-this-tool/
 - Added "About this tool" section and content
 - Updated content to pre-clearance version for settlement students
+- Added script for sending test notifications
 
 
 ## 2.0.0

--- a/paying_for_college/disclosures/scripts/ping_edmc.py
+++ b/paying_for_college/disclosures/scripts/ping_edmc.py
@@ -1,0 +1,50 @@
+# send test notifications to school
+import requests
+import datetime
+
+# urls
+EDMC_DEV = "https://dev.exml.edmc.edu/cfpb"
+EDMC_BETA = "https://beta.exml.edmc.edu/cfpb"
+EDMC_PROD = "https://exml.edmc.edu/cfpb"
+BIN = "https://httpbin.org/"
+BINPOST = "https://httpbin.org/post"
+BINGET = "https://httpbin.org/get"
+RBIN = "http://requestb.in/1ak4sxc1"
+
+# test values
+OID = '9e0280139f3238cbc9702c7b0d62e5c238a835d0'
+ERRORS = 'INVALID: test notification via Python'
+REPORT = "OK is {0}; reason is {1}; status is {2}; time sent is {3}"
+
+
+def notify_edmc(url, oid, errors):
+    payload = {
+        'oid': oid,
+        'time': "{0}+00:00".format(datetime.datetime.now().isoformat()),
+        'errors': errors
+    }
+    try:
+        resp = requests.post(url, data=payload, timeout=10)
+    except requests.exceptions.ConnectTimeout:
+        return "post to {0} timed out".format(url)
+    report = REPORT.format(resp.ok,
+                           resp.reason,
+                           resp.status_code,
+                           payload['time'])
+    return report
+
+if __name__ == "__main__":
+    print(notify_edmc(EDMC_DEV, OID, ERRORS))
+    print(notify_edmc(EDMC_BETA, OID, ERRORS))
+    print(notify_edmc(EDMC_PROD, OID, ERRORS))
+
+## to test against binpost
+# hit_binpost = requests.post(BINPOST, data=PAYLOAD)
+# print hit_binpost.content
+
+## to hit rbin
+# hit_rbin = requests.post(RBIN, data=PAYLOAD)
+## then check http://requestb.in/1ak4sxc1?inspect#s8ubhf
+
+## curl test
+# curl -v -X POST --data "oid=f38283b5b7c939a058889f997949efa566c616c5&errors=INVALID: test notification via curl&time=2016-01-21T18:36:09.922690+00:00" --url "https://dev.exml.edmc.edu/cfpb"


### PR DESCRIPTION
We need to send test notifications to EDMC from various server environments. This generates the test.
## Additions
- script to ping EMDC with a test confirmation. 
- test of the test
## Review
- @vccabral
## Checklist
- [x] CHANGELOG has been updated
