### PR TITLE
Get metric national values from financial model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,8 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
--
--
 - Added animation to button interactions
 - Change graphs to get all values from the financial model
--
--
 
 ## 2.0.2
 - Add active class to selected big question button
@@ -16,7 +12,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Added animation to button interactions
 - Switched to `merge=union` for CHANGELOG.md in .gitattributes
 - Hot fix for aligning debt values with content intent
-- 
+-
 
 ## 2.0.1
 - Updated content to be dynamic based on remaining cost

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 -
 -
+- Added animation to button interactions
+- Change graphs to get all values from the financial model
 -
 -
 

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -283,13 +283,11 @@ var financialView = {
       // to get all the right CSS values, so we'll wait 100 ms
       if ( $( this ).attr( 'href' ) === '#info-right' ) {
         e.preventDefault();
-        setTimeout( function() {
-          metricView.updateGraphs( values );
-        }, 100 );
         financialView.$infoVerified.show();
         $( 'html, body' ).stop().animate( {
           scrollTop: financialView.$infoVerified.offset().top - 120
         }, 900, 'swing', function() {
+          metricView.updateGraphs( values );
           window.location.hash = '#info-right';
         } );
       } else {

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -146,7 +146,7 @@ var financialView = {
     this.updateLeftovers( values, $leftovers );
     this.updatePrivateLoans( values, $privateLoans );
     this.updateRemainingCostContent();
-    metricView.updateDebtBurdenDisplay( values, window.nationalData );
+    metricView.updateDebtBurdenDisplay( values );
   },
 
   /**
@@ -278,14 +278,13 @@ var financialView = {
    */
   verificationListener: function() {
     this.$verifyControls.on( 'click', '.btn', function( e ) {
-      var schoolValues = getModelValues.financial(),
-          nationalValues = window.nationalData;
+      var values = getModelValues.financial();
       // Graph points need to be visible before updating their positions
       // to get all the right CSS values, so we'll wait 100 ms
       if ( $( this ).attr( 'href' ) === '#info-right' ) {
         e.preventDefault();
         setTimeout( function() {
-          metricView.updateGraphs( schoolValues, nationalValues );
+          metricView.updateGraphs( values );
         }, 100 );
         financialView.$infoVerified.show();
         $( 'html, body' ).stop().animate( {

--- a/src/disclosures/js/views/metric-view.js
+++ b/src/disclosures/js/views/metric-view.js
@@ -9,9 +9,8 @@ var metricView = {
    * Initiates the object
    */
   init: function() {
-    var schoolValues = getModelValues.financial(),
-        nationalValues = window.nationalData || {};
-    this.updateGraphs( schoolValues, nationalValues );
+    var values = getModelValues.financial();
+    this.updateGraphs( values );
     // updateDebtBurdenDisplay is called in financialView.updateView, not here,
     // since the debt burden needs to refresh when loan amounts are modified
   },
@@ -179,25 +178,24 @@ var metricView = {
 
   /**
    * Initializes all metrics with bar graphs
-   * @param {object} schoolValues Values reported by the school
-   * @param {object} nationalValues National average values
+   * @param {object} values Financial model values
    */
-  updateGraphs: function( schoolValues, nationalValues ) {
+  updateGraphs: function( values ) {
     var $graphs = $( '.bar-graph' );
     $graphs.each( function() {
       var $graph = $( this ),
           metricKey = $graph.attr( 'data-metric' ),
           nationalKey = $graph.attr( 'data-national-metric' ),
           graphFormat = $graph.attr( 'data-incoming-format' ),
-          schoolAverage = parseFloat( schoolValues[metricKey] ),
+          schoolAverage = parseFloat( values[metricKey] ),
           schoolAverageFormatted = metricView.formatValue( graphFormat, schoolAverage ),
-          nationalAverage = parseFloat( nationalValues[nationalKey] ),
+          nationalAverage = parseFloat( values[nationalKey] ),
           nationalAverageFormatted = metricView.formatValue( graphFormat, nationalAverage ),
           $schoolPoint = $graph.find( '.bar-graph_point__you' ),
           $nationalPoint = $graph.find( '.bar-graph_point__average' ),
           $notification = $graph.siblings( '.metric_notification' ),
-          sameMin = parseFloat( nationalValues[nationalKey + 'Low'] ),
-          sameMax = parseFloat( nationalValues[nationalKey + 'High'] ),
+          sameMin = parseFloat( values[nationalKey + 'Low'] ),
+          sameMax = parseFloat( values[nationalKey + 'High'] ),
           betterDirection = $notification.attr( 'data-better-direction' ),
           notificationClasses = metricView.getNotificationClasses( schoolAverage, nationalAverage, sameMin, sameMax, betterDirection );
       metricView.setGraphValues( $graph, schoolAverageFormatted, nationalAverageFormatted );
@@ -233,13 +231,12 @@ var metricView = {
   /**
    * Populates the debt burden numbers and shows the corresponding notification
    * on the page
-   * @param {object} schoolValues Values reported by the school
-   * @param {object} nationalValues National average values
+   * @param {object} values Financial model values
    */
-  updateDebtBurdenDisplay: function( schoolValues, nationalValues ) {
-    var annualSalary = Number( schoolValues.medianSalary ) || Number( nationalValues.earningsMedian ),
+  updateDebtBurdenDisplay: function( values ) {
+    var annualSalary = Number( values.medianSalary ) || Number( values.earningsMedian ),
         monthlySalary = this.calculateMonthlySalary( annualSalary ),
-        monthlyLoanPayment = schoolValues.loanMonthly || 0,
+        monthlyLoanPayment = values.loanMonthly || 0,
         debtBurden = this.calculateDebtBurden( monthlyLoanPayment, monthlySalary ),
         annualSalaryFormatted = this.formatValue( 'currency', annualSalary ),
         monthlySalaryFormatted = this.formatValue( 'currency', monthlySalary ),

--- a/test/functional/dd-school-data-spec.js
+++ b/test/functional/dd-school-data-spec.js
@@ -47,7 +47,7 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
 
   it( 'should graph graudation rates', function() {
     page.confirmVerification();
-    browser.sleep( 200 );
+    browser.sleep( 1000 );
     expect( page.schoolGradRatePoint.getCssValue( 'bottom' ) ).toEqual( '60.7px' );
     expect( page.schoolGradRateValue.getText() ).toEqual( '37%' );
     expect( page.nationalGradRatePoint.getCssValue( 'bottom' ) ).toEqual( '57.323px' );
@@ -58,14 +58,14 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
 
   it( 'should display the correct graduation rate notification', function() {
     page.confirmVerification();
-    browser.sleep( 200 );
+    browser.sleep( 1000 );
     expect( page.gradRateNotification.getText() ).toEqual( 'Higher graduation rate than national average' );
     expect( page.gradRateNotification.getAttribute( 'class' ) ).toEqual( 'metric_notification metric_notification__better' );
   } );
 
   it( 'should graph average salary', function() {
     page.confirmVerification();
-    browser.sleep( 200 );
+    browser.sleep( 1000 );
     expect( page.schoolSalaryPoint.getCssValue( 'bottom' ) ).toEqual( '45.3px' );
     // Checking for z-index lets us know an overlap is being handled correctly
     expect( page.schoolSalaryPoint.getCssValue( 'z-index' ) ).toEqual( '100' );
@@ -76,14 +76,14 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
 
   it( 'should display the correct average salary notification', function() {
     page.confirmVerification();
-    browser.sleep( 200 );
+    browser.sleep( 1000 );
     expect( page.salaryNotification.getText() ).toEqual( 'Lower salary than national average' );
     expect( page.salaryNotification.getAttribute( 'class' ) ).toEqual( 'metric_notification metric_notification__worse cf-notification cf-notification__error' );
   } );
 
   it( 'should calculate debt burden', function() {
     page.confirmVerification();
-    browser.sleep( 200 );
+    browser.sleep( 1000 );
     expect( page.debtBurdenPayment.getText() ).toEqual( '$314' );
     expect( page.debtBurdenSalary.getText() ).toEqual( '$1,917' );
     expect( page.debtBurdenPercent.getText() ).toEqual( '16%' );
@@ -91,14 +91,14 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
 
   it( 'should display the correct debt burden notification', function() {
     page.confirmVerification();
-    browser.sleep( 200 );
+    browser.sleep( 1000 );
     expect( page.debtBurdenNotification.getText() ).toEqual( 'Loan payment is higher than recommended 8% of salary' );
     expect( page.debtBurdenNotification.getAttribute( 'class' ) ).toEqual( 'metric_notification metric_notification__worse cf-notification cf-notification__error' );
   } );
 
   it( 'should graph loan default rates', function() {
     page.confirmVerification();
-    browser.sleep( 200 );
+    browser.sleep( 1000 );
     expect( page.schoolDefaultRatePoint.getCssValue( 'bottom' ) ).toEqual( '80.5px' );
     expect( page.schoolDefaultRateValue.getText() ).toEqual( '55%' );
     expect( page.nationalDefaultRatePoint.getCssValue( 'bottom' ) ).toEqual( '35.07px' );
@@ -107,7 +107,7 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
 
   it( 'should display the correct loan default rate notification', function() {
     page.confirmVerification();
-    browser.sleep( 200 );
+    browser.sleep( 1000 );
     expect( page.defaultRateNotification.getText() ).toEqual( 'Higher default rate than national average' );
     expect( page.defaultRateNotification.getAttribute( 'class' ) ).toEqual( 'metric_notification metric_notification__worse cf-notification cf-notification__error' );
   } );

--- a/test/functional/dd-school-data-spec.js
+++ b/test/functional/dd-school-data-spec.js
@@ -27,12 +27,6 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
     expect( page.completionRate.getText() ).toEqual( '37' );
   } );
 
-  it( 'should dynamically display the median school or program debt if it\'s available', function() {
-     browser.sleep( 600 );
-     page.confirmVerification();
-     expect( page.medianSchoolDebt.getText() ).toEqual( '$24,500' );
-  } );
-
   it( 'should dynamically display the expected monthly salary if it\'s available', function() {
      browser.sleep( 600 );
      page.confirmVerification();

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -393,11 +393,6 @@ settlementAidOfferPage.prototype = Object.create({}, {
         return element( by.id( 'option_completion-rate' ) );
       }
     },
-    medianSchoolDebt: {
-      get: function() {
-        return element( by.id( 'criteria_median-school-debt' ) );
-      }
-    },
     jobRate: {
       get: function() {
         return element( by.id( 'criteria_job-placement-rate' ) );


### PR DESCRIPTION
Changes graph and debt burden JavaScript to get all values from the updated financial model instead of the `window` objects
## Removals
- Unneeded test for median school/program debt to make sure all tests pass (that value was removed from the page in #138)
## Changes
- All graph and debt burden values are now pulled from the financial model
- Graphs are updated in the callback that fires when someone verifies their offer information instead of in a separate timeout
## Testing
- To test, pull in the `graph-model` branch and run `gulp`. Fire up the app in standalone or UnityBox as normal.
- Load any test school you like. Everything should look the same as before.
- All unit and functional tests should pass
## Review
- @marteki 
- @mistergone
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Visually tested in supported browsers and devices
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
