### PR TITLE
fix file path for BLS json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Removed national average graph data & explanatory boxes for settlement schools
 - Added an interaction between Step 1 and Step 2
 - Added school filtering for the Django admin
+- Fixed file path for BLS json import in views
 
 ## 2.0.4
 - Notifications enabled

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -45,7 +45,7 @@ else:  # pragma: no cover
     BASE_TEMPLATE = "front/base_update.html"
 
 URL_ROOT = 'paying-for-college2'
-EXPENSE_FILE = 'paying_for_college/fixtures/bls_data.json'
+EXPENSE_FILE = '{}/fixtures/bls_data.json'.format(BASEDIR)
 
 
 def get_json_file(filename):


### PR DESCRIPTION
When the app runs inside V1 it will need a full file path for data files. This adds the BASE_DIR value to the path.
## Changes
- path for bls_data.json
## Testing
- Should not change anything in standalone (/api/expenses/ should still work)
- in V1 standalone, this enables the endpoint
## Review
- @amymok 
- @marteki this was part of the closed [PR 161](https://github.com/cfpb/college-costs/pull/161/files) that I forgot about
- [x] CHANGELOG has been updated
