### PR TITLE
Verification, placeholder error reporting, private loan field fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   "dependencies": {
     "format-usd": "^0.2.0",
     "number-to-words": "^1.2.1",
-    "student-debt-calc": "2.2.2"
+    "student-debt-calc": "2.3.0"
   }
 }

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -83,6 +83,7 @@
                             </dd>
                         </dl>
                         <form class="verify_form">
+                          {% csrf_token %}
                             <div class="verify_estimate">
                                 <label for="estimated-years-attending"
                                 class="verify_label">

--- a/src/disclosures/js/dispatchers/get-model-values.js
+++ b/src/disclosures/js/dispatchers/get-model-values.js
@@ -1,10 +1,14 @@
 'use strict';
 
 var financialModel = require( '../models/financial-model' );
+var schoolModel = require( '../models/school-model' );
 
 var getModel = {
   financial: function() {
     return financialModel.values;
+  },
+  school: function() {
+    return schoolModel.values;
   }
 };
 

--- a/src/disclosures/js/dispatchers/post-verify.js
+++ b/src/disclosures/js/dispatchers/post-verify.js
@@ -4,19 +4,33 @@ var postVerify = {
   csrfToken: null,
 
   init: function() {
-    if ( document.cookie && document.cookie != '' ) {
-      var cookies = document.cookie.split( ';' );
-      for ( var x = 0; x < cookes.length; x++ ) {
-        var cookie = $.trim( cookies[ x ] );
-        if ( cookie.substring( 0, 10 ) === 'csrftoken=' ) {
-          this.csrfToken = cookie.substring( 10 );
-          break;
-        }
-      }
-    }
+    // Alternate code. getting token from document.cookie:
+    // 
+    // if ( document.cookie && document.cookie != '' ) {
+    //   var cookies = document.cookie.split( ';' );
+    //   for ( var x = 0; x < cookes.length; x++ ) {
+    //     var cookie = $.trim( cookies[ x ] );
+    //     if ( cookie.substring( 0, 10 ) === 'csrftoken=' ) {
+    //       this.csrfToken = cookie.substring( 10 );
+    //       break;
+    //     }
+    //   }
+    // }
+    this.csrfToken = $('[name="csrfmiddlewaretoken"]').val();
   },
 
-
+  verify: function( offerID, collegeID, error ) {
+    var postdata = {
+      'csrfmiddlewaretoken':  this.csrfToken,
+      'oid':                  offerID,
+      'iped':                 collegeID,
+      'errors':               'none'
+    };
+    if ( error === true ) {
+      postdata.errors = 'INVALID: student indicated the offer information is wrong';
+    }
+    $.post( '/understanding-your-financial-aid-offer/api/verify/', postdata );
+  }
 
 };
 

--- a/src/disclosures/js/dispatchers/post-verify.js
+++ b/src/disclosures/js/dispatchers/post-verify.js
@@ -20,16 +20,19 @@ var postVerify = {
   },
 
   verify: function( offerID, collegeID, error ) {
-    var postdata = {
+    var url,
+        postdata = {
       'csrfmiddlewaretoken':  this.csrfToken,
       'oid':                  offerID,
       'iped':                 collegeID,
       'errors':               'none'
     };
+    url = '/' + $( 'main' ).attr( 'data-context' ) +
+      '/understanding-your-financial-aid-offer/api/verify/';
     if ( error === true ) {
       postdata.errors = 'INVALID: student indicated the offer information is wrong';
     }
-    $.post( '/understanding-your-financial-aid-offer/api/verify/', postdata );
+    $.post( url, postdata );
   }
 
 };

--- a/src/disclosures/js/dispatchers/post-verify.js
+++ b/src/disclosures/js/dispatchers/post-verify.js
@@ -14,7 +14,9 @@ var postVerify = {
         }
       }
     }
-  }
+  },
+
+
 
 };
 

--- a/src/disclosures/js/dispatchers/post-verify.js
+++ b/src/disclosures/js/dispatchers/post-verify.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var postVerify = {
+  csrfToken: null,
+
+  init: function() {
+    if ( document.cookie && document.cookie != '' ) {
+      var cookies = document.cookie.split( ';' );
+      for ( var x = 0; x < cookes.length; x++ ) {
+        var cookie = $.trim( cookies[ x ] );
+        if ( cookie.substring( 0, 10 ) === 'csrftoken=' ) {
+          this.csrfToken = cookie.substring( 10 );
+          break;
+        }
+      }
+    }
+  }
+
+};
+
+module.exports = postVerify;

--- a/src/disclosures/js/index.js
+++ b/src/disclosures/js/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var fetch = require( './dispatchers/get-api-values' );
+var verifyOffer = require( './dispatchers/post-verify' );
 var financialModel = require( './models/financial-model' );
 var schoolModel = require( './models/school-model' );
 var getModelValues = require( './dispatchers/get-model-values' );
@@ -36,6 +37,7 @@ var app = {
       }
       questionView.init();
     } );
+    verifyOffer.init();
   }
 };
 

--- a/src/disclosures/js/models/financial-model.js
+++ b/src/disclosures/js/models/financial-model.js
@@ -87,6 +87,8 @@ var financialModel = {
    * Report errors to the user
    */
   reportErrors: function() {
+    // This is something of a placeholder for future code.
+    // For now, feel free to uncomment the following and view the errors object.
     // console.log( this.values.errors );
   }
 

--- a/src/disclosures/js/models/financial-model.js
+++ b/src/disclosures/js/models/financial-model.js
@@ -37,6 +37,7 @@ var financialModel = {
     this.values = recalculate( this.values );
     this.sumTotals();
     this.roundValues();
+    this.reportErrors();
   },
 
   /**
@@ -80,6 +81,13 @@ var financialModel = {
       schoolValues.undergrad = false;
     }
     $.extend( this.values, schoolValues );
+  },
+
+  /**
+   * Report errors to the user
+   */
+  reportErrors: function() {
+    // console.log( this.values.errors );
   }
 
 };

--- a/src/disclosures/js/utils/query-handler.js
+++ b/src/disclosures/js/utils/query-handler.js
@@ -11,7 +11,7 @@ function queryHandler( queryString ) {
   var valuePairs = {};
   var parameters = {};
   var numericKeys = [
-    'iped', 'pid', 'oid', 'tuit', 'hous', 'book', 'tran', 'othr',
+    'iped', 'pid', 'tuit', 'hous', 'book', 'tran', 'othr',
     'pelg', 'schg', 'stag', 'othg', 'mta', 'gib', 'fam', 'wkst', 'parl',
     'perl', 'subl', 'unsl', 'ppl', 'gpl', 'prvl', 'prvi', 'insl', 'insi', 'sav'
   ];

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -97,10 +97,10 @@ var financialView = {
    * @param {object} $privateLoans - jQuery object of the private loan elements
    */
   updatePrivateLoans: function( values, $privateLoans ) {
-    $privateLoans.not( '#' + financialView.currentInput ).each( function() {
+    $privateLoans.each( function() {
       var index = $( this ).index(),
           $fields = $( this ).find( '[data-private-loan_key]' );
-      $fields.each( function() {
+      $fields.not( '#' + financialView.currentInput ).each( function() {
         var key = $( this ).attr( 'data-private-loan_key' ),
             val = values.privateLoanMulti[index][key],
             isntCurrentInput = $( this ).attr( 'id' ) !== financialView.currentInput;

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -7,6 +7,7 @@ var formatUSD = require( 'format-usd' );
 var numberToWords = require( 'number-to-words' );
 var linksView = require( '../views/links-view' );
 var metricView = require( '../views/metric-view' );
+var postVerification = require( '../dispatchers/post-verify')
 
 var financialView = {
   $elements: $( '[data-financial]' ),
@@ -293,6 +294,7 @@ var financialView = {
       } else {
         e.preventDefault();
         financialView.$infoIncorrect.show();
+        postVerification.verify( values.offerID, values.schoolID, true );
         $( 'html, body' ).stop().animate( {
           scrollTop: financialView.$infoIncorrect.offset().top - 120
         }, 900, 'swing', function() {

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -7,7 +7,7 @@ var formatUSD = require( 'format-usd' );
 var numberToWords = require( 'number-to-words' );
 var linksView = require( '../views/links-view' );
 var metricView = require( '../views/metric-view' );
-var postVerification = require( '../dispatchers/post-verify')
+var postVerification = require( '../dispatchers/post-verify');
 
 var financialView = {
   $elements: $( '[data-financial]' ),

--- a/src/disclosures/js/views/question-view.js
+++ b/src/disclosures/js/views/question-view.js
@@ -1,4 +1,6 @@
 'use strict';
+var postVerification = require( '../dispatchers/post-verify');
+var getModelValues = require( '../dispatchers/get-model-values' );
 
 var questionView = {
   $getOptions: $( '.get-options' ),
@@ -14,6 +16,8 @@ var questionView = {
   bigQuestionListener: function() {
     var $answerButtons = $( '.question_answers > .btn' );
     $answerButtons.on( 'click', function() {
+      var values = getModelValues.financial();
+      postVerification.verify( values.offerID, values.schoolID, false);
       $answerButtons.removeClass( 'active' );
       $( this ).addClass( 'active' );
       if ( $( this ).attr( 'id' ) === 'question_answer-yes' ) {


### PR DESCRIPTION
This PR mostly adds the AJAX calls to our `/verify/` API endpoint. It also includes a placeholder for "error handling" (reporting when the user exceeds various limits), and it fixes a bug with input fields in the Private Loan section updating even when focused.
## Additions
- AJAX calls to the `verify` endpoint when the user verifies their offer (and when the user says the information is incorrect).
- Updates `student-debt-calc` to 2.3.0 (which adds error handling)
- Placeholder function for error handling, when we get around to it.
- Fix for private loan fields (they will no longer update while focused)
## Testing
- Bring it down, `npm install` and `gulp` and then verify or unverify offers!
- Passing all functional and unit tests!
## Review
- @marteki and @niqjohnson 
- @higs4281 - please check to make sure the `/verify/` calls are going wherever they're supposed to. :smile: 
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices 
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
## Special Thanks
- Thanks to @higs4281 for help debugging the `/verify/` endpoint, and for writing the whole API!
## Animated GIF

**Status code of 200 means...**
![loki-success](https://cloud.githubusercontent.com/assets/1490703/13759810/4ff2306a-ea06-11e5-8487-a607b85e5cdb.gif)
