### PR TITLE
Avoid merge conflicts in CHANGELOG.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-CHANGELOG.md merge=union
+/CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Fix graph point overlaps
 -
 - Added animation to button interactions
--
+- Switched to `merge=union` for CHANGELOG.md in .gitattributes
+- 
+- 
 
 ## 2.0.1
 - Updated content to be dynamic based on remaining cost


### PR DESCRIPTION
Or, in teamspeak, keep the changeling from experiencing Changehog Day over and over again. (AKA the movie where Bill Murray plays a web developer in western PA dealing with daily merge conflicts. Hey, wait a minute... :octopus: )

This adds a `.gitattributes` file that tells the system to merge the CHANGELOG.md file using the `union` merge driver, rather than the usual `text` driver. This should nearly eliminate merge conflicts in our changelog, unless we add a line with exactly the same text as an existing line.

References:
- http://krlmlr.github.io/using-gitattributes-to-avoid-merge-conflicts/
- http://git-scm.com/docs/git-merge-file
## Additions
- .gitattributes file that changes the merge driver for CHANGELOG.md
## Testing
- Let's try it out, and see if merge conflicts lessen/cease.
## Review
- @higs4281 @niqjohnson @mistergone 
## Checklist
- [x] CHANGELOG has been updated
