### PR TITLE
Changed the standalone base header and footer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: python
 python:
-  - "2.6"
+  - "2.7"
 install:
   - pip install -r requirements/testing.txt
   - pip install coveralls
 env:
   - DJANGO_SETTINGS_MODULE=paying_for_college.config.settings.standalone
 before_script:
-  - python manage.py syncdb --noinput
   - python manage.py migrate
   - python manage.py loaddata test_fixture.json
 script: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
-- 
+- Update the standalone templates to use on-demand-like header/footer
 
 ## 2.0.4
 - Notifications enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
+- Updated the project to Django 1.8 and removed solr dependencies
 - Update the standalone templates to use on-demand-like header/footer
 
 ## 2.0.4

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Tools to help students make informed financial decisions about college.
 - This project is under construction. Please wear a hardhat.
 
 ### Setup dependencies
- * [solr](http://lucene.apache.org/solr/)
  * [pip](https://pypi.python.org/pypi/pip)
  * [virtualenv](https://virtualenv.pypa.io/en/latest/)
  * [virtualenvwrapper](https://virtualenvwrapper.readthedocs.org/en/latest/)
@@ -23,7 +22,6 @@ Tools to help students make informed financial decisions about college.
 - [requests](http://docs.python-requests.org/en/latest/)
 - [Unipath](https://github.com/mikeorr/Unipath)
 - [haystack](http://haystacksearch.org/)
-- [pysolr](https://github.com/toastdriven/pysolr)
 
 <!-- - [django-haystack](http://haystacksearch.org/) -->
 
@@ -40,27 +38,12 @@ mkvirtualenv college-costs
 git clone https://github.com/cfpb/college-costs.git .
 setvirtualenvproject
 ```
-- Set up front-end resources and database assets:
+- Set up database assets and front-end resources:
 ```bash
 ./local_setup.sh
 ```
 
-### Prepping solr
-- If you want the college-search function to work (you know you do), you'll need to prep and fire up solr.  
-Adust the `build_solr_schema` command to match your local installation of solr and your solr version number.   
-The example is for a brew-installed solr, with brew using the user's home director as its Cellar site and solr version 4.10.2.  
-Be sure you're in the projects root directory, `/college-costs/`:  
-```bash
-./manage.py build_solr_schema > ~/homebrew/Cellar/solr/4.10.2/example/solr/collection1/conf/schema.xml
-solr start
-```
-
-The last step is to rebuild the solr index:
-```
-./manage.py rebuild_index --noinput
-```
-
-- After that finishes, fire up a local web server:
+- Now you should be able to fire up a local web server:
 ```bash
 ./manage.py runserver
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Tools to help students make informed financial decisions about college.
 - [requests](http://docs.python-requests.org/en/latest/)
 - [Unipath](https://github.com/mikeorr/Unipath)
 - [haystack](http://haystacksearch.org/)
+- [elasticsearch](https://www.elastic.co/products/elasticsearch)
 
 <!-- - [django-haystack](http://haystacksearch.org/) -->
 
@@ -32,6 +33,7 @@ Tools to help students make informed financial decisions about college.
 ### Installation
 This project is not fully functional, but feel free to give it a spin. Here's how:
 - Install the setup dependencies if you don't have them.
+- Elasticsearch is optional for the standalone setup
 - Go to the local directory where you want the project to be created, make a virtual environment, clone this repository (or your own fork of it).
 ```bash
 mkvirtualenv college-costs
@@ -40,7 +42,7 @@ setvirtualenvproject
 ```
 - Set up database assets and front-end resources:
 ```bash
-./local_setup.sh
+./standalone_setup.sh
 ```
 
 - Now you should be able to fire up a local web server:

--- a/paying_for_college/config/settings/base.py
+++ b/paying_for_college/config/settings/base.py
@@ -1,14 +1,11 @@
-import os
-import base64
 from unipath import Path
 import getpass
-import haystack
 
 LOCAL_USER = getpass.getuser()
 REPOSITORY_ROOT = Path(__file__).ancestor(4)
 PROJECT_ROOT = Path(__file__).ancestor(3)
 
-SECRET_KEY = "testonlysecretkey"
+SECRET_KEY = "forstandaloneonly"
 
 DEBUG = False
 

--- a/paying_for_college/config/settings/base.py
+++ b/paying_for_college/config/settings/base.py
@@ -23,18 +23,14 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.humanize',
     'paying_for_college',
-    'south',
     'haystack',
 ]
 
 HAYSTACK_CONNECTIONS = {
     'default': {
-        'ENGINE': 'haystack.backends.solr_backend.SolrEngine',
-        'URL': 'http://127.0.0.1:8983/solr',
-        'TIMEOUT': 60 * 5,
-        'INCLUDE_SPELLING': True,
-        'BATCH_SIZE': 100,
-        'EXCLUDED_INDEXES': ['thirdpartyapp.search_indexes.BarIndex'],
+        'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
+        'URL': 'http://127.0.0.1:9200/',
+        'INDEX_NAME': 'haystack',
     },
 }
 
@@ -44,10 +40,10 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    # 'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    # 'django.middleware.security.SecurityMiddleware',
+    'django.middleware.security.SecurityMiddleware',
 )
 
 ROOT_URLCONF = 'paying_for_college.config.urls'

--- a/paying_for_college/config/settings/base.py
+++ b/paying_for_college/config/settings/base.py
@@ -8,8 +8,7 @@ LOCAL_USER = getpass.getuser()
 REPOSITORY_ROOT = Path(__file__).ancestor(4)
 PROJECT_ROOT = Path(__file__).ancestor(3)
 
-SECRET_KEY = os.getenv('DJANGO_SECRET_KEY',
-                       base64.b64encode(os.urandom(64)))[:50]
+SECRET_KEY = "testonlysecretkey"
 
 DEBUG = False
 

--- a/paying_for_college/config/settings/base.py
+++ b/paying_for_college/config/settings/base.py
@@ -24,6 +24,7 @@ INSTALLED_APPS = [
     'django.contrib.humanize',
     'paying_for_college',
     'haystack',
+    'elasticsearch'
 ]
 
 HAYSTACK_CONNECTIONS = {
@@ -33,7 +34,6 @@ HAYSTACK_CONNECTIONS = {
         'INDEX_NAME': 'haystack',
     },
 }
-
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/paying_for_college/config/settings/base.py
+++ b/paying_for_college/config/settings/base.py
@@ -2,6 +2,7 @@ import os
 import base64
 from unipath import Path
 import getpass
+import haystack
 
 LOCAL_USER = getpass.getuser()
 REPOSITORY_ROOT = Path(__file__).ancestor(4)

--- a/paying_for_college/config/settings/standalone.py
+++ b/paying_for_college/config/settings/standalone.py
@@ -3,6 +3,8 @@ from .dev import *
 
 STANDALONE = True
 
+SECRET_KEY = "forstandaloneonly"
+
 STATICFILES_DIRS = (
     PROJECT_ROOT.child('local_static'),
 )

--- a/paying_for_college/templates/landing.html
+++ b/paying_for_college/templates/landing.html
@@ -46,16 +46,6 @@
                 </header>
                 <p>It’s more important than ever for students and former students to make smart decisions about financing their college education. Whether you’re attending college soon, are a current student, or already have student loans, we’ve put together some tools and resources to help you make the best decisions for you.</p>
             </div>
-            <div class="col last col4">
-                <div class="share-pfc">
-                    <h3 class="h4">Share this page</h3>
-                    <div class="share-links">
-                        <a href="http://www.facebook.com/sharer.php?u={% firstof share_uri request.build_absolute_uri|urlencode %}&t={{ pagetitle|default:"CFPB" }}" class="share-facebook icon-facebook-alt" ><span class="cfpb_visually_hide">Share on Facebook</span></a>
-                        <a href="http://twitter.com/share?text={% firstof tweet_text pagetitle "CFPB" %}&url={% firstof share_uri request.build_absolute_uri|urlencode %}&via=CFPB&related=CFPB" class="share-twitter icon-twitter-alt"><span class="cfpb_visually_hide">Share on Twitter</span></a>
-                        <a class="share-email addthis_button_email icon-email-social-alt" href="http://api.addthis.com/oexchange/0.8/forward/email/offer?url={% firstof share_uri request.build_absolute_uri|urlencode %}&title={% firstof email_title "CFPB" %}&pubid=ra-4da354ee346886d2"><span class="cfpb_visually_hide">Share via Email</span></a>
-                    </div>
-                </div>
-            </div>
         </section>
 
         <section id="options" class="section clearfix">

--- a/paying_for_college/templates/standalone/base_update.html
+++ b/paying_for_college/templates/standalone/base_update.html
@@ -35,28 +35,22 @@
     <meta name="viewport" content="width=1016">
     {% endblock %}
 
-    <!-- Favicons -->
-    <link rel="apple-touch-icon" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/apple-touch-icon-precomposed.png">
-    <link rel="apple-touch-icon" size="72x72" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/apple-touch-icon-72x72-precomposed.png">
-    <link rel="apple-touch-icon" size="114x114" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/apple-touch-icon-114x114-precomposed.png">
-    <link rel="apple-touch-icon" size="144x144" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/apple-touch-icon-144x144-precomposed.png">
+    <link rel="shortcut icon" type="image/x-icon" href="http://www.consumerfinance.gov/favicon.ico">
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="http://www.consumerfinance.gov/static/js/modernizr.min.js"></script>
+    <script src="http://www.consumerfinance.gov/static/js/es5-shim.js"></script>
 
-    <script src="http://www.consumerfinance.gov/static/nemo/_/js/jquery-1.9.1.min.js"></script>
     <!--[if lt IE 9]>
-    <script src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/js/html5shim.js"></script>
+    <script>
+        // If in IE8 reverse no-js/js class change made by modernizr.
+        var docElement = document.documentElement;
+        docElement.className = docElement.className.replace( /(^|\s)js(\s|$)/, '$1no-js$2' );
+    </script>
     <![endif]-->
+
+    <!--[if IE 9]><script src="http://www.consumerfinance.gov/static/js/ie/common.ie.js"></script><![endif]-->
 
     {% block nemo_styles %}
-    <!-- Styles -->
-
-    <!--[if gt IE 8]><!-->
-    <link rel="stylesheet" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/c/woff.css{{ STATIC_VERSION }}">
-    <!--<![endif]-->
-    <!--[if lt IE 9]>
-    <link rel="stylesheet" href="/wp-content/themes/cfpb_nemo/_/c/eot.css">
-    <![endif]-->
-    <link rel="stylesheet" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/c/styles.css{{ STATIC_VERSION }}">
-
     {% endblock %}
 
     {% block app_css %}
@@ -127,9 +121,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </ul> <!-- /class=bread -->
                 {% block content %}
                 {% endblock %}
-                {% block share_box %}
-            {% include "standalone/share_box.html" %}
-                {% endblock %}
 
         </section><!--/main_content-->
         </div><!-- /wrapper -->
@@ -150,10 +141,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 
 {% block nemo_js %}
-<script src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/js/functions.js?ver=all"></script>
-<script type="text/javascript" src="http://www.consumerfinance.gov/static/agreements/js/chosen.jquery.js?ver=all"></script>
 {% endblock %}
-<script src="http://www.consumerfinance.gov/static/nemo/_/js/functions.js?ver="></script>
 {% block app_js %}
 {% endblock %}
 

--- a/paying_for_college/templates/standalone/base_update.html
+++ b/paying_for_college/templates/standalone/base_update.html
@@ -1,27 +1,18 @@
-<!DOCTYPE html>
+{% load staticfiles %}
 {% load static from staticfiles %}
-<!--
-Hey! If you're viewing this, you should probably come work on our Technology
-& Innovation team. We're always looking for a few great designers, developers, data
-scientists, and network, infrastructure, privacy and security pros. Keep
-an eye on our job opportunities at: http://www.consumerfinance.gov/jobs/
-
-Also, you can see more of our code at https://github.com/cfpb
-
-And by the way, there’s another hidden message somewhere on the following page: http://www.consumerfinance.gov/jobs/technology-innovation-fellows/. See if you can find it! Hint: picture yourself embedded in our work.
--->
-
+{% load i18n %}
+<!DOCTYPE html>
 <!-- paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/ -->
-<!--[if lt IE 7]> <html class="no-js lt-ie9 lt-ie8 lt-ie7" dir="ltr" lang="en-US"> <![endif]-->
-<!--[if IE 7]>    <html class="no-js lt-ie9 lt-ie8" dir="ltr" lang="en-US"> <![endif]-->
-<!--[if IE 8]>    <html class="no-js lt-ie9" dir="ltr" lang="en-US"> <![endif]-->
+<!--[if lt IE 7]> <html class="no-js lt-ie9 lt-ie8 lt-ie7" dir="ltr" lang="{% trans "en-US" %}"> <![endif]-->
+<!--[if IE 7]>    <html class="no-js lt-ie9 lt-ie8" dir="ltr" lang="{% trans "en-US" %}"> <![endif]-->
+<!--[if IE 8]>    <html class="no-js lt-ie9" dir="ltr" lang="{% trans "en-US" %}"> <![endif]-->
 <!-- Consider adding a manifest.appcache: h5bp.com/d/Offline -->
-<!--[if gt IE 8]><!--> <html dir="ltr" lang="en-US"> <!--<![endif]-->
+<!--[if gt IE 8]><!--> <html dir="ltr" lang="{% trans "en-US" %}"> <!--<![endif]-->
 
 <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb#">
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>{% block title %}{% endblock %} > Consumer Financial Protection Bureau</title>
+    <title>{% block title %}{% endblock %} > {% trans "Consumer Financial Protection Bureau" %}</title>
 
     <!-- Meta -->
     <meta name="google-site-verification" content=""> <!-- http://google.com/webmasters -->
@@ -36,7 +27,7 @@ And by the way, there’s another hidden message somewhere on the following page
     {% endblock %}
 
     {% block page_meta %}
-    <meta property="og:title" content="Consumer Financial Protection Bureau">
+    <meta property="og:title" content="Before You Claim &gt; Consumer Financial Protection Bureau">
     <meta property="og:url" content="{{ request.build_absolute_uri }}">
     {% endblock %}
 
@@ -50,7 +41,7 @@ And by the way, there’s another hidden message somewhere on the following page
     <link rel="apple-touch-icon" size="114x114" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/apple-touch-icon-114x114-precomposed.png">
     <link rel="apple-touch-icon" size="144x144" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/apple-touch-icon-144x144-precomposed.png">
 
-    <script src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/js/jquery-1.9.1.min.js"></script>
+    <script src="http://www.consumerfinance.gov/static/nemo/_/js/jquery-1.9.1.min.js"></script>
     <!--[if lt IE 9]>
     <script src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/js/html5shim.js"></script>
     <![endif]-->
@@ -59,13 +50,13 @@ And by the way, there’s another hidden message somewhere on the following page
     <!-- Styles -->
 
     <!--[if gt IE 8]><!-->
-    <link rel="stylesheet" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/c/woff.css">
+    <link rel="stylesheet" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/c/woff.css{{ STATIC_VERSION }}">
     <!--<![endif]-->
     <!--[if lt IE 9]>
-    <link rel="stylesheet" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/c/eot.css">
+    <link rel="stylesheet" href="/wp-content/themes/cfpb_nemo/_/c/eot.css">
     <![endif]-->
-    <link rel="stylesheet" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/c/styles.css">
-    <link rel='stylesheet' id='cfpb_icon_font-css'  href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/cfpb-icon-font/css/icons.css?ver=all" type="text/css" media="all">
+    <link rel="stylesheet" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/c/styles.css{{ STATIC_VERSION }}">
+
     {% endblock %}
 
     {% block app_css %}
@@ -73,6 +64,9 @@ And by the way, there’s another hidden message somewhere on the following page
 
     {% block page_css %}
     {% endblock %}
+
+    <link rel="stylesheet" href="http://www.consumerfinance.gov/static/css/header.css"/>
+    <link rel="stylesheet" href="http://www.consumerfinance.gov/static/css/footer.css"/>
 
     <!-- Feeds -->
     <link rel="alternate" type="application/rss+xml" title="Consumer Financial Protection Bureau &raquo; Feed" href="/feed/" />
@@ -97,7 +91,7 @@ And by the way, there’s another hidden message somewhere on the following page
     {% endblock %}
 </head>
 
-<body class="{% block body_class %}page{% endblock %}">
+<body class="{% block body_class %}page{% endblock %}" data-lang="{% trans "en" %}">
 {% block gtm_js %}
 <!-- Google Tag Manager -->
 {# Should always be included immediately after the opening <body> tag #}
@@ -121,75 +115,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     htmlTag.className = classes.replace("no-js", "");
   }
 </script>
+        {% include "standalone/on-demand/header.html" %}
     <div id="page">
         {% block app_notification %}
         {% endblock %}
-        <div class="nemo">
-          <div class="wrapper-banner">
-              <div class="wrapper-container">
-                  <span class="split">
-                      <span class="official-website">An official website of the United States Government</span>
-                      <div class="split-right">
-                        <a href="/es/" hreflang="es" class="espanol-link">Español</a>
-                        {% if IS_REMIT %}
-                        <a href="/lang/#zh" hreflang="zh">中文</a>
-                        <a href="/lang/#vi" hreflang="vi">Tiếng Việt</a>
-                        <a href="/lang/#ko" hreflang="ko">한국어</a>
-                        <a href="/lang/#tl" hreflang="tl">Tagalog</a>
-                        <a href="/lang/#ru" hreflang="ru">Pусский</a>
-                        <a href="/lang/#ar" hreflang="ar">العربية</a>
-                        <a href="/lang/#ht" hreflang="ht">Kreyòl Ayisyen</a>
-                        {% endif %}
-                    </div>
-                  </span>
-              </div>
-          </div><!-- .wrapper-banner -->
-
-          <header id="header">
-              <div role="banner">
-                {% block responsive_nav %}
-                {% endblock %}
-                <a href="/" class="logo">
-                    <img id="logo"
-                         class="logo__js"
-                         src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.svg"
-                         onerror="this.src='http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png';"
-                         alt="Consumer Financial Protection Bureau"
-                         width="262"
-                         height="66">
-                    <noscript>
-                        <img id="logo"
-                             class="logo__no-js"
-                             src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png"
-                             alt="Consumer Financial Protection Bureau"
-                             width="262"
-                             height="66">
-                    </noscript>
-                </a>
-                  <p class="lang"><span class="tel"><a href="tel:+18554112372">Contact us&nbsp;&nbsp;<strong>(855) 411-2372</strong></a></span></p>
-                  <form accept-charset="UTF-8" action="http://search.consumerfinance.gov/search" class="single" id="search_form" method="get">
-                                      <input name="utf8" type="hidden" value="&#x2713;" />
-                                      <input id="affiliate" name="affiliate" type="hidden" value="cfpb" />
-                                      <div class='inf'>
-                                          <label for="query">Search</label>
-                                          <input id="query" name="query" type="text" />
-                                      </div>
-                                      <button>Go</button>
-                                  </form>
-              </div>
-              <nav class="main" role="navigation">
-                  <ul>
-                      <li><a href="/">Home</a></li>
-                      <li><a href="#inside">Inside the CFPB</a></li>
-                      <li><a href="#assistance">Get assistance</a></li>
-                      <li><a href="#participate">Participate</a></li>
-                      <li><a href="#regulation">Law &amp; Regulation</a></li>
-                      <li><a href="#alert" class="complaint">Submit a complaint</a></li>
-                  </ul>
-              </nav>
-          </header>
-        </div>
-
         <div id="wrapper">
         <section id="maincontent">
             <ul class="bread meta">
@@ -201,186 +130,35 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 {% block share_box %}
             {% include "standalone/share_box.html" %}
                 {% endblock %}
+
         </section><!--/main_content-->
         </div><!-- /wrapper -->
-
-        <div class="nemo">
-          <section id="subnav">
-          <nav id="inside">
-              <h4>Inside the CFPB</h4>
-              <ul>
-                  <li><h5><a href="/the-bureau/">About us</a></h5></li>
-                  <li><h5><a href="/jobs/">Jobs</a></h5></li>
-                  <li><h5><a href="/contact-us/">Contact us</a></h5></li>
-                  <li><h5><a href="/newsroom/">Newsroom</a></h5></li>
-                  <li><h5><a href="/reports/">Reports</a></h5></li>
-                  <li><h5><a href="/budget/">Budget and performance</a></h5></li>
-                  <li><h5><a href="/strategic-plan/">Strategic plan</a></h5></li>
-                  <li><h5><a href="/blog/">Blog</a></h5></li>
-                  <li><h5><a href="/advisory-groups/">Advisory groups</a></h5></li>
-                  <li><h5><a href="/doing-business-with-us/">Doing business with us</a></h5></li>
-          </ul>
-          </nav>
-          <nav id="assistance">
-              <h4>Get assistance</h4>
-              <ul>
-                  <li><h5><a href="/askcfpb/">Ask CFPB</a></h5>
-                    <p>Get answers to your financial questions.</p></li>
-                  <li><h5><a href="/{{url_root}}/">Paying for College</a></h5></li>
-                  <li><h5><a href="/retirement/">Planning for Retirement</a></h5></li>
-                  <li><h5><a href="/owning-a-home/">Owning a Home</a></h5></li>
-                  <li><h5><a href="/mortgagehelp/">Trouble paying your mortgage?</a></h5></li>
-                  <li><h5><a href="https://help.consumerfinance.gov/app/account/complaints/list">Check the status of a complaint</a></h5></li>
-                  <li><h5><a href="/fair-lending/">Protections against credit discrimination</a></h5></li>
-                  <li>
-                      <h5>Information for:</h5>
-                      <ul>
-                          <li><a href="/students/">Students</a></li>
-                          <li><a href="/older-americans/">Older Americans</a></li>
-                          <li><a href="/servicemembers/">Servicemembers and Veterans</a></li>
-                          <li><a href="/small-financial-services-providers/">Community Banks &amp; Credit Unions</a></li>
-                          <li><a href="/empowerment/">Economically Vulnerable Consumers</a></li>
-                      </ul>
-                  </li>
-              </ul>
-          </nav>
-          <nav id="participate">
-              <h4>Participate</h4>
-              <ul>
-                  <li>
-                      <h5>Know Before You Owe</h5>
-                      <p>Making costs and risks clear.</p>
-                      <ul>
-                          <li><a href="/credit-cards/knowbeforeyouowe/">Credit cards</a></li>
-                          <li><a href="/knowbeforeyouowe/">Mortgages</a></li>
-                          <li><a href="/students/knowbeforeyouowe/">Student loans</a></li>
-                      </ul>
-                  </li>
-                  <li>
-                      <h5><a href="/your-story/">Tell Your Story</a></h5>
-                      <p>Help inform how we protect consumers &amp; create a fairer marketplace.</p>
-                  </li>
-                  <li>
-                      <h5><a href="/complaintdatabase">Consumer Complaint Database</a></h5>
-                  </li>
-                  <li>
-                      <h5><a href="/hmda">Home Mortgage Disclosure Act Database</a></h5>
-                  </li>
-                  <li>
-                      <h5><a href="/open/">Open government</a></h5>
-                      <ul>
-                          <li><a href="/leadership-calendar/">Leadership calendar</a></li>
-                          <li><a href="/foia/">FOIA</a></li>
-                      </ul>
-                  </li>
-                  <li>
-                      <h5><a href="/notice-and-comment/">Notice and comment</a></h5>
-                      <p>Weigh in on current rulemakings.</p>
-                  </li>
-              </ul>
-          </nav>
-          <nav id="regulation">
-              <h4>Regulation</h4>
-              <ul>
-                  <li><h5><a href="/guidance/supervision/manual/">Examination manual</a></h5></li>
-                  <li><h5><a href="/guidance/">Guidance</a></h5></li>
-                  <li><h5><a href="/notice-and-comment/">Notice and comment</a></h5></li>
-                  <li><h5><a href="/regulations/">Regulations</a></h5></li>
-                  <li><h5><a href="/regulatory-implementation/">Regulatory implementation</a></h5></li>
-                  <li><h5><a href="/administrativeadjudication/">Administrative adjudication</a></h5></li>
-                  <li><h5><a href="/amicus/">Amicus program</a></h5></li>
-              </ul>
-          </nav>
-          <nav id="alert">
-              <h4>Submit a complaint</h4>
-              <ul>
-                  <li>
-                      <h5><a href="/complaint">Submit a complaint</a></h5>
-                  </li>
-                  <li><h5><a href="https://help.consumerfinance.gov/app/account/complaints/list">Check the status of your complaint</a></h5></li>
-                  <li>
-                      <h5><a href="/the-cfpb-wants-you-to-blow-the-whistle-on-lawbreakers/">Whistleblowers</a></h5>
-                      <p>Confidentially report any wrongdoing you have observed.</p>
-                  </li>
-              </ul>
-          </nav>
-          </section>
-        </div>
-
-        <div class="nemo">
-          <footer id="footer">
-              <div>
-                  <a href="/"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo-vert.png" alt="Consumer Financial Protection Bureau" title="CFPB"></a>
-                  <nav>
-                      <ul>
-                          <li><a href="/privacy-policy/">Privacy policy and legal notices</a></li>
-                          <li><a href="/accessibility/">Accessibility</a></li>
-                          <li><a href="/plain-writing/">Plain writing</a></li>
-                          <li><a href="/no-fear-act/">No FEAR Act</a></li>
-                          <li><a href="/foia/">FOIA</a></li>
-                          <li><a href="/equal-employment-opportunity/whistleblowers/">Whistleblower Act</a></li>
-                      </ul>
-                  </nav>
-                  <nav>
-                      <ul>
-                          <li><a href="http://usa.gov/">USA.gov</a></li>
-                          <li><a href="http://oig.federalreserve.gov/">Office of Inspector General</a></li>
-                          <li><a href="/ombudsman/">Ombudsman</a></li>
-                      </ul>
-                  </nav>
-                  <nav>
-                      <ul>
-                          <li class="horizontal-list-item"><a href="http://facebook.com/cfpb" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/fb_footer_icon.png" alt="Visit us on Facebook"></a>&nbsp;&nbsp;</li>
-                          <li class="horizontal-list-item"><a href="http://twitter.com/cfpb" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/twitter_footer_icon.png" alt="Visit us on Twitter"></a>&nbsp;&nbsp;</li>
-                          <li class="horizontal-list-item"><a href="http://youtube.com/CFPB" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/youtube_footer_icon.png" alt="Visit us on Youtube"></a>&nbsp;&nbsp;</li>
-                          <li class="horizontal-list-item"><a href="http://flickr.com/cfpbphotos" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/flickr_footer_icon.png" alt="Visit us on Flickr"></a>&nbsp;&nbsp;</li>
-                          <li class="horizontal-list-item"><a href="/feed/" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/rss_footer_icon.png" alt="Subscribe to updates with RSS"></a></li>
-                      </ul>
-                      <p>Visite nuestro sitio web
-                      en español</p>
-                      <p><a class="link-button espanol-link" href="/es/" hreflang="es">Español</a></p>
-                  </nav>
-              </div>
-              <nav class="bottom">
-                  <ul>
-                      <li><a href="/contact-us/">Contact us</a></li>
-                      <li><a href="/newsroom/">Newsroom</a></li>
-                      <li><a href="/jobs/">Jobs</a></li>
-                      <li><a href="/open/">Open government</a></li>
-                  </ul>
-              </nav>
-          </footer>
-        </div>
-
-        <div class="shareavatar">
-            <img alt="" class="shareavatar" height=0 width=0 src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/facebookshareavatar.png" />
-        </div> <!-- Avatar for Facebook, hidden by CSS -->
     </div><!-- /#page -->
+    {% include "standalone/on-demand/footer.html" %}
+<script type='text/javascript'>
+//<![CDATA[
+    var usasearch_config = { siteHandle: 'cfpb' };
 
+    var script = document.createElement( 'script' );
+    script.type = 'text/javascript';
+    script.src = 'http://search.usa.gov/javascripts/remote.loader.js';
+    document.getElementsByTagName( 'head' )[0].appendChild( script );
+//]]>
+</script>
     {% block app_modal %}
     {% endblock %}
 
-{% block nemo_js %}
-<script src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/js/functions.js"></script>
-<script type="text/javascript" src="http://www.consumerfinance.gov/static/agreements/js/chosen.jquery.js"></script>
-{% endblock %}
 
+{% block nemo_js %}
+<script src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/js/functions.js?ver=all"></script>
+<script type="text/javascript" src="http://www.consumerfinance.gov/static/agreements/js/chosen.jquery.js?ver=all"></script>
+{% endblock %}
+<script src="http://www.consumerfinance.gov/static/nemo/_/js/functions.js?ver="></script>
 {% block app_js %}
 {% endblock %}
 
 {% block page_js %}
 {% endblock %}
-
-<!-- for search.usa.gov indexing -->
-<script type="text/javascript">
-  //<![CDATA[
-    var aid = "cfpb";
-    var script = document.createElement('script');
-    script.type = "text/javascript";
-    script.src = "http://search.usa.gov/javascripts/stats.js";
-    document.getElementsByTagName("head")[0].appendChild(script);
-  //]]>
-</script>
 
 <script type="text/javascript">
     // If there are no breadcrumbs on this page, remove the ul tag so that screen
@@ -392,6 +170,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         }
     });
 </script>
-
+<script type="text/javascript" src="http://www.consumerfinance.gov/static/js/atomic/header.js"></script>
+<script type="text/javascript" src="http://www.consumerfinance.gov/static/js/atomic/footer.js"></script>
 </body>
 </html>

--- a/paying_for_college/templates/standalone/on-demand/footer.html
+++ b/paying_for_college/templates/standalone/on-demand/footer.html
@@ -1,0 +1,213 @@
+
+
+<footer class="o-footer" role="contentinfo">
+    <div class="wrapper wrapper__match-content">
+
+        <div class="o-footer_pre">
+
+            <a class="btn
+                      btn__secondary
+                      js-return-to-top
+                      o-footer_top-button"
+               href="#">
+                Back to top <span class="cf-icon cf-icon-arrow-up"></span>
+            </a>
+
+            <ul class="o-footer_nav-list">
+                <li class="list_item">
+                    <a class="list_link" href="/about-us/contact-us/">
+                        Contact Us
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="list_link" href="/about-us/newsroom/">
+                        Newsroom
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="list_link" href="/about-us/careers/">
+                        Careers
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="list_link" href="/cfpb-ombudsman/">
+                        CFPB Ombudsman
+                    </a>
+                </li>
+            </ul>
+            <div class="block
+                        block__flush-top
+                        block__flush-bottom
+                        block__padded-top">
+                
+
+
+
+
+<div class="m-social-media
+            m-social-media__follow">
+    
+
+    <ul class="list
+               list__unstyled
+               list__horizontal
+               m-social-media_icons">
+
+        
+
+        
+
+        
+
+        
+
+        
+
+        
+
+        
+            
+        
+
+
+        
+            
+                <li class="list_item">
+                    <a class="m-social-media_icon"
+                       href="/external-site/?ext_url=https://facebook.com/cfpb">
+                        <span class="cf-icon cf-icon-facebook-square"></span>
+                        <span class="u-visually-hidden">Visit us on Facebook</span>
+                    </a>
+                </li>
+            
+        
+            
+                <li class="list_item">
+                    <a class="m-social-media_icon"
+                       href="/external-site/?ext_url=https://twitter.com/cfpb">
+                        <span class="cf-icon cf-icon-twitter-square"></span>
+                        <span class="u-visually-hidden">Visit us on Twitter</span>
+                    </a>
+                </li>
+            
+        
+            
+                <li class="list_item">
+                    <a class="m-social-media_icon"
+                       href="/external-site/?ext_url=https://www.linkedin.com/company/consumer-financial-protection-bureau">
+                        <span class="cf-icon cf-icon-linkedin-square"></span>
+                        <span class="u-visually-hidden">Visit us on LinkedIn</span>
+                    </a>
+                </li>
+            
+        
+            
+                <li class="list_item">
+                    <a class="m-social-media_icon"
+                       href="/external-site/?ext_url=https://www.youtube.com/user/cfpbvideo">
+                        <span class="cf-icon cf-icon-youtube-square"></span>
+                        <span class="u-visually-hidden">Visit us on YouTube</span>
+                    </a>
+                </li>
+            
+        
+            
+                <li class="list_item">
+                    <a class="m-social-media_icon"
+                       href="/external-site/?ext_url=https://www.flickr.com/photos/cfpbphotos">
+                        <span class="cf-icon cf-icon-flickr-square"></span>
+                        <span class="u-visually-hidden">Visit us on Flickr</span>
+                    </a>
+                </li>
+            
+        
+
+    </ul>
+</div>
+
+            </div>
+        </div>
+
+        <div class="o-footer-middle-left">
+
+            <div class="o-footer_col">
+                <ul class="o-footer_list">
+                    <li class="list_item">
+                        <a class="list_link" href="/foia-requests/">
+                            FOIA
+                        </a>
+                    </li>
+                    <li class="list_item">
+                        <a class="list_link" href="/plain-writing/">
+                            Plain Writing
+                        </a>
+                    </li>
+                    <li class="list_item">
+                        <a class="list_link" href="/privacy/">
+                            Privacy, Policy & Legal Notices
+                        </a>
+                    </li>
+                    <li class="list_item">
+                        <a class="list_link"
+                           href="/privacy/digital-privacy-policy/">
+                            Digital Privacy Policy
+                        </a>
+                    </li>
+                </ul>
+            </div>
+            <div class="o-footer_col">
+                <ul class="o-footer_list">
+                    <li class="list_item">
+                        <a class="list_link" href="/accessibility/">
+                            Accessibility
+                        </a>
+                    </li>
+                    <li class="list_item">
+                        <a class="list_link" href="/office-civil-rights/">
+                            Office of Civil Rights
+                        </a>
+                    </li>
+                    <li class="list_item">
+                        <a class="list_link" href="/open-government/">
+                            Open Government
+                        </a>
+                    </li>
+                    <li class="list_item">
+                        <a class="list_link" href="/tribal/">
+                            Tribal
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
+        <div class="o-footer-middle-right">
+                <ul class="o-footer_list">
+                    <li class="list_item">
+                        <a class="list_link
+                                  icon-link
+                                  icon-link__external-link"
+                           href="http://usa.gov/">
+                            <span class="icon-link_text">USA.gov</span>
+                        </a>
+                    </li>
+                    <li class="list_item">
+                        <a class="list_link
+                                  icon-link
+                                  icon-link__external-link"
+                           href="http://www.federalreserve.gov/oig/default.htm">
+                            <span class="icon-link_text">Office of Inspector General</span>
+                        </a>
+                    </li>
+                </ul>
+        </div>
+
+        <div class="o-footer-post">
+            <p class="o-footer_official-website">
+                An official website of the United States Government
+            </p>
+        </div>
+
+    </div>
+</footer>
+

--- a/paying_for_college/templates/standalone/on-demand/header.html
+++ b/paying_for_college/templates/standalone/on-demand/header.html
@@ -1,0 +1,1932 @@
+
+<div class="a-overlay u-hidden"></div>
+
+
+
+<a href="#after-nav" id="skip-nav">Skip to main content</a>
+
+
+
+
+<header class="o-header"
+        role="banner">
+
+    
+
+    
+    
+    <div class="m-global-eyebrow
+                m-global-eyebrow__horizontal">
+        <div class="wrapper">
+            <div class="m-global-eyebrow_tagline">
+                An official website of the
+                <span class="m-global-eyebrow_tagline-usa">United States Government</span>
+            </div>
+            <div class="m-global-eyebrow_actions">
+                <ul class="m-global-eyebrow_languages">
+                    <li>
+                        <a href="/es/" hreflang="es" lang="es">
+                            Español
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/language/zh/" hreflang="zh" lang="zh">
+                            中文
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/language/vi/" hreflang="vi" lang="vi">
+                            Tiếng Việt
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/language/ko/" hreflang="ko" lang="ko">
+                            한국어
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/language/tl/" hreflang="tl" lang="tl">
+                            Tagalog
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/language/ru/" hreflang="ru" lang="ru">
+                            Pусский
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/language/ar/" hreflang="ar" lang="ar">
+                            العربية
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/language/ht/" hreflang="ht" lang="ht">
+                            Kreyòl Ayisyen
+                        </a>
+                    </li>
+                </ul>
+                <span class="m-global-eyebrow_phone">
+                    (855) 411-2372
+                </span>
+            </div>
+        </div>
+    </div>
+
+
+    <div class="o-header_content no-js">
+
+        <div class="wrapper">
+            
+            
+    
+    <div class="m-global-header-cta
+                m-global-header-cta__horizontal">
+        <a href="/complaint/">Submit a Complaint</a>
+    </div>
+
+
+            
+
+<div class="m-global-search"
+     data-js-hook="flyout-menu">
+    <button class="m-global-search_trigger"
+            data-js-hook="flyout-menu_trigger">
+        <span class="m-global-search_trigger-label">
+            <span class="u-visually-hidden">Search</span>
+        </span>
+    </button>
+    <div class="m-global-search_content
+                u-hidden"
+         data-js-hook="flyout-menu_content"
+         aria-expanded="false">
+        <form class="m-global-search_content-form"
+              action="http://search.consumerfinance.gov/search"
+              method="get">
+            
+            <input type="hidden"
+                   name="utf8"
+                   value="✓">
+            <input type="hidden"
+                   id="affiliate"
+                   name="affiliate"
+                   value="cfpb">
+            <div class="input-with-btn">
+                <div class="input-with-btn_input
+                            input-contains-label">
+                    <label for="query"
+                           class="input-contains-label_before
+                                  input-contains-label_before__search">
+                    </label>
+                    <label for="query"
+                           class="input-contains-label_after
+                                  input-contains-label_after__clear
+                                  u-hidden">
+                    </label>
+                    <input type="text"
+                           id="query"
+                           name="query"
+                           value=""
+                           placeholder="Search the CFPB">
+                </div>
+                <div class="input-with-btn_btn">
+                    <button class="btn" type="submit">Search</button>
+                </div>
+            </div>
+
+            <div class="m-global-search_content-suggestions">
+                <p class="h5">Suggested search terms:</p>
+                <ul class="list list__horizontal">
+                    <li class="list_item">
+                        <a class="list_link" href="http://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=regulations">
+                            Regulations
+                        </a>
+                    </li>
+                    <li class="list_item">
+                        <a class="list_link" href="http://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=compliance+guides">
+                            Compliance guides
+                        </a>
+                    </li>
+                    <li class="list_item">
+                        <a class="list_link" href="http://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=mortgage">
+                            Mortgage
+                        </a>
+                    </li>
+                    <li class="list_item">
+                        <a class="list_link" href="http://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=college+loans">
+                            College loans
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </form>
+        <button class="m-global-search_tab-trigger" aria-hidden="true"></button>
+    </div>
+</div>
+
+            <a class="o-header_logo" href="/">
+                <!--[if lt IE 9]>
+                    <img class="o-header_logo-img"
+                         src="http://www.consumerfinance.govhttp://www.consumerfinance.gov/static/img/logo_sm-exec.png"
+                         alt="Consumer Financial Protection Bureau"
+                         width="237"
+                         height="50">
+                <![endif]-->
+                <!--[if gt IE 8]><!-->
+                <img class="o-header_logo-img u-js-only"
+                     src="http://www.consumerfinance.gov/static/img/logo_sm-exec.svg"
+                     onerror="this.onerror=null;this.src='http://www.consumerfinance.gov/static/img/logo_sm-exec.png';"
+                     alt="Consumer Financial Protection Bureau"
+                     width="237"
+                     height="50">
+                <noscript>
+                    <img class="o-header_logo-img"
+                         src="http://www.consumerfinance.gov/static/img/logo_sm-exec.png"
+                         alt="Consumer Financial Protection Bureau"
+                         width="237"
+                         height="50">
+                </noscript>
+                <!--<![endif]-->
+            </a>
+
+            
+                
+
+
+
+
+
+
+
+
+
+
+
+
+
+<nav class="o-mega-menu u-hidden"
+     data-js-hook="flyout-menu"
+     aria-label="main navigation"
+     role="navigation">
+    <button class="o-mega-menu_trigger" data-js-hook="flyout-menu_trigger">
+        <span class="u-visually-hidden">Menu</span>
+    </button>
+    
+    
+<div class="o-mega-menu_content o-mega-menu_content-1
+            u-hidden-overflow"
+     aria-expanded="false"
+     data-js-hook="flyout-menu_content">
+
+    <div class="o-mega-menu_content-wrapper o-mega-menu_content-1-wrapper">
+        
+            
+            
+            <div class="o-mega-menu_content-grid o-mega-menu_content-1-grid">
+                
+                <div class="o-mega-menu_content-lists o-mega-menu_content-1-lists">
+                    
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-1-list">
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-1-item">
+        
+        
+    
+    <div class="m-global-header-cta
+                m-global-header-cta__list">
+        <a href="/complaint/">Submit a Complaint</a>
+    </div>
+
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-1-item"
+        data-js-hook=flyout-menu>
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-1-link
+                  o-mega-menu_content-link__has-children o-mega-menu_content-1-link__has-children
+                  "
+           href=#
+           data-js-hook=flyout-menu_trigger>
+            Consumer Tools
+        </a>
+        
+            
+<div class="o-mega-menu_content o-mega-menu_content-2
+            u-hidden-overflow"
+     aria-expanded="false"
+     data-js-hook="flyout-menu_content">
+
+    <div class="o-mega-menu_content-wrapper o-mega-menu_content-2-wrapper">
+        <div class="wrapper">
+            
+            
+            <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-2-alt-trigger"
+                    data-js-hook="flyout-menu_alt-trigger">
+                Back
+            </button>
+            
+            <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid">
+                
+                <span class="o-mega-menu_content-overview o-mega-menu_content-2-overview">
+                    
+                    
+                    <a class="u-link__disabled
+                              o-mega-menu_content-overview-link o-mega-menu_content-2-overview-link
+                              "
+                       >
+                        Consumer Tools Overview
+                    </a>
+                    
+                </span>
+                
+                <div class="o-mega-menu_content-lists o-mega-menu_content-2-lists">
+                    
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-2-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/complaint/
+           >
+            Submit a Complaint
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/askcfpb/
+           >
+            Ask CFPB
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/your-story/
+           >
+            Tell Your Story
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/students/
+           >
+            Information for Students
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/older-americans/
+           >
+            Information for Older Americans
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/servicemembers/
+           >
+            Information for Servicemembers &amp; Veterans
+        </a>
+        
+    </li>
+</ul>
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-2-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/paying-for-college/
+           >
+            Paying for College
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/owning-a-home/
+           >
+            Owning a Home
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/retirement/
+           >
+            Planning for Retirement
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/sending-money/
+           >
+            Sending Money Abroad
+        </a>
+        
+    </li>
+</ul>
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-2-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/know-before-you-owe/
+           >
+            Know Before You Owe Mortgages
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/mortgagehelp/
+           >
+            Trouble Paying Your Mortgage?
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/fair-lending/
+           >
+            Protections Against Discrimination
+        </a>
+        
+    </li>
+</ul>
+
+                </div>
+            </div>
+            
+                
+            
+                
+            
+        
+        </div>
+    </div>
+
+    
+
+</div>
+
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-1-item"
+        data-js-hook=flyout-menu>
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-1-link
+                  o-mega-menu_content-link__has-children o-mega-menu_content-1-link__has-children
+                  "
+           href=#
+           data-js-hook=flyout-menu_trigger>
+            Educational Resources
+        </a>
+        
+            
+<div class="o-mega-menu_content o-mega-menu_content-2
+            u-hidden-overflow"
+     aria-expanded="false"
+     data-js-hook="flyout-menu_content">
+
+    <div class="o-mega-menu_content-wrapper o-mega-menu_content-2-wrapper">
+        <div class="wrapper">
+            
+            
+            <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-2-alt-trigger"
+                    data-js-hook="flyout-menu_alt-trigger">
+                Back
+            </button>
+            
+            <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid">
+                
+                <span class="o-mega-menu_content-overview o-mega-menu_content-2-overview">
+                    
+                    
+                    <a class="u-link__disabled
+                              o-mega-menu_content-overview-link o-mega-menu_content-2-overview-link
+                              "
+                       >
+                        Educational Resources Overview
+                    </a>
+                    
+                </span>
+                
+                <div class="o-mega-menu_content-lists o-mega-menu_content-2-lists">
+                    
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-2-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/your-money-your-goals/
+           >
+            Your Money, Your Goals
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/adult-financial-education/
+           >
+            Adult Financial Education
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/youth-financial-education/
+           >
+            Youth Financial Education
+        </a>
+        
+    </li>
+</ul>
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-2-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/library-resources/
+           >
+            Resources for Libraries
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/tax-preparer-resources/
+           >
+            Resources for Tax Preparers
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/money-as-you-grow/
+           >
+            Resources for Parents
+        </a>
+        
+    </li>
+</ul>
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-2-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/empowerment/
+           >
+            Information for Economically Vulnerable Consumers
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/managing-someone-elses-money/
+           >
+            Managing Someone Else’s Money
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=http://promotions.usa.gov/cfpbpubs.html
+           >
+            Free Brochures
+        </a>
+        
+    </li>
+</ul>
+
+                </div>
+            </div>
+            
+                
+            
+                
+            
+        
+        </div>
+    </div>
+
+    
+
+</div>
+
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-1-item"
+        data-js-hook=flyout-menu>
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-1-link
+                  o-mega-menu_content-link__has-children o-mega-menu_content-1-link__has-children
+                  "
+           href=/data-research/
+           data-js-hook=flyout-menu_trigger>
+            Data &amp; Research
+        </a>
+        
+            
+<div class="o-mega-menu_content o-mega-menu_content-2
+            u-hidden-overflow"
+     aria-expanded="false"
+     data-js-hook="flyout-menu_content">
+
+    <div class="o-mega-menu_content-wrapper o-mega-menu_content-2-wrapper">
+        <div class="wrapper">
+            
+            
+            <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-2-alt-trigger"
+                    data-js-hook="flyout-menu_alt-trigger">
+                Back
+            </button>
+            
+            <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid">
+                
+                <span class="o-mega-menu_content-overview o-mega-menu_content-2-overview">
+                    
+                    
+                    <a class="
+                              o-mega-menu_content-overview-link o-mega-menu_content-2-overview-link
+                              "
+                       href=/data-research/>
+                        Data &amp; Research Overview
+                    </a>
+                    
+                </span>
+                
+                <div class="o-mega-menu_content-lists o-mega-menu_content-2-lists">
+                    
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-2-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/data-research/research-reports/
+           >
+            Research &amp; Reports
+        </a>
+        
+    </li>
+</ul>
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-2-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/data-research/consumer-complaints/
+           >
+            Consumer Complaint Database
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/data-research/mortgage-data-hmda/
+           >
+            Mortgage Database (HMDA)
+        </a>
+        
+    </li>
+</ul>
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-2-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/data-research/credit-card-data/
+           >
+            Credit Card Surveys &amp; Agreements
+        </a>
+        
+    </li>
+</ul>
+
+                </div>
+            </div>
+            
+                
+            
+                
+            
+        
+        </div>
+    </div>
+
+    
+
+</div>
+
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-1-item"
+        data-js-hook=flyout-menu>
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-1-link
+                  o-mega-menu_content-link__has-children o-mega-menu_content-1-link__has-children
+                  "
+           href=/policy-compliance/
+           data-js-hook=flyout-menu_trigger>
+            Policy &amp; Compliance
+        </a>
+        
+            
+<div class="o-mega-menu_content o-mega-menu_content-2
+            u-hidden-overflow"
+     aria-expanded="false"
+     data-js-hook="flyout-menu_content">
+
+    <div class="o-mega-menu_content-wrapper o-mega-menu_content-2-wrapper">
+        <div class="wrapper">
+            
+            
+            <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-2-alt-trigger"
+                    data-js-hook="flyout-menu_alt-trigger">
+                Back
+            </button>
+            
+            <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid">
+                
+                <span class="o-mega-menu_content-overview o-mega-menu_content-2-overview">
+                    
+                    
+                    <a class="
+                              o-mega-menu_content-overview-link o-mega-menu_content-2-overview-link
+                              "
+                       href=/policy-compliance/>
+                        Policy &amp; Compliance Overview
+                    </a>
+                    
+                </span>
+                
+                <div class="o-mega-menu_content-lists o-mega-menu_content-2-lists">
+                    
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-2-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        data-js-hook=flyout-menu>
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  o-mega-menu_content-link__has-children o-mega-menu_content-2-link__has-children
+                  "
+           href=/policy-compliance/rulemaking/
+           data-js-hook=flyout-menu_trigger>
+            Rulemaking
+        </a>
+        
+            
+<div class="o-mega-menu_content o-mega-menu_content-3
+            u-hidden-overflow"
+     aria-expanded="false"
+     data-js-hook="flyout-menu_content">
+
+    <div class="o-mega-menu_content-wrapper o-mega-menu_content-3-wrapper">
+        <div class="wrapper">
+            
+            
+            <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-3-alt-trigger"
+                    data-js-hook="flyout-menu_alt-trigger">
+                Back
+            </button>
+            
+            <div class="o-mega-menu_content-grid o-mega-menu_content-3-grid">
+                
+                <span class="o-mega-menu_content-overview o-mega-menu_content-3-overview">
+                    
+                    
+                    <a class="
+                              o-mega-menu_content-overview-link o-mega-menu_content-3-overview-link
+                              "
+                       href=/policy-compliance/rulemaking/>
+                        Rulemaking Overview
+                    </a>
+                    
+                </span>
+                
+                <div class="o-mega-menu_content-lists o-mega-menu_content-3-lists">
+                    
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-3-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/policy-compliance/rulemaking/final-rules/
+           >
+            Final Rules
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/policy-compliance/rulemaking/rules-under-development/
+           >
+            Rules Under Development
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/policy-compliance/rulemaking/regulatory-agenda/
+           >
+            Regulatory Agenda
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/policy-compliance/rulemaking/small-business-review-panels/
+           >
+            Small Business Review Panels
+        </a>
+        
+    </li>
+</ul>
+
+                </div>
+            </div>
+            
+                
+            
+                
+            
+        
+        </div>
+    </div>
+
+    
+
+</div>
+
+        
+    </li>
+</ul>
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-2-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        data-js-hook=flyout-menu>
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  o-mega-menu_content-link__has-children o-mega-menu_content-2-link__has-children
+                  "
+           href=/policy-compliance/guidance/
+           data-js-hook=flyout-menu_trigger>
+            Compliance &amp; Guidance
+        </a>
+        
+            
+<div class="o-mega-menu_content o-mega-menu_content-3
+            u-hidden-overflow"
+     aria-expanded="false"
+     data-js-hook="flyout-menu_content">
+
+    <div class="o-mega-menu_content-wrapper o-mega-menu_content-3-wrapper">
+        <div class="wrapper">
+            
+            
+            <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-3-alt-trigger"
+                    data-js-hook="flyout-menu_alt-trigger">
+                Back
+            </button>
+            
+            <div class="o-mega-menu_content-grid o-mega-menu_content-3-grid">
+                
+                <span class="o-mega-menu_content-overview o-mega-menu_content-3-overview">
+                    
+                    
+                    <a class="
+                              o-mega-menu_content-overview-link o-mega-menu_content-3-overview-link
+                              "
+                       href=/policy-compliance/guidance/>
+                        Compliance &amp; Guidance Overview
+                    </a>
+                    
+                </span>
+                
+                <div class="o-mega-menu_content-lists o-mega-menu_content-3-lists">
+                    
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-3-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/policy-compliance/guidance/implementation-guidance/
+           >
+            Implementation &amp; Guidance
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/policy-compliance/guidance/supervision-examinations/
+           >
+            Supervision &amp; Examinations
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/policy-compliance/guidance/supervisory-highlights/
+           >
+            Supervisory Highlights
+        </a>
+        
+    </li>
+</ul>
+
+                </div>
+            </div>
+            
+                
+            
+                
+            
+        
+        </div>
+    </div>
+
+    
+
+</div>
+
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        data-js-hook=flyout-menu>
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  o-mega-menu_content-link__has-children o-mega-menu_content-2-link__has-children
+                  "
+           href=/policy-compliance/enforcement/
+           data-js-hook=flyout-menu_trigger>
+            Enforcement
+        </a>
+        
+            
+<div class="o-mega-menu_content o-mega-menu_content-3
+            u-hidden-overflow"
+     aria-expanded="false"
+     data-js-hook="flyout-menu_content">
+
+    <div class="o-mega-menu_content-wrapper o-mega-menu_content-3-wrapper">
+        <div class="wrapper">
+            
+            
+            <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-3-alt-trigger"
+                    data-js-hook="flyout-menu_alt-trigger">
+                Back
+            </button>
+            
+            <div class="o-mega-menu_content-grid o-mega-menu_content-3-grid">
+                
+                <span class="o-mega-menu_content-overview o-mega-menu_content-3-overview">
+                    
+                    
+                    <a class="
+                              o-mega-menu_content-overview-link o-mega-menu_content-3-overview-link
+                              "
+                       href=/policy-compliance/enforcement/>
+                        Enforcement Overview
+                    </a>
+                    
+                </span>
+                
+                <div class="o-mega-menu_content-lists o-mega-menu_content-3-lists">
+                    
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-3-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/policy-compliance/enforcement/actions/
+           >
+            Enforcement Actions
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/policy-compliance/enforcement/petitions/
+           >
+            Petitions to Modify or Set Aside
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/policy-compliance/enforcement/warning-letters/
+           >
+            Warning Letters
+        </a>
+        
+    </li>
+</ul>
+
+                </div>
+            </div>
+            
+                
+            
+                
+            
+        
+        </div>
+    </div>
+
+    
+
+</div>
+
+        
+    </li>
+</ul>
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-2-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        data-js-hook=flyout-menu>
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  o-mega-menu_content-link__has-children o-mega-menu_content-2-link__has-children
+                  "
+           href=/policy-compliance/notice-opportunities-comment/
+           data-js-hook=flyout-menu_trigger>
+            Notices &amp; Opportunities to Comment
+        </a>
+        
+            
+<div class="o-mega-menu_content o-mega-menu_content-3
+            u-hidden-overflow"
+     aria-expanded="false"
+     data-js-hook="flyout-menu_content">
+
+    <div class="o-mega-menu_content-wrapper o-mega-menu_content-3-wrapper">
+        <div class="wrapper">
+            
+            
+            <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-3-alt-trigger"
+                    data-js-hook="flyout-menu_alt-trigger">
+                Back
+            </button>
+            
+            <div class="o-mega-menu_content-grid o-mega-menu_content-3-grid">
+                
+                <span class="o-mega-menu_content-overview o-mega-menu_content-3-overview">
+                    
+                    
+                    <a class="
+                              o-mega-menu_content-overview-link o-mega-menu_content-3-overview-link
+                              "
+                       href=/policy-compliance/notice-opportunities-comment/>
+                        Notices &amp; Opportunities to Comment Overview
+                    </a>
+                    
+                </span>
+                
+                <div class="o-mega-menu_content-lists o-mega-menu_content-3-lists">
+                    
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-3-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/policy-compliance/notice-opportunities-comment/open-notices/
+           >
+            Open Notices
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/policy-compliance/notice-opportunities-comment/archive-closed/
+           >
+            Archive of Closed Notices
+        </a>
+        
+    </li>
+</ul>
+
+                </div>
+            </div>
+            
+                
+            
+                
+            
+        
+        </div>
+    </div>
+
+    
+
+</div>
+
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        data-js-hook=flyout-menu>
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  o-mega-menu_content-link__has-children o-mega-menu_content-2-link__has-children
+                  "
+           href=/policy-compliance/amicus/
+           data-js-hook=flyout-menu_trigger>
+            Amicus Program
+        </a>
+        
+            
+<div class="o-mega-menu_content o-mega-menu_content-3
+            u-hidden-overflow"
+     aria-expanded="false"
+     data-js-hook="flyout-menu_content">
+
+    <div class="o-mega-menu_content-wrapper o-mega-menu_content-3-wrapper">
+        <div class="wrapper">
+            
+            
+            <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-3-alt-trigger"
+                    data-js-hook="flyout-menu_alt-trigger">
+                Back
+            </button>
+            
+            <div class="o-mega-menu_content-grid o-mega-menu_content-3-grid">
+                
+                <span class="o-mega-menu_content-overview o-mega-menu_content-3-overview">
+                    
+                    
+                    <a class="
+                              o-mega-menu_content-overview-link o-mega-menu_content-3-overview-link
+                              "
+                       href=/policy-compliance/amicus/>
+                        Amicus Program Overview
+                    </a>
+                    
+                </span>
+                
+                <div class="o-mega-menu_content-lists o-mega-menu_content-3-lists">
+                    
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-3-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/policy-compliance/amicus/briefs/
+           >
+            Filed Briefs
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/policy-compliance/amicus/suggest/
+           >
+            Suggest a Case
+        </a>
+        
+    </li>
+</ul>
+
+                </div>
+            </div>
+            
+                
+            
+                
+            
+        
+        </div>
+    </div>
+
+    
+
+</div>
+
+        
+    </li>
+</ul>
+
+                </div>
+            </div>
+            
+                
+            
+                
+                
+<aside class="m-featured-menu-content
+              ">
+    <div class="m-featured-menu-content_text">
+        <p class="h4">
+            <a href="/policy-compliance/guidance/implementation-guidance/">
+                  Resources to help you comply
+            </a>
+        </p>
+        <p>
+            The TILA-RESPA integrated disclosure rule replaces four disclosure forms with two new ones. We have resources to help you comply.
+        </p>
+    </div>
+    <a href="/policy-compliance/guidance/implementation-guidance/"
+       class="m-featured-menu-content_img">
+        <img src="http://www.consumerfinance.gov/static/img/fmc-poly-com-540x300.jpg"
+             alt="Still from Know Before You Owe video."
+             height="150"
+             width="270">
+    </a>
+</aside>
+
+                
+            
+        
+        </div>
+    </div>
+
+    
+
+</div>
+
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-1-item"
+        data-js-hook=flyout-menu>
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-1-link
+                  o-mega-menu_content-link__has-children o-mega-menu_content-1-link__has-children
+                  "
+           href=/about-us/
+           data-js-hook=flyout-menu_trigger>
+            About Us
+        </a>
+        
+            
+<div class="o-mega-menu_content o-mega-menu_content-2
+            u-hidden-overflow"
+     aria-expanded="false"
+     data-js-hook="flyout-menu_content">
+
+    <div class="o-mega-menu_content-wrapper o-mega-menu_content-2-wrapper">
+        <div class="wrapper">
+            
+            
+            <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-2-alt-trigger"
+                    data-js-hook="flyout-menu_alt-trigger">
+                Back
+            </button>
+            
+            <div class="o-mega-menu_content-grid o-mega-menu_content-2-grid">
+                
+                <span class="o-mega-menu_content-overview o-mega-menu_content-2-overview">
+                    
+                    
+                    <a class="
+                              o-mega-menu_content-overview-link o-mega-menu_content-2-overview-link
+                              "
+                       href=/about-us/>
+                        About Us Overview
+                    </a>
+                    
+                </span>
+                
+                <div class="o-mega-menu_content-lists o-mega-menu_content-2-lists">
+                    
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-2-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/about-us/the-bureau/
+           >
+            The Bureau
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/about-us/budget-strategy/
+           >
+            Budget &amp; Strategy
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/about-us/payments-harmed-consumers/
+           >
+            Payments to Harmed Consumers
+        </a>
+        
+    </li>
+</ul>
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-2-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/about-us/blog/
+           >
+            Blog
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/about-us/newsroom/
+           >
+            Newsroom
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/about-us/events/
+           >
+            Events
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/activity-log/
+           >
+            Recent Postings
+        </a>
+        
+    </li>
+</ul>
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-2-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        data-js-hook=flyout-menu>
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  o-mega-menu_content-link__has-children o-mega-menu_content-2-link__has-children
+                  "
+           href=/about-us/careers/
+           data-js-hook=flyout-menu_trigger>
+            Careers
+        </a>
+        
+            
+<div class="o-mega-menu_content o-mega-menu_content-3
+            u-hidden-overflow"
+     aria-expanded="false"
+     data-js-hook="flyout-menu_content">
+
+    <div class="o-mega-menu_content-wrapper o-mega-menu_content-3-wrapper">
+        <div class="wrapper">
+            
+            
+            <button class="o-mega-menu_content-alt-trigger o-mega-menu_content-3-alt-trigger"
+                    data-js-hook="flyout-menu_alt-trigger">
+                Back
+            </button>
+            
+            <div class="o-mega-menu_content-grid o-mega-menu_content-3-grid">
+                
+                <span class="o-mega-menu_content-overview o-mega-menu_content-3-overview">
+                    
+                    
+                    <a class="
+                              o-mega-menu_content-overview-link o-mega-menu_content-3-overview-link
+                              "
+                       href=/about-us/careers/>
+                        Careers Overview
+                    </a>
+                    
+                </span>
+                
+                <div class="o-mega-menu_content-lists o-mega-menu_content-3-lists">
+                    
+<ul class="list
+           list__unstyled
+           o-mega-menu_content-list o-mega-menu_content-3-list">
+    
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/about-us/careers/working-at-cfpb/
+           >
+            Working @ CFPB
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/about-us/careers/application-process/
+           >
+            Job Application Process
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/about-us/careers/students-and-graduates/
+           >
+            Students &amp; Recent Graduates
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-3-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-3-link
+                  
+                  "
+           href=/about-us/careers/current-openings/
+           >
+            All Current Openings
+        </a>
+        
+    </li>
+</ul>
+
+                </div>
+            </div>
+            
+                
+            
+                
+            
+        
+        </div>
+    </div>
+
+    
+
+</div>
+
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/about-us/doing-business-with-us/
+           >
+            Doing Business With Us
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/about-us/advisory-groups/
+           >
+            Advisory Groups
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/about-us/project-catalyst/
+           >
+            Project Catalyst
+        </a>
+        
+    </li>
+    <li class="list_item
+               o-mega-menu_content-item o-mega-menu_content-2-item"
+        >
+        
+        <a class="
+                  o-mega-menu_content-link o-mega-menu_content-2-link
+                  
+                  "
+           href=/about-us/contact-us/
+           >
+            Contact Us
+        </a>
+        
+    </li>
+</ul>
+
+                </div>
+            </div>
+            
+                
+                
+<aside class="m-featured-menu-content
+              ">
+    <div class="m-featured-menu-content_text">
+        <p class="h4">
+            <a href="/about-us/the-bureau/">
+                  The CFPB: Working for you
+            </a>
+        </p>
+        <p>
+            This short video covers what the CFPB is and how we are working for American consumers.
+        </p>
+    </div>
+    <a href="/about-us/the-bureau/"
+       class="m-featured-menu-content_img">
+        <img src="http://www.consumerfinance.gov/static/img/fmc-about-us-540x300.jpg"
+             alt="Still from about the CFPB video."
+             height="150"
+             width="270">
+    </a>
+</aside>
+
+                
+            
+                
+            
+        
+        </div>
+    </div>
+
+    
+
+</div>
+
+        
+    </li>
+</ul>
+
+                </div>
+            </div>
+            
+        
+        
+    </div>
+
+    
+    
+    
+    <div class="m-global-eyebrow
+                m-global-eyebrow__list">
+        <div class="wrapper">
+            <div class="m-global-eyebrow_tagline">
+                An official website of the
+                <span class="m-global-eyebrow_tagline-usa">United States Government</span>
+            </div>
+            <div class="m-global-eyebrow_actions">
+                <ul class="m-global-eyebrow_languages">
+                    <li>
+                        <a href="/es/" hreflang="es" lang="es">
+                            Español
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/language/zh/" hreflang="zh" lang="zh">
+                            中文
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/language/vi/" hreflang="vi" lang="vi">
+                            Tiếng Việt
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/language/ko/" hreflang="ko" lang="ko">
+                            한국어
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/language/tl/" hreflang="tl" lang="tl">
+                            Tagalog
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/language/ru/" hreflang="ru" lang="ru">
+                            Pусский
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/language/ar/" hreflang="ar" lang="ar">
+                            العربية
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/language/ht/" hreflang="ht" lang="ht">
+                            Kreyòl Ayisyen
+                        </a>
+                    </li>
+                </ul>
+                <span class="m-global-eyebrow_phone">
+                    (855) 411-2372
+                </span>
+            </div>
+        </div>
+    </div>
+
+    
+
+</div>
+
+    <button class="o-mega-menu_tab-trigger" aria-hidden="true"></button>
+</nav>
+            
+        </div>
+
+    </div>
+    <script>
+      /* TODO: scope no-js to individual molecules/organisms. This is a hack to fix no-js on the on-demand header, while also allowing the menu to be scoped to o-header for on-demand pages. */
+      var headerDom = document.querySelector( '.o-header_content' );
+      headerDom.className = headerDom.className.replace('no-js','js');
+    </script>
+</header>
+
+
+<div id="after-nav"></div>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 Django==1.8.12
 Unipath==1.1
 requests==2.7.0
-django-haystack==2.4.0
+django-haystack==2.4.1
 python-dateutil==2.2
 PyYAML==3.11
 elasticsearch==2.3.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,9 +1,6 @@
-Django==1.6.11
-South==1.0
+Django==1.8.12
 Unipath==1.1
 requests==2.7.0
 django-haystack==2.4.0
-pysolr==3.3.2
-ordereddict==1.1
 python-dateutil==2.2
 PyYAML==3.11

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,3 +4,4 @@ requests==2.7.0
 django-haystack==2.4.0
 python-dateutil==2.2
 PyYAML==3.11
+elasticsearch==2.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 -r base.txt
--r test.txt
+-r testing.txt
 
 django-debug-toolbar==1.4
 

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,8 +1,4 @@
 -r base.txt
 
-nose==1.3.7
 coverage==4.0
 mock==1.3.0
-# selenium==2.48.0
-# behave==1.2.5
-# PyHamcrest==1.8.5

--- a/standalone_setup.sh
+++ b/standalone_setup.sh
@@ -5,21 +5,19 @@
 
 # Set script to exit on any errors.
 set -e
-
+  
 # Install project dependencies.
 install(){
-  echo 'Installing project dependencies...'
-  pip install -r requirements/testing.txt
-  npm install
-  gulp build
-
+  echo 'Installing front-end resources'
+  ./setup.sh
 }
 
 # Setup local data store in sqlite3
 dbsetup(){
   source .env
+  echo 'Loading requirements'
+  pip install -r requirements/testing.txt
   echo 'Loading college data into local test database'
-  python manage.py syncdb --noinput --no-initial-data
   python manage.py migrate paying_for_college
   python manage.py loaddata collegedata.json
   # python manage.py rebuild_index


### PR DESCRIPTION
This mimics the standalone scheme we used for Retirement. 
It picks up static versions of the on-demand header/footer used on cfgov.
It also converts (again) to Python 2.7, Django 1.8 and Elasticsearch
## Additions
- static versions of the on-demand header/footer templates
## Testing
- Fire up with runserver 
## Review

any of @mistergone  @niqjohnson @marteki 
## Screenshots
## Todos
- footer icons don't display on some pages; may be a local issue
## Checklist
- [x] CHANGELOG has been updated
