### PR TITLE
Data refresh

### DIFF
--- a/paying_for_college/migrations/0017_auto__add_field_school_under_investigation.py
+++ b/paying_for_college/migrations/0017_auto__add_field_school_under_investigation.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'School.under_investigation'
+        db.add_column(u'paying_for_college_school', 'under_investigation',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'School.under_investigation'
+        db.delete_column(u'paying_for_college_school', 'under_investigation')
+
+
+    models = {
+        u'paying_for_college.alias': {
+            'Meta': {'object_name': 'Alias'},
+            'alias': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'is_primary': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'paying_for_college.bahrate': {
+            'Meta': {'object_name': 'BAHRate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'value': ('django.db.models.fields.IntegerField', [], {}),
+            'zip5': ('django.db.models.fields.CharField', [], {'max_length': '5'})
+        },
+        u'paying_for_college.constantcap': {
+            'Meta': {'ordering': "['slug']", 'object_name': 'ConstantCap'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'value': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'paying_for_college.constantrate': {
+            'Meta': {'ordering': "['slug']", 'object_name': 'ConstantRate'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'value': ('django.db.models.fields.DecimalField', [], {'max_digits': '6', 'decimal_places': '5'})
+        },
+        u'paying_for_college.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'contact': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'endpoint': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'internal_note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'paying_for_college.disclosure': {
+            'Meta': {'object_name': 'Disclosure'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'paying_for_college.feedback': {
+            'Meta': {'object_name': 'Feedback'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {})
+        },
+        u'paying_for_college.nickname': {
+            'Meta': {'ordering': "['nickname']", 'object_name': 'Nickname'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'is_female': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'nickname': ('django.db.models.fields.TextField', [], {})
+        },
+        u'paying_for_college.notification': {
+            'Meta': {'object_name': 'Notification'},
+            'email': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'errors': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'oid': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        u'paying_for_college.program': {
+            'Meta': {'object_name': 'Program'},
+            'accreditor': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'books': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'campus': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'cip_code': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'completion_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'default_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'fees': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'housing': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'institution': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.School']"}),
+            'institutional_debt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'job_note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'job_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '2', 'blank': 'True'}),
+            'level': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'mean_student_loan_completers': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'median_student_loan_completers': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'other_costs': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'private_debt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'program_code': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'program_length': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'program_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'salary': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'soc_codes': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'time_to_complete': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'titleiv_debt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'total_cost': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'transportation': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'tuition': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'paying_for_college.school': {
+            'KBYOSS': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'Meta': {'object_name': 'School'},
+            'accreditor': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'avg_net_price': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['paying_for_college.Contact']", 'null': 'True', 'blank': 'True'}),
+            'control': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'data_json': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'default_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '3', 'blank': 'True'}),
+            'degrees_highest': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'degrees_predominant': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'enrollment': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'grad_rate': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '3', 'blank': 'True'}),
+            'grad_rate_4yr': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '3', 'blank': 'True'}),
+            'grad_rate_lt4': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '5', 'decimal_places': '3', 'blank': 'True'}),
+            'main_campus': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'median_annual_pay': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'median_monthly_debt': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '14', 'decimal_places': '9', 'blank': 'True'}),
+            'median_total_debt': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '7', 'decimal_places': '1', 'blank': 'True'}),
+            'online_only': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'ope6_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'ope8_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'operating': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'ownership': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'repay_3yr': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '13', 'decimal_places': '10', 'blank': 'True'}),
+            'school_id': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '2', 'blank': 'True'}),
+            'tuition_in_state': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'tuition_out_of_state': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'under_investigation': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'url': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'zip5': ('django.db.models.fields.CharField', [], {'max_length': '5', 'blank': 'True'})
+        },
+        u'paying_for_college.worksheet': {
+            'Meta': {'object_name': 'Worksheet'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'guid': ('django.db.models.fields.CharField', [], {'max_length': '64', 'primary_key': 'True'}),
+            'saved_data': ('django.db.models.fields.TextField', [], {}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['paying_for_college']

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -155,6 +155,8 @@ class School(models.Model):
     main_campus = models.NullBooleanField()
     online_only = models.NullBooleanField()
     operating = models.BooleanField(default=True)
+    under_investigation = models.BooleanField(default=False,
+                                              help_text="Heightened Cash Monitoring 2")
     KBYOSS = models.BooleanField(default=False)  # shopping-sheet participant
 
     grad_rate_4yr = models.DecimalField(max_digits=5,

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -204,7 +204,7 @@ class OfferTest(django.test.TestCase):
         resp2 = client.get(url+no_oid)
         self.assertTrue(resp2.status_code == 200)
         resp3 = client.get(url+bad_school)
-        self.assertTrue("No school" in resp3.content)
+        self.assertTrue("No active school" in resp3.content)
         self.assertTrue(resp3.status_code == 400)
         resp4 = client.get(url+bad_program)
         self.assertTrue(resp4.status_code == 200)

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -135,8 +135,8 @@ class OfferView(TemplateView):  # TODO log errors
         if 'iped' in request.GET and request.GET['iped']:
             iped = request.GET['iped']
             school = get_school(iped)
-            if not school:
-                error = "No school could be found for iped ID {0}".format(iped)
+            if not school or not school.operating:
+                error = "No active school could be found for iped ID {0}".format(iped)
                 return HttpResponseBadRequest(error)
             if 'oid' in request.GET:
                 OID = request.GET['oid']


### PR DESCRIPTION
This pulls in the latest Ed API refresh, taking closed schools out of the mix and adding an "under_investigation" flag for possible use. Latest data year is still 2013, although some values, like "operating" and "under_investigation," are 2015 or better.
## Additions
- `under_investigation` column in our database. This requires a migrate/loaddata refresh.
  - on UnityBox:  
    
    ```
    workon cfpb_django
    cd /var/www/django/cfpb
    ./manage.py migrate paying_for_college
    ./manage.py loaddata collegedata.json --settings=cfpb_django.settings.no_haystack
    ```
  - in standalone:  
    
    ```
    ./manage.py migrate paying_for_college
    ./manage.py loaddata collegedata.json
    ```
## Testing
- DeVry University-Wisconsin has closed and should no longer show up:
  - [standalone](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=482671)
  - [UnityBox](http://localhost:8080/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=482671)
## Review
- any: @mistergone @marteki @niqjohnson 
## Screenshots

BEFORE:  
<img width="579" alt="devry-wis_before" src="https://cloud.githubusercontent.com/assets/515885/13713126/70b69994-e795-11e5-85fa-b7903838e975.png">
