### PR TITLE
Add acitve state to selected big question answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
 -
--
+- Add active class to selected big question button
 -
 - Fix graph point overlaps
 -

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -212,7 +212,7 @@ var financialView = {
    */
   enumeratePrivateLoanIDs: function() {
     // renumber private loan ids to prevent duplicate IDs
-    $( '[data-private-loan' ).each( function() {
+    $( '[data-private-loan]' ).each( function() {
       var index = $( this ).index(),
           $ele = $( this ),
           $fields = $ele.find( '[data-private-loan_key]' );

--- a/src/disclosures/js/views/question-view.js
+++ b/src/disclosures/js/views/question-view.js
@@ -12,7 +12,10 @@ var questionView = {
   },
 
   bigQuestionListener: function() {
-    $( '.question_answers > .btn' ).on( 'click', function() {
+    var $answerButtons = $( '.question_answers > .btn' );
+    $answerButtons.on( 'click', function() {
+      $answerButtons.removeClass( 'active' );
+      $( this ).addClass( 'active' );
       if ( $( this ).attr( 'id' ) === 'question_answer-yes' ) {
         questionView.$followupYes.show();
         questionView.$followupNoNotSure.hide();

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -605,6 +605,7 @@ it( 'should properly update when more than one private loans is modified', funct
     browser.sleep( 1000 );
     page.answerBigQuestionYes();
     browser.sleep( 1000 );
+    expect( page.bigQuestionYesButton.getAttribute( 'class' ) ).toEqual( 'btn btn__grouped active' );
     expect( page.optionsConsiderationsSection.isDisplayed() ).toBeTruthy();
     expect( page.followupNoNotSureContent.isDisplayed() ).toBeFalsy();
     expect( page.followupYesContent.isDisplayed() ).toBeTruthy();
@@ -617,6 +618,7 @@ it( 'should properly update when more than one private loans is modified', funct
     browser.sleep( 1000 );
     page.answerBigQuestionNo();
     browser.sleep( 1000 );
+    expect( page.bigQuestionNoButton.getAttribute( 'class' ) ).toEqual( 'btn btn__grouped-first active' );
     expect( page.optionsConsiderationsSection.isDisplayed() ).toBeTruthy();
     expect( page.followupNoNotSureContent.isDisplayed() ).toBeTruthy();
     expect( page.followupYesContent.isDisplayed() ).toBeFalsy();
@@ -629,6 +631,7 @@ it( 'should properly update when more than one private loans is modified', funct
     browser.sleep( 1000 );
     page.answerBigQuestionNotSure();
     browser.sleep( 1000 );
+    expect( page.bigQuestionNotSureButton.getAttribute( 'class' ) ).toEqual( 'btn btn__grouped-last active' );
     expect( page.optionsConsiderationsSection.isDisplayed() ).toBeTruthy();
     expect( page.followupNoNotSureContent.isDisplayed() ).toBeTruthy();
     expect( page.followupYesContent.isDisplayed() ).toBeFalsy();

--- a/test/functional/dd-school-data-spec.js
+++ b/test/functional/dd-school-data-spec.js
@@ -47,6 +47,7 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
 
   it( 'should graph graudation rates', function() {
     page.confirmVerification();
+    browser.sleep( 200 );
     expect( page.schoolGradRatePoint.getCssValue( 'bottom' ) ).toEqual( '60.7px' );
     expect( page.schoolGradRateValue.getText() ).toEqual( '37%' );
     expect( page.nationalGradRatePoint.getCssValue( 'bottom' ) ).toEqual( '57.323px' );
@@ -57,12 +58,14 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
 
   it( 'should display the correct graduation rate notification', function() {
     page.confirmVerification();
+    browser.sleep( 200 );
     expect( page.gradRateNotification.getText() ).toEqual( 'Higher graduation rate than national average' );
     expect( page.gradRateNotification.getAttribute( 'class' ) ).toEqual( 'metric_notification metric_notification__better' );
   } );
 
   it( 'should graph average salary', function() {
     page.confirmVerification();
+    browser.sleep( 200 );
     expect( page.schoolSalaryPoint.getCssValue( 'bottom' ) ).toEqual( '45.3px' );
     // Checking for z-index lets us know an overlap is being handled correctly
     expect( page.schoolSalaryPoint.getCssValue( 'z-index' ) ).toEqual( '100' );
@@ -73,12 +76,14 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
 
   it( 'should display the correct average salary notification', function() {
     page.confirmVerification();
+    browser.sleep( 200 );
     expect( page.salaryNotification.getText() ).toEqual( 'Lower salary than national average' );
     expect( page.salaryNotification.getAttribute( 'class' ) ).toEqual( 'metric_notification metric_notification__worse cf-notification cf-notification__error' );
   } );
 
   it( 'should calculate debt burden', function() {
     page.confirmVerification();
+    browser.sleep( 200 );
     expect( page.debtBurdenPayment.getText() ).toEqual( '$314' );
     expect( page.debtBurdenSalary.getText() ).toEqual( '$1,917' );
     expect( page.debtBurdenPercent.getText() ).toEqual( '16%' );
@@ -86,12 +91,14 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
 
   it( 'should display the correct debt burden notification', function() {
     page.confirmVerification();
+    browser.sleep( 200 );
     expect( page.debtBurdenNotification.getText() ).toEqual( 'Loan payment is higher than recommended 8% of salary' );
     expect( page.debtBurdenNotification.getAttribute( 'class' ) ).toEqual( 'metric_notification metric_notification__worse cf-notification cf-notification__error' );
   } );
 
   it( 'should graph loan default rates', function() {
     page.confirmVerification();
+    browser.sleep( 200 );
     expect( page.schoolDefaultRatePoint.getCssValue( 'bottom' ) ).toEqual( '80.5px' );
     expect( page.schoolDefaultRateValue.getText() ).toEqual( '55%' );
     expect( page.nationalDefaultRatePoint.getCssValue( 'bottom' ) ).toEqual( '35.07px' );
@@ -100,6 +107,7 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
 
   it( 'should display the correct loan default rate notification', function() {
     page.confirmVerification();
+    browser.sleep( 200 );
     expect( page.defaultRateNotification.getText() ).toEqual( 'Higher default rate than national average' );
     expect( page.defaultRateNotification.getAttribute( 'class' ) ).toEqual( 'metric_notification metric_notification__worse cf-notification cf-notification__error' );
   } );


### PR DESCRIPTION
Add an active class to the selected big question button
## Additions
- Active class to the selected big question button
## Changes
- Missing bracket in a selector in `enumeratePrivateLoanIDs` (fixes #126 )
## Testing
- To test, pull in the `button-state` branch and run `gulp`. Fire up the app in standalone or UnityBox as normal.
- Load any test school you like and choose an answer to the big question. Your chosen answer should look like the screenshot below. If you choose a different answer, your newly chosen answer will get the darker blue active style.
- If you happen to have an iPhone, you should be able to remove a private loan and see your totals update correctly.
## Screenshot

![button-state](https://cloud.githubusercontent.com/assets/1862695/13433098/67460a1a-df9e-11e5-81f5-237b3f8a0da0.png)
## Review
- @marteki 
- @higs4281 
- @mistergone
## To do
- Depending on the results of user testing, we may want to consider hiding the big question buttons entirely once a choice is made.
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] Visually tested in supported browsers and devices
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
