### PR TITLE
Fix handling of ownership and control values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
+
+## 2.1.0
 - Pinned and shrinkwrapped NPM dependencies
 - Added `snyk` to monitor for known NPM package vulnerabilities.
 - Updated the project to Django 1.8 and removed solr dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Removed national average graph data & explanatory boxes for settlement schools
 - Added an interaction between Step 1 and Step 2
 - Added school filtering for the Django admin
+- Fix handling of ownership and control values in update_colleges script
 
 ## 2.0.4
 - Notifications enabled

--- a/paying_for_college/disclosures/scripts/update_colleges.py
+++ b/paying_for_college/disclosures/scripts/update_colleges.py
@@ -90,7 +90,8 @@ def update(exclude_ids=[], single_school=None):
                         if key in data.keys() and data[key] is not None:
                             setattr(school, MODEL_MAP[key], data[key])
                             updated = True
-                    if data['ownership']:
+                    if data['school.ownership']:
+                        school.ownership = str(data['school.ownership'])
                         school.control = CONTROL_MAP[school.ownership]
                     if school.grad_rate_4yr:
                         school.grad_rate == school.grad_rate_4yr

--- a/paying_for_college/disclosures/scripts/update_colleges.py
+++ b/paying_for_college/disclosures/scripts/update_colleges.py
@@ -12,8 +12,9 @@ import datetime
 import requests
 
 from paying_for_college.disclosures.scripts import api_utils
-from paying_for_college.disclosures.scripts.api_utils import MODEL_MAP, LATEST_YEAR
-from paying_for_college.models import School
+from paying_for_college.disclosures.scripts.api_utils import (MODEL_MAP,
+                                                              LATEST_YEAR)
+from paying_for_college.models import School, CONTROL_MAP
 
 DATESTAMP = datetime.datetime.now().strftime("%Y-%m-%d")
 HOME = os.path.expanduser("~")
@@ -89,6 +90,8 @@ def update(exclude_ids=[], single_school=None):
                         if key in data.keys() and data[key] is not None:
                             setattr(school, MODEL_MAP[key], data[key])
                             updated = True
+                    if data['ownership']:
+                        school.control = CONTROL_MAP[school.ownership]
                     if school.grad_rate_4yr:
                         school.grad_rate == school.grad_rate_4yr
                     elif school.grad_rate_lt4:
@@ -131,16 +134,16 @@ def update(exclude_ids=[], single_school=None):
                     print("request for {0} returned {1}".format(school,
                                                               resp.status_code))
                     continue
-    endmsg = "\nTried to get new data for {0} schools:\n\
+    endmsg = """\nTried to get new data for {0} schools:\n\
     updated {1} and found no data for {2}\n\
     API response failures: {3}; schools that closed since last run: {4}\n\
-    \n{5} took {6} to run".format(processed,
-                                  update_count,
-                                  len(NO_DATA),
-                                  len(FAILED),
-                                  CLOSED,
-                                  SCRIPTNAME,
-                                  (datetime.datetime.now()-starter))
+    \n{5} took {6} to run""".format(processed,
+                                    update_count,
+                                    len(NO_DATA),
+                                    len(FAILED),
+                                    CLOSED,
+                                    SCRIPTNAME,
+                                    (datetime.datetime.now()-starter))
     if NO_DATA:
         endmsg += "\nA list of schools that had no API data was saved to {0}".format(NO_DATA_FILE)
         no_data_dict = {}

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -31,7 +31,7 @@ REGION_NAMES = {'MW': 'Midwest',
 
 HIGHEST_DEGREES = {  # highest-awarded values from Ed API and our CSV spec
     '0': "Non-degree-granting",
-    '1': 'Certificate degree',
+    '1': 'Certificate',
     '2': "Associate degree",
     '3': "Bachelor's degree",
     '4': "Graduate degree"

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -19,6 +19,11 @@ REGION_MAP = {'MW': ['IL', 'IN', 'IA', 'KS', 'MI', 'MN',
               'WE': ['AK', 'AZ', 'CA', 'CO', 'HI', 'ID', 'MT', 'NV', 'NM',
                      'OR', 'UT', 'WA', 'WY']
               }
+
+CONTROL_MAP = {'1': 'Public',
+               '2': 'Private',
+               '3': 'For-profit'}
+
 REGION_NAMES = {'MW': 'Midwest',
                 'NE': "Northeast",
                 'SO': 'South',
@@ -178,7 +183,7 @@ class School(models.Model):
     ownership = models.CharField(max_length=255, blank=True)
     control = models.CharField(max_length=50,
                                blank=True,
-                               help_text="'Public', 'Private' or 'For Profit'")
+                               help_text="'Public', 'Private' or 'For-profit'")
     url = models.TextField(blank=True)
     degrees_predominant = models.TextField(blank=True)
     degrees_highest = models.TextField(blank=True)

--- a/paying_for_college/tests/test_scripts.py
+++ b/paying_for_college/tests/test_scripts.py
@@ -31,7 +31,7 @@ class TestUpdater(django.test.TestCase):
                    'url': '',
                    'degrees_predominant': '',
                    'degrees_highest': '',
-                   'ownership': '',
+                   'school.ownership': '',
                    'main_campus': True,
                    'online_only': False,
                    'operating': True,

--- a/repositories.yml
+++ b/repositories.yml
@@ -1,1 +1,1 @@
-deploy_repository: https://github.com/cfpb/college-costs.git@2.0.4
+deploy_repository: https://github.com/cfpb/college-costs.git@2.1.0

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ class bdist_wheel(_bdist_wheel):
 
 setup(
     name='college-costs',
-    version='2.0.4',
+    version='2.1.0',
     author='CFPB',
     author_email='tech@cfpb.gov',
     maintainer='cfpb',

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 import os
-from setuptools import setup
-# from setuptools import find_packages
-# from subprocess import call
-# from setuptools import Command
-# from distutils.command.build_ext import build_ext as _build_ext
-# from setuptools.command.bdist_egg import bdist_egg as _bdist_egg
+from setuptools import setup, find_packages
+from subprocess import call
+from setuptools import Command
+from distutils.command.build_ext import build_ext as _build_ext
+from setuptools.command.bdist_egg import bdist_egg as _bdist_egg
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
 
 def read_file(filename):
@@ -16,6 +16,44 @@ def read_file(filename):
     except IOError:
         return ''
 
+
+class build_frontend(Command):
+    """ A command class to run `setup.sh` """
+    description = 'build front-end JavaScript and CSS'
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        print __file__
+        call(['./setup.sh'],
+             cwd=os.path.dirname(os.path.abspath(__file__)))
+
+
+class build_ext(_build_ext):
+    """ A build_ext subclass that adds build_frontend """
+    def run(self):
+        self.run_command('build_frontend')
+        _build_ext.run(self)
+
+
+class bdist_egg(_bdist_egg):
+    """ A bdist_egg subclass that runs build_frontend """
+    def run(self):
+        self.run_command('build_frontend')
+        _bdist_egg.run(self)
+
+
+class bdist_wheel(_bdist_wheel):
+    """ A bdist_wheel subclass that runs build_frontend """
+    def run(self):
+        self.run_command('build_frontend')
+        _bdist_wheel.run(self)
+
 setup(
     name='college-costs',
     version='2.0.4',
@@ -23,7 +61,7 @@ setup(
     author_email='tech@cfpb.gov',
     maintainer='cfpb',
     maintainer_email='tech@cfpb.gov',
-    packages=['paying_for_college'],
+    packages=['paying_for_college', 'paying_for_college.disclosures', 'paying_for_college.data_sources', 'paying_for_college', ],
     include_package_data=True,
     description=u'College cost tools',
     classifiers=[
@@ -38,4 +76,10 @@ setup(
     ],
     long_description=read_file('README.md'),
     zip_safe=False,
+    cmdclass={
+        'build_frontend': build_frontend,
+        'build_ext': build_ext,
+        'bdist_egg': bdist_egg,
+        'bdist_wheel': bdist_wheel,
+    },
 )


### PR DESCRIPTION
In order to deliver proper text values for school ownership, and to
update them properly from the scorecard API, we need to alter how the
update_colleges script handles ownership and control values and how the
School model delivers them.
## Additions
- CONTROL_MAP dictionary for the School model.
## Changes
- Alter handling of ownership and control values in the update_colleges script 
## Review
- @amymok @kurzn @marteki @mistergone 

A partial view of what the Fort Wayne [json payload](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/school/408039/) looks like now:

<img width="358" alt="for_profit_json" src="https://cloud.githubusercontent.com/assets/515885/15518623/cf1f26d4-21cb-11e6-88d3-00e51d381127.png">
## Checklist
- [x] CHANGELOG has been updated
