### PR TITLE
[HOTFIX] Make adjustments to what content was intending to express about debt repayment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Adds avg_net_price to scorecard api updates
 - Added animation to button interactions
 - Switched to `merge=union` for CHANGELOG.md in .gitattributes
-- 
+- Hot fix for aligning debt values with content intent
 - 
 
 ## 2.0.1

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -2129,20 +2129,11 @@
                                     your salary. The general rule of thumb is
                                     that you shouldn’t borrow more than you
                                     will make during your first year out of
-                                    college. Your student loan payment
-                                    shouldn’t be more than 8% of your total
-                                    monthly income.
+                                    college.
                                 </p>
                                 <p>
-                                    Your total estimated debt, according to
-                                    the amounts entered above, is <span
-                                    data-financial="totalDebt">[XX]</span>.
-                                    <span id="criteria_median-school-debt-content">On average, students from your
-                                    school graduate with
-                                    <span id="criteria_median-school-debt"
-                                    data-financial="medianSchoolDebt">[XX]
-                                    </span> of debt (includes part-time,
-                                    full-time, and transfer students).</span>
+                                    Your student loan payment shouldn’t be
+                                    more than 8% of your total monthly income.
                                     The lower your total debt, the lower your
                                     debt burden will be.</p>
                                 <p>
@@ -2384,10 +2375,9 @@
                             <div class="question_content">
                                 <h2 class="step_heading">
                                     Do you feel like going into <span
-                                    data-financial="totalDebt">[XX]</span> of
-                                    debt to attend this school is a good
-                                    investment in your future?
-                                </h2>
+                                    data-financial="loanLifetime">[XX]</span>
+                                    of debt to attend this school is a good
+                                    investment in your future? </h2>
                                 <div class="question_answers">
                                     <button class="btn btn__grouped-first"
                                     id="question_answer-no"


### PR DESCRIPTION
Need to make a hotfix adjustment for usability testing, since the values passing through weren't the right ones for the content and user experience.
## Removals
- Got rid of a confusing paragraph in the debt burden area.
## Changes
- The "Do you feel..." question now references the total repayment debt value after interest and fees.
## Testing
- It's on the `fix-debt-value` branch. Give it a whirl. I'm looking to commit today, so it can get onto build for testing by tomorrow.
## Review
- Already reviewed by @kurzn 
- One of @niqjohnson @higs4281 @mistergone 
## Checklist
- [x] CHANGELOG has been updated
