### PR TITLE
Fix sync of our migrations with server databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
+- fix migrations for deployment, adding 0003
 
 ## 2.1.0
 - Pinned and shrinkwrapped NPM dependencies

--- a/paying_for_college/migrations/0001_initial.py
+++ b/paying_for_college/migrations/0001_initial.py
@@ -169,7 +169,6 @@ class Migration(migrations.Migration):
                 ('avg_net_price', models.IntegerField(help_text=b'OVERALL AVERAGE', null=True, blank=True)),
                 ('tuition_out_of_state', models.IntegerField(null=True, blank=True)),
                 ('tuition_in_state', models.IntegerField(null=True, blank=True)),
-                ('offers_perkins', models.BooleanField(default=False)),
                 ('contact', models.ForeignKey(blank=True, to='paying_for_college.Contact', null=True)),
             ],
         ),

--- a/paying_for_college/migrations/0003_auto_20160525_2048.py
+++ b/paying_for_college/migrations/0003_auto_20160525_2048.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('paying_for_college', '0002_school_settlement_school'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='school',
+            name='offers_perkins',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AlterField(
+            model_name='school',
+            name='control',
+            field=models.CharField(help_text=b"'Public', 'Private' or 'For-profit'", max_length=50, blank=True),
+        ),
+    ]


### PR DESCRIPTION
The deployment issue was that the `offers_perkins` column on the School
model was in our Django 1.8 initial migration, so there is no new column
detected when run on the build server, even with --fake-initial. The new
`settlement_school` column gets detected and created in migration 0002.
The solution is to delete `offers_perkins` from the initial migration
and then run `makemigrations`, which creates a new 0003 migration that
will get the table created in our deployment. it is fervently hoped.
## Additions
- migration 0003 
## Removals
- `offers_perkins` line from initial migration
## Review
- @amymok 
## Checklist
- [x] CHANGELOG has been updated
