### PR TITLE
Netprice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 -
 -
--
+- Adds avg_net_price to scorecard api updates
 
 ## 2.0.1
 - Updated content to be dynamic based on remaining cost

--- a/paying_for_college/disclosures/scripts/api_utils.py
+++ b/paying_for_college/disclosures/scripts/api_utils.py
@@ -61,19 +61,22 @@ MODEL_MAP = {
     'school.operating': 'operating',
     'school.under_investigation': 'under_investigation',
     'school.zip': 'zip5',
-    '{0}.completion.completion_rate_4yr_150nt_pooled'.format(LATEST_YEAR): 'grad_rate',
-    '{0}.completion.completion_rate_less_than_4yr_150nt_pooled'.format(LATEST_YEAR): 'grad_rate',
+    '{0}.completion.completion_rate_4yr_150nt_pooled'.format(LATEST_YEAR): 'grad_rate_4yr',
+    '{0}.completion.completion_rate_less_than_4yr_150nt_pooled'.format(LATEST_YEAR): 'grad_rate_lt4',
     '{0}.repayment.repayment_cohort.3_year_declining_balance'.format(LATEST_YEAR): 'repay_3yr',  # NEW
     '{0}.repayment.3_yr_default_rate'.format(LATEST_YEAR): 'default_rate',
     '{0}.aid.median_debt_suppressed.overall'.format(LATEST_YEAR): 'median_total_debt',
     '{0}.aid.median_debt_suppressed.completers.monthly_payments'.format(LATEST_YEAR): 'median_monthly_debt',  # NEW
+    '{0}.cost.avg_net_price.overall'.format(LATEST_YEAR): 'avg_net_price',
+    '{0}.cost.tuition.out_of_state'.format(LATEST_YEAR): 'tuition_out_of_state',
+    '{0}.cost.tuition.in_state'.format(LATEST_YEAR): 'tuition_in_state',
     '{0}.earnings.10_yrs_after_entry.median'.format(LATEST_SALARY_YEAR): 'median_annual_pay',
 }
 
-JSON_MAP = {
-    # '{0}.student.retention_rate.four_year.full_time'.format(LATEST_YEAR): 'RETENTRATE',
-    # '{0}.student.retention_rate.lt_four_year.full_time'.format(LATEST_YEAR): 'RETENTRATELT4',  # NEW
-}
+# JSON_MAP = {
+#     # '{0}.student.retention_rate.four_year.full_time'.format(LATEST_YEAR): 'RETENTRATE',
+#     # '{0}.student.retention_rate.lt_four_year.full_time'.format(LATEST_YEAR): 'RETENTRATELT4',  # NEW
+# }
 
 BASE_FIELDS = [
     'id',
@@ -103,6 +106,7 @@ YEAR_FIELDS = [
     'cost.tuition.in_state',
     'cost.tuition.out_of_state',
     'cost.tuition.program_year',
+    'cost.avg_net_price.overall',
     'student.fafsa_sent.2_college_allyrs',
     'student.fafsa_sent.3_college_allyrs',
     'student.fafsa_sent.4_college_allyrs',

--- a/paying_for_college/disclosures/scripts/ping_edmc.py
+++ b/paying_for_college/disclosures/scripts/ping_edmc.py
@@ -14,7 +14,8 @@ RBIN = "http://requestb.in/1ak4sxc1"
 # test values
 OID = '9e0280139f3238cbc9702c7b0d62e5c238a835d0'
 ERRORS = 'INVALID: test notification via Python'
-REPORT = "OK is {0}; reason is {1}; status is {2}; time sent is {3}"
+REPORT = "OK is {0}; reason is {1}; status is {2}; time sent is {3};\n\
+content is {4}"
 
 
 def notify_edmc(url, oid, errors):
@@ -30,7 +31,8 @@ def notify_edmc(url, oid, errors):
     report = REPORT.format(resp.ok,
                            resp.reason,
                            resp.status_code,
-                           payload['time'])
+                           payload['time'],
+                           resp.content)
     return report
 
 if __name__ == "__main__":

--- a/paying_for_college/migrations/0014_auto__add_field_school_avg_net_price.py
+++ b/paying_for_college/migrations/0014_auto__add_field_school_avg_net_price.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'School.avg_net_price'
+        db.add_column(u'paying_for_college_school', 'avg_net_price',
+                      self.gf('django.db.models.fields.IntegerField')(null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'School.avg_net_price'
+        db.delete_column(u'paying_for_college_school', 'avg_net_price')
+
+
+    models = {
+        u'paying_for_college.alias': {
+            'Meta': {'object_name': 'Alias'},
+            'alias': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'is_primary': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'paying_for_college.bahrate': {
+            'Meta': {'object_name': 'BAHRate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'value': ('django.db.models.fields.IntegerField', [], {}),
+            'zip5': ('django.db.models.fields.CharField', [], {'max_length': '5'})
+        },
+        u'paying_for_college.constantcap': {
+            'Meta': {'ordering': "['slug']", 'object_name': 'ConstantCap'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'value': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'paying_for_college.constantrate': {
+            'Meta': {'ordering': "['slug']", 'object_name': 'ConstantRate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'value': ('django.db.models.fields.DecimalField', [], {'max_digits': '6', 'decimal_places': '5'})
+        },
+        u'paying_for_college.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'contact': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'endpoint': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'internal_note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'paying_for_college.disclosure': {
+            'Meta': {'object_name': 'Disclosure'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'paying_for_college.feedback': {
+            'Meta': {'object_name': 'Feedback'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {})
+        },
+        u'paying_for_college.nickname': {
+            'Meta': {'ordering': "['nickname']", 'object_name': 'Nickname'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'is_female': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'nickname': ('django.db.models.fields.TextField', [], {})
+        },
+        u'paying_for_college.notification': {
+            'Meta': {'object_name': 'Notification'},
+            'email': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'errors': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'oid': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        u'paying_for_college.program': {
+            'Meta': {'object_name': 'Program'},
+            'accreditor': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'books': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'campus': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'cip_code': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'completion_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'default_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'fees': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'housing': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'institutional_debt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'job_note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'job_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'level': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'mean_student_loan_completers': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'median_student_loan_completers': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'other_costs': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'private_debt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'program_code': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'program_length': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'program_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'salary': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'soc_codes': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'time_to_complete': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'titleiv_debt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'total_cost': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'transportation': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'tuition': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'paying_for_college.school': {
+            'KBYOSS': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'Meta': {'object_name': 'School'},
+            'accreditor': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'avg_net_price': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.Contact']", 'null': 'True', 'blank': 'True'}),
+            'control': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'data_json': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'default_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '3', 'blank': 'True'}),
+            'degrees_highest': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'degrees_predominant': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'enrollment': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'grad_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '2', 'blank': 'True'}),
+            'grad_rate_4yr': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '2', 'blank': 'True'}),
+            'grad_rate_lt4': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '2', 'blank': 'True'}),
+            'main_campus': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'median_annual_pay': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'median_monthly_debt': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '14', 'decimal_places': '9', 'blank': 'True'}),
+            'median_total_debt': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '7', 'decimal_places': '1', 'blank': 'True'}),
+            'online_only': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'ope6_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'ope8_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'operating': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'ownership': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'repay_3yr': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '13', 'decimal_places': '10', 'blank': 'True'}),
+            'school_id': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '2', 'blank': 'True'}),
+            'url': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'zip5': ('django.db.models.fields.CharField', [], {'max_length': '5', 'blank': 'True'})
+        },
+        u'paying_for_college.worksheet': {
+            'Meta': {'object_name': 'Worksheet'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'guid': ('django.db.models.fields.CharField', [], {'max_length': '64', 'primary_key': 'True'}),
+            'saved_data': ('django.db.models.fields.TextField', [], {}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['paying_for_college']

--- a/paying_for_college/migrations/0015_auto__add_field_school_tuition_out_of_state__add_field_school_tuition_.py
+++ b/paying_for_college/migrations/0015_auto__add_field_school_tuition_out_of_state__add_field_school_tuition_.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'School.tuition_out_of_state'
+        db.add_column(u'paying_for_college_school', 'tuition_out_of_state',
+                      self.gf('django.db.models.fields.IntegerField')(null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'School.tuition_in_state'
+        db.add_column(u'paying_for_college_school', 'tuition_in_state',
+                      self.gf('django.db.models.fields.IntegerField')(null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'School.tuition_out_of_state'
+        db.delete_column(u'paying_for_college_school', 'tuition_out_of_state')
+
+        # Deleting field 'School.tuition_in_state'
+        db.delete_column(u'paying_for_college_school', 'tuition_in_state')
+
+
+    models = {
+        u'paying_for_college.alias': {
+            'Meta': {'object_name': 'Alias'},
+            'alias': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'is_primary': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'paying_for_college.bahrate': {
+            'Meta': {'object_name': 'BAHRate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'value': ('django.db.models.fields.IntegerField', [], {}),
+            'zip5': ('django.db.models.fields.CharField', [], {'max_length': '5'})
+        },
+        u'paying_for_college.constantcap': {
+            'Meta': {'ordering': "['slug']", 'object_name': 'ConstantCap'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'value': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'paying_for_college.constantrate': {
+            'Meta': {'ordering': "['slug']", 'object_name': 'ConstantRate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'value': ('django.db.models.fields.DecimalField', [], {'max_digits': '6', 'decimal_places': '5'})
+        },
+        u'paying_for_college.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'contact': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'endpoint': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'internal_note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'paying_for_college.disclosure': {
+            'Meta': {'object_name': 'Disclosure'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'paying_for_college.feedback': {
+            'Meta': {'object_name': 'Feedback'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {})
+        },
+        u'paying_for_college.nickname': {
+            'Meta': {'ordering': "['nickname']", 'object_name': 'Nickname'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'is_female': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'nickname': ('django.db.models.fields.TextField', [], {})
+        },
+        u'paying_for_college.notification': {
+            'Meta': {'object_name': 'Notification'},
+            'email': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'errors': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'oid': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        u'paying_for_college.program': {
+            'Meta': {'object_name': 'Program'},
+            'accreditor': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'books': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'campus': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'cip_code': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'completion_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'default_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'fees': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'housing': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'institutional_debt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'job_note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'job_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'level': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'mean_student_loan_completers': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'median_student_loan_completers': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'other_costs': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'private_debt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'program_code': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'program_length': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'program_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'salary': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'soc_codes': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'time_to_complete': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'titleiv_debt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'total_cost': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'transportation': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'tuition': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'paying_for_college.school': {
+            'KBYOSS': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'Meta': {'object_name': 'School'},
+            'accreditor': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'avg_net_price': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.Contact']", 'null': 'True', 'blank': 'True'}),
+            'control': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'data_json': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'default_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '3', 'blank': 'True'}),
+            'degrees_highest': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'degrees_predominant': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'enrollment': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'grad_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '2', 'blank': 'True'}),
+            'grad_rate_4yr': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '2', 'blank': 'True'}),
+            'grad_rate_lt4': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '2', 'blank': 'True'}),
+            'main_campus': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'median_annual_pay': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'median_monthly_debt': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '14', 'decimal_places': '9', 'blank': 'True'}),
+            'median_total_debt': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '7', 'decimal_places': '1', 'blank': 'True'}),
+            'online_only': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'ope6_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'ope8_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'operating': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'ownership': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'repay_3yr': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '13', 'decimal_places': '10', 'blank': 'True'}),
+            'school_id': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '2', 'blank': 'True'}),
+            'tuition_in_state': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'tuition_out_of_state': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'url': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'zip5': ('django.db.models.fields.CharField', [], {'max_length': '5', 'blank': 'True'})
+        },
+        u'paying_for_college.worksheet': {
+            'Meta': {'object_name': 'Worksheet'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'guid': ('django.db.models.fields.CharField', [], {'max_length': '64', 'primary_key': 'True'}),
+            'saved_data': ('django.db.models.fields.TextField', [], {}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['paying_for_college']

--- a/paying_for_college/migrations/0016_auto__chg_field_school_grad_rate_lt4__chg_field_school_grad_rate_4yr__.py
+++ b/paying_for_college/migrations/0016_auto__chg_field_school_grad_rate_lt4__chg_field_school_grad_rate_4yr__.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'School.grad_rate_lt4'
+        db.alter_column(u'paying_for_college_school', 'grad_rate_lt4', self.gf('django.db.models.fields.DecimalField')(null=True, max_digits=5, decimal_places=3))
+
+        # Changing field 'School.grad_rate_4yr'
+        db.alter_column(u'paying_for_college_school', 'grad_rate_4yr', self.gf('django.db.models.fields.DecimalField')(null=True, max_digits=5, decimal_places=3))
+
+        # Changing field 'School.grad_rate'
+        db.alter_column(u'paying_for_college_school', 'grad_rate', self.gf('django.db.models.fields.DecimalField')(null=True, max_digits=5, decimal_places=3))
+
+        # Changing field 'School.default_rate'
+        db.alter_column(u'paying_for_college_school', 'default_rate', self.gf('django.db.models.fields.DecimalField')(null=True, max_digits=5, decimal_places=3))
+
+    def backwards(self, orm):
+
+        # Changing field 'School.grad_rate_lt4'
+        db.alter_column(u'paying_for_college_school', 'grad_rate_lt4', self.gf('django.db.models.fields.DecimalField')(null=True, max_digits=4, decimal_places=2))
+
+        # Changing field 'School.grad_rate_4yr'
+        db.alter_column(u'paying_for_college_school', 'grad_rate_4yr', self.gf('django.db.models.fields.DecimalField')(null=True, max_digits=4, decimal_places=2))
+
+        # Changing field 'School.grad_rate'
+        db.alter_column(u'paying_for_college_school', 'grad_rate', self.gf('django.db.models.fields.DecimalField')(null=True, max_digits=4, decimal_places=2))
+
+        # Changing field 'School.default_rate'
+        db.alter_column(u'paying_for_college_school', 'default_rate', self.gf('django.db.models.fields.DecimalField')(null=True, max_digits=4, decimal_places=3))
+
+    models = {
+        u'paying_for_college.alias': {
+            'Meta': {'object_name': 'Alias'},
+            'alias': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'is_primary': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'paying_for_college.bahrate': {
+            'Meta': {'object_name': 'BAHRate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'value': ('django.db.models.fields.IntegerField', [], {}),
+            'zip5': ('django.db.models.fields.CharField', [], {'max_length': '5'})
+        },
+        u'paying_for_college.constantcap': {
+            'Meta': {'ordering': "['slug']", 'object_name': 'ConstantCap'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'value': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'paying_for_college.constantrate': {
+            'Meta': {'ordering': "['slug']", 'object_name': 'ConstantRate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'value': ('django.db.models.fields.DecimalField', [], {'max_digits': '6', 'decimal_places': '5'})
+        },
+        u'paying_for_college.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'contact': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'endpoint': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'internal_note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'paying_for_college.disclosure': {
+            'Meta': {'object_name': 'Disclosure'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'paying_for_college.feedback': {
+            'Meta': {'object_name': 'Feedback'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {})
+        },
+        u'paying_for_college.nickname': {
+            'Meta': {'ordering': "['nickname']", 'object_name': 'Nickname'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'is_female': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'nickname': ('django.db.models.fields.TextField', [], {})
+        },
+        u'paying_for_college.notification': {
+            'Meta': {'object_name': 'Notification'},
+            'email': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'errors': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'oid': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        u'paying_for_college.program': {
+            'Meta': {'object_name': 'Program'},
+            'accreditor': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'books': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'campus': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'cip_code': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'completion_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'default_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'fees': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'housing': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'institutional_debt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'job_note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'job_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'level': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'mean_student_loan_completers': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'median_student_loan_completers': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'other_costs': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'private_debt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'program_code': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'program_length': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'program_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'salary': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'soc_codes': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'time_to_complete': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'titleiv_debt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'total_cost': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'transportation': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'tuition': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'paying_for_college.school': {
+            'KBYOSS': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'Meta': {'object_name': 'School'},
+            'accreditor': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'avg_net_price': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.Contact']", 'null': 'True', 'blank': 'True'}),
+            'control': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'data_json': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'default_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '3', 'blank': 'True'}),
+            'degrees_highest': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'degrees_predominant': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'enrollment': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'grad_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '3', 'blank': 'True'}),
+            'grad_rate_4yr': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '3', 'blank': 'True'}),
+            'grad_rate_lt4': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '3', 'blank': 'True'}),
+            'main_campus': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'median_annual_pay': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'median_monthly_debt': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '14', 'decimal_places': '9', 'blank': 'True'}),
+            'median_total_debt': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '7', 'decimal_places': '1', 'blank': 'True'}),
+            'online_only': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'ope6_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'ope8_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'operating': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'ownership': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'repay_3yr': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '13', 'decimal_places': '10', 'blank': 'True'}),
+            'school_id': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '2', 'blank': 'True'}),
+            'tuition_in_state': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'tuition_out_of_state': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'url': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'zip5': ('django.db.models.fields.CharField', [], {'max_length': '5', 'blank': 'True'})
+        },
+        u'paying_for_college.worksheet': {
+            'Meta': {'object_name': 'Worksheet'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'guid': ('django.db.models.fields.CharField', [], {'max_length': '64', 'primary_key': 'True'}),
+            'saved_data': ('django.db.models.fields.TextField', [], {}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['paying_for_college']

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -157,21 +157,21 @@ class School(models.Model):
     operating = models.BooleanField(default=True)
     KBYOSS = models.BooleanField(default=False)  # shopping-sheet participant
 
-    grad_rate_4yr = models.DecimalField(max_digits=4,
-                                        decimal_places=2,
+    grad_rate_4yr = models.DecimalField(max_digits=5,
+                                        decimal_places=3,
                                         blank=True, null=True)
-    grad_rate_lt4 = models.DecimalField(max_digits=4,
-                                        decimal_places=2,
+    grad_rate_lt4 = models.DecimalField(max_digits=5,
+                                        decimal_places=3,
                                         blank=True, null=True)
-    grad_rate = models.DecimalField(max_digits=4,
-                                    decimal_places=2,
+    grad_rate = models.DecimalField(max_digits=5,
+                                    decimal_places=3,
                                     blank=True, null=True,
                                     help_text="A 2-YEAR POOLED VALUE")
     repay_3yr = models.DecimalField(max_digits=13,
                                     decimal_places=10,
                                     blank=True, null=True,
                                     help_text="GRADS WITH A DECLINING BALANCE AFTER 3 YRS")
-    default_rate = models.DecimalField(max_digits=4,
+    default_rate = models.DecimalField(max_digits=5,
                                        decimal_places=3,
                                        blank=True, null=True,
                                        help_text="LOAN DEFAULT RATE AT 3 YRS")
@@ -186,12 +186,20 @@ class School(models.Model):
     median_annual_pay = models.IntegerField(blank=True,
                                      null=True,
                                      help_text="MEDIAN PAY 10 YRS AFTER ENTRY")
+    avg_net_price = models.IntegerField(blank=True,
+                                        null=True,
+                                        help_text="OVERALL AVERAGE")
+    tuition_out_of_state = models.IntegerField(blank=True,
+                                               null=True)
+    tuition_in_state = models.IntegerField(blank=True,
+                                           null=True)
 
     def as_json(self):
         """delivers pertinent data points as json"""
         ordered_out = OrderedDict()
         jdata = json.loads(self.data_json)
         dict_out = {
+            'avg_net_price': self.avg_net_price,
             'books': jdata['BOOKS'],
             'city': self.city,
             'control': self.control,
@@ -223,8 +231,8 @@ class School(models.Model):
             'tuitionGradInS': jdata['TUITIONGRADINS'],
             'tuitionGradOss': jdata['TUITIONGRADOSS'],
             'tuitionUnderInDis': jdata['TUITIONUNDERINDIS'],
-            'tuitionUnderInS': jdata['TUITIONUNDERINS'],
-            'tuitionUnderOoss': jdata['TUITIONUNDEROSS'],
+            'tuitionUnderInS': self.tuition_in_state,
+            'tuitionUnderOoss': self.tuition_out_of_state,
             'url': self.url,
             'zip5': self.zip5,
         }


### PR DESCRIPTION
Adds avg_net_price to school model and updates data and utils
## Additions
- New columns for the School model 
## Removals
- unneeded code for updating json_data 
## Changes
- api utility scripts updated
- collegedata.json fixture is updated, touching most schools
## Testing
- The data and model refresh will require a migration and load.   
  
  ```
  ./manage.py migrate paying_for_college  
  ./manage.py loaddata collegedata.json
  ```
- For UnityBox, you'll want to use
  
  ```
  workon cfpb_django && cd /var/www/django/cfpb
  ./manage.py migrate paying_for_college
  ./manage.py loaddata collegedata.json --settings=cfpb_django.settings.no_haystack
  ```
  
  Loaddata will take a few minutes.
- Test url ([standalone](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=449898&pid=1509&oid=fa8283b5b7c939a058889f997949efa566c616c6&tuit=16360&ppl=0&subl=3500&gpl=0&perl=5500&book=1500&gib=0&pelg=1500&ta=500&unsl=2000&insi=5.0&parl=7000&insl=3000&stag=2000&prvl=2000&prvi=4.55&wkst=1000&hous=5611&othg=100&tran=500&schg=2000&mta=0&othr=6079) or [UnityBox](http://localhost:8080/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=449898&pid=1509&oid=fa8283b5b7c939a058889f997949efa566c616c6&tuit=16360&ppl=0&subl=3500&gpl=0&perl=5500&book=1500&gib=0&pelg=1500&ta=500&unsl=2000&insi=5.0&parl=7000&insl=3000&stag=2000&prvl=2000&prvi=4.55&wkst=1000&hous=5611&othg=100&tran=500&schg=2000&mta=0&othr=6079)) should show $16,360 for tuition and fees
## Review
- two from @mistergone @marteki @niqjohnson 
- [x] CHANGELOG has been updated (blank lines added to avoid changehogday scenario)
