### PR TITLE
fix verify view and related test

### DIFF
--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -315,29 +315,22 @@ class APITests(django.test.TestCase):
 class VerifyViewTest(django.test.TestCase):
 
     fixtures = ['test_fixture.json']
-    mock_payload = {
-        'oid': 'f38283b5b7c939a058889f997949efa566c616c5',
-        'iped': '408039',
-        'errors': 'none'
-    }
+    post_data = {'oid': 'f38283b5b7c939a058889f997949efa566c616c5',
+                 'iped': '408039',
+                 'errors': 'none'}
+    url = reverse('disclosures:verify')
 
     def test_verify_view(self):
-        url = reverse('disclosures:verify')
-        resp = client.post(url,
-                           data=json.dumps(self.mock_payload),
-                           content_type="application/x-www-form-urlencoded; charset=UTF-8")
+        resp = client.post(self.url, data=self.post_data)
         self.assertTrue(resp.status_code == 200)
-
-    def test_verify_view_no_data(self):
-        url = reverse('disclosures:verify')
-        resp = client.post(url,
-                           data='',
-                           content_type="application/x-www-form-urlencoded; charset=UTF-8")
-        self.assertTrue(resp.status_code == 400)
+        self.assertTrue('verification' in resp.content)
 
     def test_verify_view_bad_id(self):
-        url = reverse('disclosures:verify')
-        resp = client.post(url,
-                           data='{"iped": ""}',
-                           content_type="application/x-www-form-urlencoded; charset=UTF-8")
+        self.post_data['iped'] = ''
+        resp = client.post(self.url, data=self.post_data)
+        self.assertTrue(resp.status_code == 400)
+
+    def test_verify_view_no_data(self):
+        self.post_data = {}
+        resp = client.post(self.url, data=self.post_data)
         self.assertTrue(resp.status_code == 400)

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -447,20 +447,18 @@ def school_search_api(request):
 
 class VerifyView(View):
     def post(self, request):
-        if request.body:
-            timestamp = timezone.now()
-            data = json.loads(request.body)
-            if 'iped' in data and data['iped']:
-                school = School.objects.get(school_id=int(data['iped']))
-                notification = Notification.objects.create(institution=school,
-                                                           oid=data['oid'],
-                                                           timestamp=timestamp,
-                                                           errors=data['errors'][:255])
-                msg = notification.notify_school()
-            else:
-                return HttpResponseBadRequest("No valid school ID found")
+        data = request.POST
+        timestamp = timezone.now()
+        if 'iped' in data and data['iped']:
+            school = School.objects.get(school_id=int(data['iped']))
+            notification = Notification.objects.create(institution=school,
+                                                       oid=data['oid'],
+                                                       timestamp=timestamp,
+                                                       errors=data['errors'][:255])
+            msg = notification.notify_school()
+            callback = json.dumps({'result': "verification recorded; {0}".format(msg)})
         else:
-            return HttpResponseBadRequest("No form data found")
+            return HttpResponseBadRequest("No valid school ID found; postdata is {0}".format(request.POST))
 
-        response = HttpResponse({'result': msg})
+        response = HttpResponse(callback)
         return response


### PR DESCRIPTION
fixes payload handling in verify view
## Changes
- views.py and related tests 
## Testing
- This won't enable verifications until merged with the @mistergone error-reporting branch, but it shouldn't cause any mischief.
- Before merging, clicking on "No, this is not my information" shouldn't make any api calls. 
- When merged, clicking on "No, this is not my information" should make a request to `/api/verify/` and return a 200 response.

<img width="733" alt="verify_request" src="https://cloud.githubusercontent.com/assets/515885/13693540/20b2756a-e71a-11e5-81d6-b9683b775db8.png">
## Review
- @mistergone and any others
