### PR TITLE
Animations after answering verification question and "do you think..." question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 - Fix graph point overlaps
 -
--
+- Added animation to button interactions
 -
 
 ## 2.0.1

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -12,6 +12,8 @@ var financialView = {
   $elements: $( '[data-financial]' ),
   $reviewAndEvaluate: $( '[data-section="review"], [data-section="evaluate"]' ),
   $verifyControls: $( '.verify_controls' ),
+  $infoVerified: $( '.information-right' ),
+  $infoIncorrect: $( '.information-wrong' ),
   $programLength: $( '#estimated-years-attending' ),
   $addPrivateButton: $( '.private-loans_add-btn' ),
   $gradPlusSection: $( '[data-section="gradPlus"]'),
@@ -274,15 +276,31 @@ var financialView = {
    * Listener function for offer verification buttons
    */
   verificationListener: function() {
-    this.$verifyControls.on( 'click', '.btn', function() {
+    this.$verifyControls.on( 'click', '.btn', function( e ) {
       var schoolValues = getModelValues.financial(),
           nationalValues = window.nationalData;
       // Graph points need to be visible before updating their positions
       // to get all the right CSS values, so we'll wait 100 ms
       if ( $( this ).attr( 'href' ) === '#info-right' ) {
+        e.preventDefault();
         setTimeout( function() {
           metricView.updateGraphs( schoolValues, nationalValues );
         }, 100 );
+        financialView.$infoVerified.show();
+        financialView.$verifyControls.hide();
+        $( 'html, body' ).stop().animate( {
+          scrollTop: financialView.$infoVerified.offset().top - 120
+        }, 900, 'swing', function() {
+          window.location.hash = '#info-right';
+        } );
+      } else {
+        e.preventDefault();
+        financialView.$infoIncorrect.show();
+        $( 'html, body' ).stop().animate( {
+          scrollTop: financialView.$infoIncorrect.offset().top - 120
+        }, 900, 'swing', function() {
+          window.location.hash = '#info-wrong';
+        } );
       }
     } );
   },

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -287,7 +287,6 @@ var financialView = {
           metricView.updateGraphs( schoolValues, nationalValues );
         }, 100 );
         financialView.$infoVerified.show();
-        financialView.$verifyControls.hide();
         $( 'html, body' ).stop().animate( {
           scrollTop: financialView.$infoVerified.offset().top - 120
         }, 900, 'swing', function() {
@@ -302,6 +301,7 @@ var financialView = {
           window.location.hash = '#info-wrong';
         } );
       }
+      financialView.$verifyControls.hide();
     } );
   },
 

--- a/src/disclosures/js/views/question-view.js
+++ b/src/disclosures/js/views/question-view.js
@@ -20,10 +20,13 @@ var questionView = {
         questionView.$followupNoNotSure.show();
         questionView.$followupYes.hide();
       }
-      // Show the rest of the page with a 600 millisecond animation.
+      // Show the rest of the page
       questionView.$getOptions.show();
       questionView.$nextSteps.show();
       questionView.$feedback.show();
+      $( 'html, body' ).stop().animate( {
+        scrollTop: questionView.$getOptions.offset().top - 120
+      }, 900, 'swing', function() {} );
     } );
   }
 

--- a/test/functional/dd-feedback-spec.js
+++ b/test/functional/dd-feedback-spec.js
@@ -12,18 +12,20 @@ fdescribe( 'The "Was this tool helpful?" section', function() {
 
   it( 'should contain a link to the feedback form', function() {
     page.confirmVerification();
+    browser.sleep( 1000 );
     page.answerBigQuestionNo();
-    browser.sleep( 750 );
+    browser.sleep( 1000 );
     browser.wait( EC.visibilityOf( page.feedbackLink ), 8000 );
     expect( page.feedbackLink.getAttribute( 'href' ) ).toMatch( /\/paying-for-college2\/understanding-your-financial-aid-offer\/feedback$/ );
   } );
 
   it( 'should open the feedback form in a new tab', function() {
     page.confirmVerification();
+    browser.sleep( 1000 );
     page.answerBigQuestionNo();
-    browser.sleep( 750 );
+    browser.sleep( 1000 );
     page.followFeedbackLink();
-    browser.sleep( 600 );
+    browser.sleep( 1000 );
     browser.getAllWindowHandles()
       .then( function ( handles ) {
         expect( handles.length ).toBe( 2 );
@@ -33,7 +35,7 @@ fdescribe( 'The "Was this tool helpful?" section', function() {
           } )
           .then( function () {
             browser.close();
-            browser.sleep( 600 );
+            browser.sleep( 1000 );
             browser.switchTo().window( handles[0] );
           } );;
       } );

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -39,6 +39,9 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   // TODO - Add expectation that verification buttons disappear, and all fields that should be prepopulated actually are
   it( 'should let a student verify their information and go on to Step 1 and Step 2 of the offer', function() {
     page.confirmVerification();
+    expect( page.correctInfoButton.isDisplayed() ).toBeFalsy();
+    expect( page.incorrectInfoButton.isDisplayed() ).toBeFalsy();
+    expect( page.correctInfoSection.isDisplayed() ).toBeTruthy();
     expect( page.reviewSection.isDisplayed() ).toBeTruthy();
     expect( page.evaluateSection.isDisplayed() ).toBeTruthy();
     expect( page.optionsConsiderationsSection.isDisplayed() ).toBeFalsy();
@@ -47,6 +50,10 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   // TODO - Add expectation that verification buttons disappear, that next steps for incorrect info are displayed, and that the trigger to notify the school is activated
   it( 'should let a student report incorrect aid offer information', function() {
     page.denyVerification();
+    expect( page.correctInfoButton.isDisplayed() ).toBeFalsy();
+    expect( page.incorrectInfoButton.isDisplayed() ).toBeFalsy();
+    expect( page.correctInfoSection.isDisplayed() ).toBeFalsy();
+    expect( page.incorrectInfoSection.isDisplayed() ).toBeTruthy();
     expect( page.reviewSection.isDisplayed() ).toBeFalsy();
     expect( page.evaluateSection.isDisplayed() ).toBeFalsy();
     expect( page.optionsConsiderationsSection.isDisplayed() ).toBeFalsy();
@@ -595,8 +602,9 @@ it( 'should properly update when more than one private loans is modified', funct
 
   it( 'should allow a student who feels that it\'s a good aid offer to go on to Step 3', function() {
     page.confirmVerification();
+    browser.sleep( 1000 );
     page.answerBigQuestionYes();
-    browser.sleep( 750 );
+    browser.sleep( 1000 );
     expect( page.optionsConsiderationsSection.isDisplayed() ).toBeTruthy();
     expect( page.followupNoNotSureContent.isDisplayed() ).toBeFalsy();
     expect( page.followupYesContent.isDisplayed() ).toBeTruthy();
@@ -606,8 +614,9 @@ it( 'should properly update when more than one private loans is modified', funct
 
   it( 'should allow a student who feels that it\'s not a good aid offer to go on to Step 3', function() {
     page.confirmVerification();
+    browser.sleep( 1000 );
     page.answerBigQuestionNo();
-    browser.sleep( 750 );
+    browser.sleep( 1000 );
     expect( page.optionsConsiderationsSection.isDisplayed() ).toBeTruthy();
     expect( page.followupNoNotSureContent.isDisplayed() ).toBeTruthy();
     expect( page.followupYesContent.isDisplayed() ).toBeFalsy();
@@ -617,8 +626,9 @@ it( 'should properly update when more than one private loans is modified', funct
 
   it( 'should allow a student who is not sure that it\'s a good aid offer to go on to Step 3', function() {
     page.confirmVerification();
+    browser.sleep( 1000 );
     page.answerBigQuestionNotSure();
-    browser.sleep( 750 );
+    browser.sleep( 1000 );
     expect( page.optionsConsiderationsSection.isDisplayed() ).toBeTruthy();
     expect( page.followupNoNotSureContent.isDisplayed() ).toBeTruthy();
     expect( page.followupYesContent.isDisplayed() ).toBeFalsy();
@@ -629,11 +639,11 @@ it( 'should properly update when more than one private loans is modified', funct
   // *** Step 3: Consider your options / A few more things to consider ***
   it( 'should link to the school website in a new tab', function() {
     page.confirmVerification();
-    browser.sleep( 750 );
+    browser.sleep( 1000 );
     page.answerBigQuestionNo();
-    browser.sleep( 750 );
+    browser.sleep( 1000 );
     page.followSchoolLink();
-    browser.sleep( 750 );
+    browser.sleep( 1000 );
     browser.getAllWindowHandles()
       .then( function ( handles ) {
         expect( handles.length ).toBe( 2 );
@@ -652,7 +662,7 @@ it( 'should properly update when more than one private loans is modified', funct
 
   it( 'should link to the correct College Scorecard search in a new tab', function() {
     page.confirmVerification();
-    browser.sleep( 750 );
+    browser.sleep( 1000 );
     page.answerBigQuestionNo();
     browser.sleep( 1000 );
     page.followScorecardLink();

--- a/test/functional/dd-interactions-spec.js
+++ b/test/functional/dd-interactions-spec.js
@@ -21,6 +21,7 @@ fdescribe( 'The college costs worksheet page', function() {
   it( 'should add a private loan entry when the add button is clicked', function() {
     var count;
     page.confirmVerification();
+    browser.sleep( 1000 );
     page.addPrivateLoanButton.click();
     count = element.all( by.css( '.private-loans .private-loans_loan' ) ).count();
     expect( count ).toBe( 2 );
@@ -29,6 +30,7 @@ fdescribe( 'The college costs worksheet page', function() {
   it( 'should remove a private loan entry when the loan\'s remove button is clicked', function() {
     var count;
     page.confirmVerification();
+    browser.sleep( 1000 );
     element.all( by.css( '.private-loans .private-loans_loan'))
       .last().all( by.css( '.private-loans_remove-btn' ) ).click();
     count = element.all( by.css( '.private-loans .private-loans_loan' ) ).count();
@@ -38,6 +40,7 @@ fdescribe( 'The college costs worksheet page', function() {
   it( 'should add a private loan even after the last private loan is removed', function() {
     var count;
     page.confirmVerification();
+    browser.sleep( 1000 );
     element.all( by.css( '.private-loans .private-loans_loan'))
       .last().all( by.css( '.private-loans_remove-btn' ) ).click();
     page.addPrivateLoanButton.click();

--- a/test/functional/dd-school-data-spec.js
+++ b/test/functional/dd-school-data-spec.js
@@ -14,15 +14,16 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
     browser.sleep( 600 );
     expect( page.programLengthSelect.$('option:checked').getText() ).toMatch( /2 years/ );
     page.confirmVerification();
+    browser.sleep( 1000 );
     expect( page.totalProgramDebt.getText() ).toEqual( '29,000' );
   } );
 
   it( 'should dynamically display the completion rate if it\'s available', function() {
     browser.sleep( 600 );
     page.confirmVerification();
-    browser.sleep( 750 );
+    browser.sleep( 1000 );
     page.answerBigQuestionNo();
-    browser.sleep( 750 );
+    browser.sleep( 1000 );
     expect( page.completionRate.getText() ).toEqual( '37' );
   } );
 

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -35,6 +35,16 @@ settlementAidOfferPage.prototype = Object.create({}, {
         this.incorrectInfoButton.click();
       }
     },
+    correctInfoSection: {
+      get: function() {
+        return element( by.id( 'info-right' ) );
+      }
+    },
+    incorrectInfoSection: {
+      get: function() {
+        return element( by.id( 'info-wrong' ) );
+      }
+    },
     programLengthSelect: {
       get: function() {
         return element ( by.css( '#estimated-years-attending' ) );


### PR DESCRIPTION
Adds animations when a student answer the verification question or the "do you think X amount of debt" question
## Additions
- Hides the verification buttons when answered "Yes, this is my info"
- When answer is given to verification question, scrolls down to the newly exposed content
- When answer is given to "do you think" question, scrolls down to the newly exposed content
## Testing
- Switch to the `animate-and-hide` branch, run gulp, and view the page with a fully loaded settlement program URL.
  - See what happens when you say the information isn't yours.
  - Refresh the page, then see what happens when you verify that the information is yours.
  - Scroll down the page to the "do you think..." question, and see what happens now when you make a choice.
## Review
- @niqjohnson @mistergone @higs4281
## To-dos

The browser.sleep()s in our functional testing are getting a little ridiculous. I think I found a way to avoid them, and make the tests more robust as a result. Stay tuned for a new PR about that this week.
## Checklist
- [x] CHANGELOG has been updated
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] Placeholder code is flagged
