### PR TITLE
Update about page to new design standards

### DIFF
--- a/paying_for_college/templates/technote.html
+++ b/paying_for_college/templates/technote.html
@@ -1,154 +1,267 @@
 {% extends base_template %}
 {% load staticfiles %}
-
-{% block title %}Paying for College Cost Comparison Tool{% endblock %}
-
-{% block page_css %}
-<link rel="stylesheet" href="{% static "paying_for_college/disclosures/css/comparison-tool.css" %}">
+{% block title %}Understanding your financial aid offer{% endblock %}
+{% block page_viewport %}
+<meta name="viewport" content="width=device-width, initial-scale=1">
+{% endblock %}
+{% block nemo_styles %}
+{% endblock %}
+{% block app_css %}
+<!--[if lt IE 9]>
+    <link rel="stylesheet" href="{% static "paying_for_college/disclosures/static/css/main.ie.css" %}">
+<![endif]-->
+<!--[if gt IE 8]><!-->
+    <link rel="stylesheet" href="{% static "paying_for_college/disclosures/static/css/main.min.css" %}">
+<!--<![endif]-->
+{% endblock %}
+{% block responsive_nav %}
+<a class="toggle-menu" href="#"><i class="cf-icon cf-icon-menu"></i>
+    <span class="u-visually-hidden">Menu</span></a>
 {% endblock %}
 
-{% block body_class %}page paying-for-college{% endblock %}
-
 {% block content %}
-
-<div id="comparison-tool" class="comparison-tool sub-page-wrapper">
-		
-	<header id="comparison-tool-header" class="pfc-header sub-page">
-		<a class="noStyles" href="/paying-for-college/"><h1>Paying for College</h1></a>
-		<p>Compare financial aid and college cost</p>				
-	</header><!-- end #comparison-tool-header -->
-	
-	<section class="about-section clearfix">
-		<header class="section-header col col4">
-			<h2>Technical notes and assumptions</h2>
-		</header>
-		<div class="col last col8">
-			<p>For users interested in learning more about how specific sections of this tool work, scroll down to the relevant section below. Some of this information may be a bit technical, but we want to be open and transparent.</p>
-			<p>Below is more information on how we developed this version of the tool, including the data we’ve used and assumptions we’ve made.</p>
-		</div>
-	</section><!-- end .about-section -->
-
-	<section class="about-section clearfix">
-		<header class="section-header col col4">
-			<h2>Financial aid shopping sheet</h2>
-		</header>
-		<div class="col last col8">
-			<p>As part of our <a href="http://www.consumerfinance.gov/students/knowbeforeyouowe/">Know Before You Owe</a> project, we worked with the Department of Education to create a <a class="exit-link pdf" href="http://collegecost.ed.gov/shopping_sheet.pdf">Financial Aid Shopping Sheet</a>. Now that hundreds of colleges are adopting this clear and comparable form, we have rebuilt this tool to complement that shopping sheet to help students make comparisons tailored to their individual circumstances.</p>
-			<p>If your school indicated to the Department of Education that it has adopted the Financial Aid Shopping sheet, the tool gives you the option to upload an XML version of the sheet (an option some schools choose to offer) by pasting in XML code. This step is optional. If your school did not indicate to the Department of Education that it was adopting the shopping sheet, you can still make a comparison by manually entering information from your offer letter.</p>
-		</div>
-	</section><!-- end .about-section -->
-
-	<section class="about-section clearfix">
-		<header class="section-header col col4">
-			<h2>Compare schools</h2>
-		</header>
-		<div class="col last col8">
-			<p>Start using the tool by clicking on “Get started.” As you type your school’s name in the first field, the tool will autocomplete with the names of schools with similar spelling. The tool should also be able to find commonly used names for a particular school (e.g., type in UCLA and you should find the University of California Los Angeles). The tool uses the Department of Education’s IPEDS list of postsecondary institutions.</p>
-			<p>After choosing a school, set program length (1-5 years) and program type (Associates or certificate, Bachelors, Graduate). By selecting your program type, the tool adjusts your federal loan limits (see below) and calculates your estimated monthly payments based on the length of your program (see below).</p>
-			<p>Indicate whether or not you have a financial aid offer from each school. This will help us follow up with the right questions based on your situation.</p>
-		</div>
-	</section><!-- end .about-section -->
-
-	<section class="about-section clearfix">
-		<header class="section-header col col4">
-			<h2>Cost of attendance</h2>
-		</header>
-		<div class="col last col8">
-			<p>Using your financial aid offer letter, enter in your first year tuition &amp; fees, housing &amp; meals, books &amp; supplies and other expenses. If you have not yet received your offer letter, you can find the cost information by clicking where indicated. This will take you to the Department of Education’s College Navigator page for this school. Click on the “Tuition, Fees and Estimated Student Expenses” tab to locate cost information to add to your comparison.</p>
-		</div>
-	</section><!-- end .about-section -->
-
-	<section class="about-section clearfix">
-		<header class="section-header col col4">
-			<h2>Money for school</h2>
-		</header>
-		<div class="col last col8">
-			<p>After you fill out your Free Application for Federal Student Aid (FAFSA), each college that sends you an acceptance letter should also send you a financial aid offer letter. This should include the types and amounts of “financial aid” being offered to the student.</p>
-			<ul>
-				<li><a class="exit-link" href="http://studentaid.ed.gov/types/grants-scholarships/pell">Pell grants</a> are federal grants that do not have to be repaid and are awarded based on your financial need, up to $5,730 per year.</li>
-				<li><em>Military tuition assistance</em>: Tuition Assistance provides support (up to $4,500 per year) for some active-duty servicemembers (active &amp; reserve) who are pursuing higher education. Military TA benefits do not need to be repaid.</li>
-				<li><em>GI Bill</em> benefits offer education benefits for servicemembers and veterans. This funding covers tuition and fees, a monthly living allowance, and an annual book stipend. GI Bill benefits do not need to be repaid (see below).</li>
-				<li><a class="exit-link" href="http://studentaid.ed.gov/types/loans/perkins">Perkins loans</a> are low-interest loans for students with financial need and do not accrue interest while students are enrolled in school. These loans are available up to $5,500 per year for undergraduates and $8,000 per year for graduate students.</li>
-				<li><a class="exit-link" href="http://studentaid.ed.gov/types/loans/subsidized-unsubsidized">Subsidized loans</a> are federal loans for students who demonstrate financial need and do not accrue interest while students are enrolled in school. These loans, which must be repaid, are available for up to $3,500 per year for first year college students. Graduates students are not eligible for these loans.</li>
-				<li><a class="exit-link" href="http://studentaid.ed.gov/types/loans/subsidized-unsubsidized">Unsubsidized loans</a> do not require students to demonstrate financial need but they do accrue interest while students are in school. All first year dependent, undergraduate students may borrow up to $5,500 per year in subsidized and unsubsidized loans. For independent undergraduate students, this limit rises to $9,500 per year. For graduate students the limit is $20,500 per year.</li>
-				<li><a class="exit-link" href="http://studentaid.ed.gov/types/loans/plus">PLUS Loans</a> are available to graduate and professional students, up to the program’s cost of attendance minus any other financial assistance received. Parents may also borrow PLUS loans to pay for the expenses of undergraduate dependents. Under some circumstances, independent undergraduate students may also borrow PLUS loans. Unlike other federal student loans, eligibility for PLUS loans is dependent on the borrower’s credit</li>
-				<li>Loans from your school: A private loan from your school may have variable interest rates, require a credit check and/or a cosigner and lack many of the repayment options available with federal student loans. The tool allows you to adjust the interest rate to match what you have been offered by your lender (see below).</li>
-				<li>Private loans often have variable interest rates, require a credit check and/or a cosigner and lack many of the repayment options of federal student loans. Students should explore all of their federal grant and loan options before taking out a private student loan. The tool allows you to adjust that interest rate to match what you have been offered by your lender.(see below)</li>
-			</ul>
-		</div>
-	</section><!-- end .about-section -->
-
-	<section class="about-section clearfix">
-		<header class="section-header col col4">
-			<h2>GI Bill benefits calculator</h2>
-		</header>
-		<div class="col last col8">
-			<p>The tool allows veterans, servicemembers and eligible family members to calculate their GI Bill benefits. The tool assumes the following conditions for students seeking to use GI Bill benefits:</p>
-			<ul>
-				<li>Veterans will use the Post-9/11 GI Bill (Chapter 33). If a veteran has yet to serve 90 days of active duty service after September 11, 2001; but, is serving in the National Guard or Reserves, they will use the Select Reserve GI Bill (Chapter 1606).</li>
-				<li>Veterans have 36 months of remaining eligibility (equivalent to 4 academic years).</li>
-				<li>Student is enrolled in at least one class in a physical classroom unless the Department of Education has indicated that this school provides exclusively online education. If a veteran is taking all of their classes online they are only eligible to receive a living allowance of up to $684/month.</li>
-			</ul>
-		</div>
-	</section><!-- end .about-section -->
-
-	<section class="about-section clearfix">
-		<header class="section-header col col4">
-			<h2>After school</h2>
-		</header>
-		<div class="col last col8">
-			<p>Based on what you’ve entered, we’ve come up with a rough estimate of what your monthly payment would be if you borrowed the same amount each year of your program, completed your program on time (based on the program length you provide when you added the school), and paid your loan on a standard 10-year repayment schedule. To come up with this estimate, we’ve made certain assumptions about your total debt at graduation, the interest rate of your loans, and when you’ll begin repayment.</p>
-			<p>In calculating estimated monthly repayment amounts, we assume that the sticker price or cost of attendance remains constant for the duration of the program and that students take out the same loans (both type and amount) for each year that they are in school. In fact, students may take longer to complete their degrees; institutions have historically increased tuition prices each year; and students may make different financing decisions in different years.</p>
-			<p>We also assume a standard repayment-term of ten years and that students begin repayment after they graduate and their allotted grace period expires (between 6-9 months after graduating, depending on the type of loan). For federal student loans, we apply the interest rates for originations beginning on July 1, 2013:
-			<ul>
-				<li>Perkins (for undergraduate and graduate/professional students): Fixed at 5%</li>
-				<li>Direct Subsidized and Unsubsidized Loans (for undergraduate students): Fixed at 3.86%</li>
-				<li>Direct Unsubsidized Loans (for graduate/professional students): Fixed at 5.41%</li>
-				<li>Direct PLUS Loans (for parents and graduate/professional students): Fixed at 6.41%</li>
-				<li>For all Direct Subsidized and Unsubsidized Loans, the Department of Education also charges a 1% loan fee. For all PLUS loans, there is a 4% loan fee.</li>
-			</ul>
-			<p>These rates are set by the laws governing federal student loan programs, including the Higher Education Act.</p>
-			<p>For institutional and private student loans, we assume a fixed interest rate of 7.9%, which is identical to the old PLUS loan rate. The tool allows you to adjust that interest rate to match what you have been offered by your lender. However, keep in mind that interest rates on institutional and private student loans may be variable and change significantly throughout the duration of the loan.</p>
-			<h3>Debt at graduation</h3>
-			<p>Based on what you’ve entered, we’ve come up with a rough estimate of how much you will owe in students loans when you begin repayment. We use the same assumptions for debt at graduation as we do for the estimated monthly payment.</p>
-			<h3>Monthly payments</h3>
-			<p>Percent of monthly salary: The pie chart shows you how much of your post-graduation income will be spent repaying your student loans. Since institution-specific salary data is not available, this version of the tool uses the average salary one year after graduation for a student with a bachelor’s degree, as reported by the <a class="exit-link" href="http://nces.ed.gov/surveys/b&amp;b/">Department of Education’s Baccalaureate and Beyond</a> study. Adjusted for inflation, this figure equates to $30,922 per year on a pre-tax basis (a monthly salary of $2,577).</p>
-			<h3>Debt burden</h3>
-			<p>Your debt burden measures your estimated debt after school against the national average starting salary for college grads. Again, it’s an average. If you make more money, you’ll have a lower burden. It also doesn’t factor in specific information about your school or special repayment programs, like Income Based Repayment or Public Service Loan Forgiveness.</p>
-			<p>Total debt is calculated as described above. Since institution-specific salary data is not available, this version of the tool uses the average salary one year after graduation for a student with a bachelor’s degree, as reported by the <a class="exit-link" href="http://nces.ed.gov/surveys/b&amp;b/">Department of Education’s Baccalaureate and Beyond</a> study. Adjusted for inflation, this figure equates to $30,922 per year on a pre-tax basis (a monthly salary of $2,577).</p>
-			<p>Debt burden does not take into account that the average starting salary of graduates of particular institutions may vary. This tool will provide an indication of whether debt burden is low, medium, or high as follows:
-			<ul>
-				<li>Low: monthly payment is &lt; 8% of average monthly salary</li>
-				<li>Medium: monthly payment is 8%–14% of average monthly salary</li>
-				<li>High: monthly payment is > 14% of average monthly salary</li>
-			</ul>
-			<p>Since this version uses the same salary assumption across institutions, the debt burden indicator is not specific to an institution.</p>
-		</div>
-	</section><!-- end .about-section -->
-
-	<section class="about-section clearfix">
-		<header class="section-header col col4">
-			<h2>School indicators</h2>
-		</header>
-		<div class="col last col8">
-			<p>Schools disclose key institutional performance metrics, including graduation and loan default rates as well as the median amount of Federal loans borrowed by students at the institution and the corresponding estimated monthly payment over a ten year period.</p>
-			<p>Schools that only offer graduate programs are not required to report these rates, and will be shown as “Not Reported.” School indicators are then evaluated against other schools. Users interested in further school-specific information may wish to visit the <a class="exit-link" href="http://nces.ed.gov/collegenavigator/">Department of Education’s College Navigator website</a> for a more complete set of indicators.</p>
-			<h3>Graduation rate</h3>
-			<p>The graduation rate is for first-time, full-time degree or certificate-seeking undergraduate students who began at the institution. For primarily bachelor’s degree-granting institutions, the graduation rate displayed is for students beginning in Fall 2006 and seeking a bachelor’s degree. For primarily associate’s degree-granting institutions and primarily certificate-granting institutions, the graduation rate displayed is for students beginning in Fall 2009.
-			<p>Data used to calculate an institution’s graduation rate come from the institution’s annual submission to the U.S. Department of Education’s Integrated Postsecondary Education Data System (IPEDS).</p>
-			<p>The institution’s graduation rate is displayed with an indication of how it compares with graduation rates among institutions that primarily grant the same degree or certificate. For example, the comparison group for an institution that primarily awards bachelor’s degrees is all institutions that primarily award bachelor’s degrees. Graduation rate data are based on undergraduate students who enrolled full-time and have never enrolled in college before. This may not represent all undergraduates that attend this institution. Data from the IPEDS Completions component is used to determine each institution’s group.</p>
-			<h3>Loan default rate</h3>
-			<p>Loan default rate refers to the institution’s three-year cohort default rate. This is the percentage of an institution’s borrowers who entered repayment on certain Federal Family Education Loan (FFEL) Program or William D. Ford Federal Direct Loan (Direct Loan) Program loans in Federal fiscal year 2010 (between October 1, 2009 and September 30, 2010) and who defaulted before September 30, 2012.</p>
-			<p>Data used to calculate an institution’s cohort default rate come from ED’s National Student Data System (NSLDS).</p>
-			<h3>Median borrowing</h3>
-			<p>Median borrowing refers to the median amount of Federal student loans borrowed for a students’ undergraduate study at the institution.</p>
-			<p>Data used to calculate the median amount of Federal student loans borrowed for a students’ undergraduate study is from the U.S. Department of Education’s National Student Loan Data System (NSLDS). Data represent all undergraduate borrowers who graduated or withdrew from the institution between July 1, 2011, and June 30, 2012. All Federal loans for undergraduate study, including Parent PLUS loans, are included for this cohort of borrowers. Only the debt associated with the students’ attendance at the institution is included in the calculation. The estimated monthly repayment amount has been calculated using the Department’s standard graduated repayment calculator based on an interest rate of 6.8%.</p>
-		</div>
-	</section><!-- end .about-section -->
-</div><!-- end #comparison-tool -->
-						
+<main>
+    <div class="content content__2-1 content__bleedbar">
+        <div class="wrapper content_wrapper">
+            <section class="content_main">
+                <h1>
+                    About this tool
+                </h1>
+                <section class="block block_section block_section__h2">
+                    <h2>
+                        Technical notes and assumptions
+                    </h2>
+                    <p>
+                        For users interested in learning more about how specific sections of this tool work, scroll down to the relevant section below. Some of this information may be a bit technical, but we want to be open and transparent.
+                    </p>
+                    <p>
+                        Below is more information on how we developed this version of the tool, including the data we’ve used and assumptions we’ve made.
+                    </p>
+                </section>
+                <section class="block block_section block_section__h2">
+                    <h2>
+                        Financial aid shopping sheet
+                    </h2>
+                    <p>
+                        As part of our <a href="http://www.consumerfinance.gov/students/knowbeforeyouowe/">Know Before You Owe</a> project, we worked with the Department of Education to create a <a class="exit-link pdf" href="http://collegecost.ed.gov/shopping_sheet.pdf">Financial Aid Shopping Sheet</a>. Now that hundreds of colleges are adopting this clear and comparable form, we have rebuilt this tool to complement that shopping sheet to help students make comparisons tailored to their individual circumstances.
+                    </p>
+                    <p>
+                        If your school indicated to the Department of Education that it has adopted the Financial Aid Shopping sheet, the tool gives you the option to upload an XML version of the sheet (an option some schools choose to offer) by pasting in XML code. This step is optional. If your school did not indicate to the Department of Education that it was adopting the shopping sheet, you can still make a comparison by manually entering information from your offer letter.
+                    </p>
+                </section>
+                <section class="block block_section block_section__h2">
+                    <h2>
+                        Compare schools
+                    </h2>
+                    <p>
+                        tart using the tool by clicking on “Get started.” As you type your school’s name in the first field, the tool will autocomplete with the names of schools with similar spelling. The tool should also be able to find commonly used names for a particular school (e.g., type in UCLA and you should find the University of California Los Angeles). The tool uses the Department of Education’s IPEDS list of postsecondary institutions.
+                    </p>
+                    <p>
+                        After choosing a school, set program length (1-5 years) and program type (Associates or certificate, Bachelors, Graduate). By selecting your program type, the tool adjusts your federal loan limits (see below) and calculates your estimated monthly payments based on the length of your program (see below).
+                    </p>
+                    <p>
+                        Indicate whether or not you have a financial aid offer from each school. This will help us follow up with the right questions based on your situation.
+                    </p>
+                </section>
+                <section class="block block_section block_section__h2">
+                    <h2>Cost of attendance</h2>
+                    <p>
+                        Using your financial aid offer letter, enter in your first year tuition &amp; fees, housing &amp; meals, books &amp; supplies and other expenses. If you have not yet received your offer letter, you can find the cost information by clicking where indicated. This will take you to the Department of Education’s College Navigator page for this school. Click on the “Tuition, Fees and Estimated Student Expenses” tab to locate cost information to add to your comparison.
+                    </p>
+                </section>
+                <section class="block block_section block_section__h2">
+                    <h2>
+                        Money for school
+                    </h2>
+                    <p>
+                        After you fill out your Free Application for Federal Student Aid (FAFSA), each college that sends you an acceptance letter should also send you a financial aid offer letter. This should include the types and amounts of “financial aid” being offered to the student.
+                    </p>
+                    <ul>
+                        <li>
+                            <a class="exit-link" href="http://studentaid.ed.gov/types/grants-scholarships/pell">Pell grants</a> are federal grants that do not have to be repaid and are awarded based on your financial need, up to $5,730 per year.
+                        </li>
+                        <li>
+                            <em>Military tuition assistance</em>: Tuition Assistance provides support (up to $4,500 per year) for some active-duty servicemembers (active &amp; reserve) who are pursuing higher education. Military TA benefits do not need to be repaid.
+                        </li>
+                        <li>
+                            <em>GI Bill</em> benefits offer education benefits for servicemembers and veterans. This funding covers tuition and fees, a monthly living allowance, and an annual book stipend. GI Bill benefits do not need to be repaid (see below).
+                        </li>
+                        <li>
+                            <a class="exit-link" href="http://studentaid.ed.gov/types/loans/perkins">Perkins loans</a> are low-interest loans for students with financial need and do not accrue interest while students are enrolled in school. These loans are available up to $5,500 per year for undergraduates and $8,000 per year for graduate students.
+                        </li>
+                        <li>
+                            <a class="exit-link" href="http://studentaid.ed.gov/types/loans/subsidized-unsubsidized">Subsidized loans</a> are federal loans for students who demonstrate financial need and do not accrue interest while students are enrolled in school. These loans, which must be repaid, are available for up to $3,500 per year for first year college students. Graduates students are not eligible for these loans.
+                        </li>
+                        <li>
+                            <a class="exit-link" href="http://studentaid.ed.gov/types/loans/subsidized-unsubsidized">Unsubsidized loans</a> do not require students to demonstrate financial need but they do accrue interest while students are in school. All first year dependent, undergraduate students may borrow up to $5,500 per year in subsidized and unsubsidized loans. For independent undergraduate students, this limit rises to $9,500 per year. For graduate students the limit is $20,500 per year.
+                        </li>
+                        <li>
+                            <a class="exit-link" href="http://studentaid.ed.gov/types/loans/plus">PLUS Loans</a> are available to graduate and professional students, up to the program’s cost of attendance minus any other financial assistance received. Parents may also borrow PLUS loans to pay for the expenses of undergraduate dependents. Under some circumstances, independent undergraduate students may also borrow PLUS loans. Unlike other federal student loans, eligibility for PLUS loans is dependent on the borrower’s credit
+                        </li>
+                        <li>
+                            Loans from your school: A private loan from your school may have variable interest rates, require a credit check and/or a cosigner and lack many of the repayment options available with federal student loans. The tool allows you to adjust the interest rate to match what you have been offered by your lender (see below).
+                        </li>
+                        <li>
+                            Private loans often have variable interest rates, require a credit check and/or a cosigner and lack many of the repayment options of federal student loans. Students should explore all of their federal grant and loan options before taking out a private student loan. The tool allows you to adjust that interest rate to match what you have been offered by your lender.(see below)
+                        </li>
+                    </ul>
+                </section>
+                <section class="block block_section block_section__h2">
+                    <h2>
+                        GI Bill benefits calculator
+                    </h2>
+                    <p>
+                        The tool allows veterans, servicemembers and eligible family members to calculate their GI Bill benefits. The tool assumes the following conditions for students seeking to use GI Bill benefits:
+                    </p>
+                    <ul>
+                        <li>
+                            Veterans will use the Post-9/11 GI Bill (Chapter 33). If a veteran has yet to serve 90 days of active duty service after September 11, 2001; but, is serving in the National Guard or Reserves, they will use the Select Reserve GI Bill (Chapter 1606).
+                        </li>
+                        <li>
+                            Veterans have 36 months of remaining eligibility (equivalent to 4 academic years).
+                        </li>
+                        <li>
+                            Student is enrolled in at least one class in a physical classroom unless the Department of Education has indicated that this school provides exclusively online education. If a veteran is taking all of their classes online they are only eligible to receive a living allowance of up to $684/month.
+                        </li>
+                    </ul>
+                </section>
+                <section class="block block_section block_section__h2">
+                    <h2>
+                        After school
+                    </h2>
+                    <p>
+                        Based on what you’ve entered, we’ve come up with a rough estimate of what your monthly payment would be if you borrowed the same amount each year of your program, completed your program on time (based on the program length you provide when you added the school), and paid your loan on a standard 10-year repayment schedule. To come up with this estimate, we’ve made certain assumptions about your total debt at graduation, the interest rate of your loans, and when you’ll begin repayment.
+                    </p>
+                    <p>
+                        In calculating estimated monthly repayment amounts, we assume that the sticker price or cost of attendance remains constant for the duration of the program and that students take out the same loans (both type and amount) for each year that they are in school. In fact, students may take longer to complete their degrees; institutions have historically increased tuition prices each year; and students may make different financing decisions in different years.
+                    </p>
+                    <p>
+                        We also assume a standard repayment-term of ten years and that students begin repayment after they graduate and their allotted grace period expires (between 6-9 months after graduating, depending on the type of loan). For federal student loans, we apply the interest rates for originations beginning on July 1, 2013:
+                    <ul>
+                        <li>
+                            Perkins (for undergraduate and graduate/professional students): Fixed at 5%
+                        </li>
+                        <li>
+                            Direct Subsidized and Unsubsidized Loans (for undergraduate students): Fixed at 3.86%
+                        </li>
+                        <li>
+                            Direct Unsubsidized Loans (for graduate/professional students): Fixed at 5.41%
+                        </li>
+                        <li>
+                            Direct PLUS Loans (for parents and graduate/professional students): Fixed at 6.41%
+                        </li>
+                        <li>
+                            For all Direct Subsidized and Unsubsidized Loans, the Department of Education also charges a 1% loan fee. For all PLUS loans, there is a 4% loan fee.
+                        </li>
+                    </ul>
+                    <p>
+                        These rates are set by the laws governing federal student loan programs, including the Higher Education Act.
+                    </p>
+                    <p>
+                        For institutional and private student loans, we assume a fixed interest rate of 7.9%, which is identical to the old PLUS loan rate. The tool allows you to adjust that interest rate to match what you have been offered by your lender. However, keep in mind that interest rates on institutional and private student loans may be variable and change significantly throughout the duration of the loan.
+                    </p>
+                    <h3>
+                        Debt at graduation
+                    </h3>
+                    <p>
+                        Based on what you’ve entered, we’ve come up with a rough estimate of how much you will owe in students loans when you begin repayment. We use the same assumptions for debt at graduation as we do for the estimated monthly payment.
+                    </p>
+                    <h3>
+                        Monthly payments
+                    </h3>
+                    <p>
+                        Percent of monthly salary: The pie chart shows you how much of your post-graduation income will be spent repaying your student loans. Since institution-specific salary data is not available, this version of the tool uses the average salary one year after graduation for a student with a bachelor’s degree, as reported by the <a class="exit-link" href="http://nces.ed.gov/surveys/b&amp;b/">Department of Education’s Baccalaureate and Beyond</a> study. Adjusted for inflation, this figure equates to $30,922 per year on a pre-tax basis (a monthly salary of $2,577).
+                    </p>
+                    <h3>
+                        Debt burden
+                    </h3>
+                    <p>
+                        Your debt burden measures your estimated debt after school against the national average starting salary for college grads. Again, it’s an average. If you make more money, you’ll have a lower burden. It also doesn’t factor in specific information about your school or special repayment programs, like Income Based Repayment or Public Service Loan Forgiveness.
+                    </p>
+                    <p>
+                        Total debt is calculated as described above. Since institution-specific salary data is not available, this version of the tool uses the average salary one year after graduation for a student with a bachelor’s degree, as reported by the <a class="exit-link" href="http://nces.ed.gov/surveys/b&amp;b/">Department of Education’s Baccalaureate and Beyond</a> study. Adjusted for inflation, this figure equates to $30,922 per year on a pre-tax basis (a monthly salary of $2,577).
+                    </p>
+                    <p>
+                        Debt burden does not take into account that the average starting salary of graduates of particular institutions may vary. This tool will provide an indication of whether debt burden is low, medium, or high as follows:
+                    <ul>
+                        <li>
+                            Low: monthly payment is &lt; 8% of average monthly salary
+                        </li>
+                        <li>
+                            Medium: monthly payment is 8%–14% of average monthly salary
+                        </li>
+                        <li>
+                            High: monthly payment is > 14% of average monthly salary
+                        </li>
+                    </ul>
+                    <p>
+                        Since this version uses the same salary assumption across institutions, the debt burden indicator is not specific to an institution.
+                    </p>
+                </section>
+                <section class="block block_section block_section__h2">
+                    <h2>
+                        School indicators
+                    </h2>
+                    <p>
+                        Schools disclose key institutional performance metrics, including graduation and loan default rates as well as the median amount of Federal loans borrowed by students at the institution and the corresponding estimated monthly payment over a ten year period.
+                    </p>
+                    <p>
+                        Schools that only offer graduate programs are not required to report these rates, and will be shown as “Not Reported.” School indicators are then evaluated against other schools. Users interested in further school-specific information may wish to visit the <a class="exit-link" href="http://nces.ed.gov/collegenavigator/">Department of Education’s College Navigator website</a> for a more complete set of indicators.
+                    </p>
+                    <h3>
+                        Graduation rate
+                    </h3>
+                    <p>
+                        The graduation rate is for first-time, full-time degree or certificate-seeking undergraduate students who began at the institution. For primarily bachelor’s degree-granting institutions, the graduation rate displayed is for students beginning in Fall 2006 and seeking a bachelor’s degree. For primarily associate’s degree-granting institutions and primarily certificate-granting institutions, the graduation rate displayed is for students beginning in Fall 2009.
+                    <p>
+                        Data used to calculate an institution’s graduation rate come from the institution’s annual submission to the U.S. Department of Education’s Integrated Postsecondary Education Data System (IPEDS).
+                    </p>
+                    <p>
+                        The institution’s graduation rate is displayed with an indication of how it compares with graduation rates among institutions that primarily grant the same degree or certificate. For example, the comparison group for an institution that primarily awards bachelor’s degrees is all institutions that primarily award bachelor’s degrees. Graduation rate data are based on undergraduate students who enrolled full-time and have never enrolled in college before. This may not represent all undergraduates that attend this institution. Data from the IPEDS Completions component is used to determine each institution’s group.
+                    </p>
+                    <h3>
+                        Loan default rate
+                    </h3>
+                    <p>
+                        Loan default rate refers to the institution’s three-year cohort default rate. This is the percentage of an institution’s borrowers who entered repayment on certain Federal Family Education Loan (FFEL) Program or William D. Ford Federal Direct Loan (Direct Loan) Program loans in Federal fiscal year 2010 (between October 1, 2009 and September 30, 2010) and who defaulted before September 30, 2012.
+                    </p>
+                    <p>
+                        Data used to calculate an institution’s cohort default rate come from ED’s National Student Data System (NSLDS).
+                    </p>
+                    <h3>
+                        Median borrowing
+                    </h3>
+                    <p>
+                        Median borrowing refers to the median amount of Federal student loans borrowed for a students’ undergraduate study at the institution.
+                    </p>
+                    <p>
+                        Data used to calculate the median amount of Federal student loans borrowed for a students’ undergraduate study is from the U.S. Department of Education’s National Student Loan Data System (NSLDS). Data represent all undergraduate borrowers who graduated or withdrew from the institution between July 1, 2011, and June 30, 2012. All Federal loans for undergraduate study, including Parent PLUS loans, are included for this cohort of borrowers. Only the debt associated with the students’ attendance at the institution is included in the calculation. The estimated monthly repayment amount has been calculated using the Department’s standard graduated repayment calculator based on an interest rate of 6.8%.
+                    </p>
+                </section>
+            </section>
+            <aside class="content_sidebar">
+                <div class="block block__flush-top">
+                    <h2 class="header-slug">
+                        <span class="header-slug_inner">Sidebar heading</span>
+                    </h2>
+                    <ul class="short-desc">
+                        <li></li>
+                    </ul>
+                </div>
+            </aside>
+        </div>
+    </div>
+</main>
 {% endblock content %}
 
-{% block page_js %}
-    <script src="{% static "paying_for_college/disclosures/js/pfc-analytics.js" %}"></script>
+{% block share_box %}
+{% endblock %}
+
+{% block nemo_js %}
+{% endblock %}
+
+{% block app_js %}
+<script type="text/javascript"
+src="{% static "paying_for_college/disclosures/static/js/main.js" %}">
+</script>
 {% endblock %}

--- a/paying_for_college/templates/technote.html
+++ b/paying_for_college/templates/technote.html
@@ -20,7 +20,7 @@
 {% endblock %}
 
 {% block content %}
-<main>
+<main data-context="{{url_root}}">
     <div class="content content__2-1 content__bleedbar">
         <div class="wrapper content_wrapper">
             <section class="content_main">

--- a/src/disclosures/css/cf-enhancements.less
+++ b/src/disclosures/css/cf-enhancements.less
@@ -394,3 +394,69 @@ a.btn__full-small.btn__link {
         content: '';
     }
 }
+
+/* ==========================================================================
+   Accessible bleedbar
+   ========================================================================== */
+
+.content__bleedbar {
+
+  .content_wrapper:after {
+    background-color: @gray-5;
+  }
+
+  .header-slug {
+    border-color: @gray-40;
+  }
+}
+
+/* ==========================================================================
+   Tyopgraphy spacing enhancements
+   ========================================================================== */
+
+.block_section {
+  margin: 0;
+}
+
+.block_section__h2 {
+
+  p + &,
+  ul + &,
+  ol + &,
+  dl + &,
+  figure + &,
+  img + &,
+  table + &,
+  blockquote + &,
+  .block_section + & {
+    margin-top: unit( 45px / @base-font-size-px, em );
+  }
+
+  h1 + &,
+  .h1 + &,
+  h3 + &,
+  .h3 + &,
+  h4 + &,
+  .h4 + &,
+  h5 + &,
+  .h5 + &,
+  h6 + &,
+  .h6 + & {
+    margin-top: unit( 30px / @base-font-size-px, em );
+  }
+
+  .respond-to-max(@bp-xs-max, {
+
+    p + &,
+    ul + &,
+    ol + &,
+    dl + &,
+    figure + &,
+    img + &,
+    table + &,
+    blockquote + &,
+    .block_section + & {
+      margin-top: unit( 30px / @base-font-size-px, em );
+    }
+  });
+}


### PR DESCRIPTION
Updates the "about this tool" page to new design standards (specifically, the V1 "learn" page style)
## Additions
- A few `cf-enhancements` styles
## Changes
- Markup of `technote.html` to use standard Capital Framework classes and the updated template elements from `worksheet.html`
## Testing
- To test, pull in the `about-page` branch and run `gulp`. Fire up the app in standalone or UnityBox as normal. Follow the "Get details about how this tool works" link.
- Besides having an updated style, the about page should now be responsive, too
## Review
- @marteki and/or @mistergone and/or @higs4281 
## To do
- Add new content to the page when the content is ready
- <strike>Fix a JS error on the page (I'll open a separate issue for this)</strike>
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] Visually tested in supported browsers and devices
