### PR TITLE
Adjust setup.py to pick up template files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 - Parent PLUS loans separated from other family contributions
 - Fixed migrations for deployment, adding 0003
-- Adjusted setup.py to include fixtures 
+- Adjusted setup.py to include fixtures and templates
 
 ## 2.1.0
 - Pinned and shrinkwrapped NPM dependencies

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,8 @@ setup(
     packages=find_packages(),
     package_data={'paying_for_college':
                   ['fixtures/*.json',
+                   'templates/*.html',
+                   'templates/*.txt',
                    'static/paying_for_college/disclosures/static/css/*.css',
                    'static/paying_for_college/disclosures/static/css/*.map',
                    'static/paying_for_college/disclosures/static/fonts/*.eot',


### PR DESCRIPTION
We didn't realize our non-python template files would not be picked up
in the deployment wheel, so we need tpo included them in the `package_data`
list.
## Changes
- Adjust setup.py to catch our templates
## Review
- @amymok 
## Checklist
- [x] CHANGELOG has been updated
