### PR TITLE
Adjust setup.py to include fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
 - Parent PLUS loans separated from other family contributions
-- fix migrations for deployment, adding 0003
+- Fixed migrations for deployment, adding 0003
+- Adjusted setup.py to include fixtures 
 
 ## 2.1.0
 - Pinned and shrinkwrapped NPM dependencies

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setup(
     maintainer_email='tech@cfpb.gov',
     packages=find_packages(),
     package_data={'paying_for_college':
-                  ['static/paying_for_college/disclosures/static/css/*.css',
+                  ['fixtures/*.json',
+                   'static/paying_for_college/disclosures/static/css/*.css',
                    'static/paying_for_college/disclosures/static/css/*.map',
                    'static/paying_for_college/disclosures/static/fonts/*.eot',
                    'static/paying_for_college/disclosures/static/fonts/*.svg',


### PR DESCRIPTION
We need to have BLS data and our collegedata fixture available to the
server to support our API and data migration.
## Changes
- Adjusted setup.py to include fixtures 
## Review
- @amymok 
## Checklist
- [x] CHANGELOG has been updated
