### PR TITLE
Fix unclosed <p>s on about page

### DIFF
--- a/paying_for_college/templates/technote.html
+++ b/paying_for_college/templates/technote.html
@@ -137,6 +137,7 @@
                     </p>
                     <p>
                         We also assume a standard repayment-term of ten years and that students begin repayment after they graduate and their allotted grace period expires (between 6-9 months after graduating, depending on the type of loan). For federal student loans, we apply the interest rates for originations beginning on July 1, 2013:
+                    </p>
                     <ul>
                         <li>
                             Perkins (for undergraduate and graduate/professional students): Fixed at 5%
@@ -183,6 +184,7 @@
                     </p>
                     <p>
                         Debt burden does not take into account that the average starting salary of graduates of particular institutions may vary. This tool will provide an indication of whether debt burden is low, medium, or high as follows:
+                    </p>
                     <ul>
                         <li>
                             Low: monthly payment is &lt; 8% of average monthly salary
@@ -213,6 +215,7 @@
                     </h3>
                     <p>
                         The graduation rate is for first-time, full-time degree or certificate-seeking undergraduate students who began at the institution. For primarily bachelor’s degree-granting institutions, the graduation rate displayed is for students beginning in Fall 2006 and seeking a bachelor’s degree. For primarily associate’s degree-granting institutions and primarily certificate-granting institutions, the graduation rate displayed is for students beginning in Fall 2009.
+                    </p>
                     <p>
                         Data used to calculate an institution’s graduation rate come from the institution’s annual submission to the U.S. Department of Education’s Integrated Postsecondary Education Data System (IPEDS).
                     </p>


### PR DESCRIPTION
Oh, the shame! I left out a few closing `</p>` tags, but now they're there.
## Additions
- Three tiny little `</p>`
## Testing
- The "about this tool" page should still look the same as before, but now it shouldn't throw any "unclosed element" errors if you validate the HTML.
## Review
- @mistergone or @marteki 
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
