### PR TITLE
Graph fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 -
 -
--
+- Fix graph point overlaps
 -
 -
 -

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -1025,7 +1025,8 @@
 .bar-graph {
   @bar-graph-container-max-width:  380px;
   @bar-graph-width:                45px;
-  @bar-graph-width-narrow:         25px;
+  @bar-graph-width-sm:             25px;
+  @bar-graph-width-xs:             17px;
   @bar-graph-height:              130px;
   @bar-graph-label-width:         135px;
   @bar-graph-value-min-width:      95px;
@@ -1090,9 +1091,22 @@
     background-color: @gray-10;
 
     .respond-to-range(@bp-graph-cols-min, @bp-med-max, {
-      width: @bar-graph-width-narrow;
-      border-right: (@bar-graph-width - @bar-graph-width-narrow) / 2 solid @gray-5;
-      border-left: (@bar-graph-width - @bar-graph-width-narrow) / 2 solid @gray-5;
+      width: @bar-graph-width-sm;
+      border-right: (@bar-graph-width - @bar-graph-width-sm) / 2 solid @gray-5;
+      border-left: (@bar-graph-width - @bar-graph-width-sm) / 2 solid @gray-5;
+    });
+
+    // Graph bars need to get really skinny at some screen sizes
+    .respond-to-range(@bp-graph-cols-min, 759px, {
+      width: @bar-graph-width-xs;
+      border-right: (@bar-graph-width - @bar-graph-width-xs) / 2 solid @gray-5;
+      border-left: (@bar-graph-width - @bar-graph-width-xs) / 2 solid @gray-5;
+    });
+
+    .respond-to-range(901px, 929px, {
+      width: @bar-graph-width-xs;
+      border-right: (@bar-graph-width - @bar-graph-width-xs) / 2 solid @gray-5;
+      border-left: (@bar-graph-width - @bar-graph-width-xs) / 2 solid @gray-5;
     });
   }
 

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -271,7 +271,7 @@ var financialView = {
   },
 
   /**
-   * Listener function for "estimated years in program" select element
+   * Listener function for offer verification buttons
    */
   verificationListener: function() {
     this.$verifyControls.on( 'click', '.btn', function() {

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -11,6 +11,7 @@ var metricView = require( '../views/metric-view' );
 var financialView = {
   $elements: $( '[data-financial]' ),
   $reviewAndEvaluate: $( '[data-section="review"], [data-section="evaluate"]' ),
+  $verifyControls: $( '.verify_controls' ),
   $programLength: $( '#estimated-years-attending' ),
   $addPrivateButton: $( '.private-loans_add-btn' ),
   $gradPlusSection: $( '[data-section="gradPlus"]'),
@@ -26,6 +27,7 @@ var financialView = {
   init: function() {
     this.keyupListener();
     this.focusoutListener();
+    this.verificationListener();
     this.estimatedYearsListener();
     this.addPrivateListener();
     this.removePrivateListener();
@@ -265,6 +267,23 @@ var financialView = {
       clearTimeout( financialView.keyupDelay );
       financialView.currentInput = $( this ).attr( 'id' );
       financialView.inputHandler( financialView.currentInput );
+    } );
+  },
+
+  /**
+   * Listener function for "estimated years in program" select element
+   */
+  verificationListener: function() {
+    this.$verifyControls.on( 'click', '.btn', function() {
+      var schoolValues = getModelValues.financial(),
+          nationalValues = window.nationalData;
+      // Graph points need to be visible before updating their positions
+      // to get all the right CSS values, so we'll wait 100 ms
+      if ( $( this ).attr( 'href' ) === '#info-right' ) {
+        setTimeout( function() {
+          metricView.updateGraphs( schoolValues, nationalValues );
+        }, 100 );
+      }
     } );
   },
 

--- a/src/disclosures/js/views/metric-view.js
+++ b/src/disclosures/js/views/metric-view.js
@@ -9,10 +9,9 @@ var metricView = {
    * Initiates the object
    */
   init: function() {
-    var $graphs = $( '.bar-graph' ),
-        schoolValues = getModelValues.financial(),
+    var schoolValues = getModelValues.financial(),
         nationalValues = window.nationalData || {};
-    this.initGraphs( $graphs, schoolValues, nationalValues );
+    this.updateGraphs( schoolValues, nationalValues );
     // updateDebtBurdenDisplay is called in financialView.updateView, not here,
     // since the debt burden needs to refresh when loan amounts are modified
   },
@@ -85,6 +84,10 @@ var metricView = {
         'padding-bottom': offset,
         'top': -offset
       } );
+      // Need to reset the z-index since fixOverlap is called on page load and
+      // again when a verification button is clicked
+      $higherPoint.css( 'z-index', 'auto' );
+      $lowerPoint.css( 'z-index', 'auto' );
       $lowerPoint.css( 'z-index', 100 );
     }
   },
@@ -176,11 +179,11 @@ var metricView = {
 
   /**
    * Initializes all metrics with bar graphs
-   * @param {object} $graphs jQuery object of all graphs on the page
    * @param {object} schoolValues Values reported by the school
    * @param {object} nationalValues National average values
    */
-  initGraphs: function( $graphs, schoolValues, nationalValues ) {
+  updateGraphs: function( schoolValues, nationalValues ) {
+    var $graphs = $( '.bar-graph' );
     $graphs.each( function() {
       var $graph = $( this ),
           metricKey = $graph.attr( 'data-metric' ),

--- a/test/functional/dd-school-data-spec.js
+++ b/test/functional/dd-school-data-spec.js
@@ -63,6 +63,8 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
   it( 'should graph average salary', function() {
     page.confirmVerification();
     expect( page.schoolSalaryPoint.getCssValue( 'bottom' ) ).toEqual( '45.3px' );
+    // Checking for z-index lets us know an overlap is being handled correctly
+    expect( page.schoolSalaryPoint.getCssValue( 'z-index' ) ).toEqual( '100' );
     expect( page.schoolSalaryValue.getText() ).toEqual( '$23,000' );
     expect( page.nationalSalaryPoint.getCssValue( 'bottom' ) ).toEqual( '54.188px' );
     expect( page.nationalSalaryValue.getText() ).toEqual( '$31,080' );


### PR DESCRIPTION
Fixes various overlapping problems on the graphs
## Additions
- `verificationListener` to trigger the graphs to update once the section they're in is visible (fixes #125)
## Changes
- Narrower graph bar at certain screen sizes (fixes #108 )
## Testing
- To test, pull in the `graph-fixes` branch and run `gulp`. Fire up the app in standalone or UnityBox as normal.
- Load any test school you like, but NOT with the `#info-right` bit at the end of the URL. Hit the "Yes, this is correct" button. Graph points should no longer overlap. You can try again WITH the `#info-right` bit at the end of the URL, and the points should still not overlap.
- Shrink your browser to any size you want—the bar should never get overlapped by the points (as it was in #108)
## Review
- @marteki 
- @higs4281 
- @mistergone: All the JS look OK?
## To do
- Refactor JS to stop using `window.nationalData` and use the updated model instead
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Visually tested in supported browsers and devices
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
