### PR TITLE
Graph adjustments to step 2 (graduation rate, loan default rate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - fix migrations for deployment, adding 0003
 - Perkins loans hidden for schools that do not offer them
 - Added "your salary and total student debt" section in step 2
+- Added graduation rate and loan default rate external links
+- Changed the scale of the loan default rate graph to 40%
 
 ## 2.1.1
 - Parent PLUS loans separated from other family contributions

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -2318,40 +2318,18 @@
                         <div class="criteria_wrapper">
                             <div class="criteria_intro">
                                 <p>
-                                    There are several <a
-                                    href="https://studentaid.ed.gov/sa/repay-loans/understand/plans" target="_blank">
-                                    options for reducing your federal student
-                                    loan payments</a> to help make them more
-                                    affordable. Many of these alternative
-                                    repayment plans are based on income and
-                                    family size, which means the lower your
-                                    salary, the lower your student loan
-                                    payment. For instance, if you have a
-                                    family of four with an annual income of
-                                    $50,000, your monthly student loan payment
-                                    would be $114. It could be as low as $0,
-                                    depending on your income and family size.
-                                </p>
-                                <p>
-                                    These repayment plans aren’t available for
-                                    private student loans, which can be why
-                                    some students still struggle to afford
-                                    their monthly student loan payment. If
-                                    you’re still not able to make payments on
-                                    your loans, you could go into default.
-                                </p>
-                                <p>
                                     Defaulting on a loan is when you fail to
                                     make scheduled payments over a certain
                                     period of time. This length of time can
                                     vary based on the type of loan. It can
-                                    also mean added late fees and interest
+                                    also mean added fees and interest
                                     because the debt isn’t paid off in time.
-                                    Defaulting on a loan can have serious
-                                    negative affects on your financial future.
-                                    It can make it difficult for you to get a
-                                    car or home loan, lower your credit score,
-                                    or result in wage garnishment.
+                                    Defaulting on a loan can negatively impact
+                                    your credit rating, which could make it
+                                    more difficult in the future to borrow
+                                    money to purchase a care or a home.
+                                    Defaulting could also result in wage
+                                    garnishment.
                                 </p>
                             </div>
                             <section class="metric loan-default-rates
@@ -2362,8 +2340,9 @@
                                         Loan default rates
                                     </h4>
                                     <p class="metric_explanation">
-                                        Percentage of students who default on
-                                        loans after entering repayment
+                                        Percentage of students from this
+                                        program who default on loans after
+                                        entering repayment
                                     </p>
                                     <div class="bar-graph"
                                     data-metric="defaultRate"
@@ -2392,6 +2371,15 @@
                                                 <div class="bar-graph_number"></div>
                                             </div>
                                         </div>
+                                    </div>
+                                    <div class="metric_link">
+                                        <p>
+                                            <a
+                                            href="http://nces.ed.gov/collegenavigator/"
+                                            class="loan-default-link"
+                                            target="_blank">See the loan default rates for the entire school
+</a>
+                                        </p>
                                     </div>
                                     <div class="metric_notification"
                                     data-better-direction="lower">

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -1811,6 +1811,17 @@
                                             </div>
                                         </div>
                                     </div>
+                                    <div class="metric_link">
+                                        <p>
+                                            Curious about the graduation rate
+                                            for the entire school? <a
+                                            href="https://collegescorecard.ed.gov/"
+                                            class="graduation-link"
+                                            target="_blank">See how this
+                                            school’s graduation rate compares
+                                            to the national average</a>
+                                        </p>
+                                    </div>
                                     <div class="metric_notification"
                                     data-better-direction="higher">
                                         <p class="cf-notification_text

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -2349,7 +2349,10 @@
                                     data-national-metric="loanDefaultRate"
                                     data-incoming-format="decimal-percent"
                                     data-graph-min="0"
-                                    data-graph-max="1">
+                                    data-graph-max="0.4">
+                                        <div class="bar-graph_top-label">
+                                            40%
+                                        </div>
                                         <div class="bar-graph_bar"></div>
                                         <div class="bar-graph_point
                                         bar-graph_point__you u-clearfix">

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -1146,8 +1146,9 @@
     display: none;
   }
 
-  // Median salary graph needs room above it for the top-label
-  &[data-metric="medianSalary"] {
+  // Median salary and loan default graphs need room above for the top-label
+  &[data-metric="medianSalary"],
+  &[data-metric="defaultRate"], {
     border-top: @bar-graph-top-label-height solid transparent;
   }
 }

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -926,6 +926,12 @@
     }
   }
 
+  &_link {
+    border-top: 1px solid @gray-40;
+    margin-top: 30px;
+    padding-top: 30px;
+  }
+
   &.column-well__not-stacked {
 
     .respond-to-range(@bp-sm-min, @bp-graph-cols-min - 1, {

--- a/src/disclosures/js/views/links-view.js
+++ b/src/disclosures/js/views/links-view.js
@@ -4,6 +4,7 @@ var formatURL = require( '../utils/format-url' );
 var constructScorecardSearch = require( '../utils/construct-scorecard-search' );
 
 var linksView = {
+  $gradLink: $( '.graduation-link' ),
   $schoolLinkText: $( '.school-link' ),
   $scorecardLink: $( '.scorecard-link' ),
 
@@ -13,10 +14,32 @@ var linksView = {
    * @param {object} values Financial model values
    */
   updateLinks: function( values ) {
+    this.$gradLinkText = $( '.graduation-link' );
     this.$schoolLinkText = $( '.school-link' );
     this.$scorecardLink = $( '.scorecard-link' );
+    this.setGraduationLink( values );
     this.setSchoolLink( values );
     this.setScorecardSearch( values );
+  },
+
+  /**
+   * Creates a link in Step 2 to the school's graduation metrics
+   * on the College Scorecard website
+   * @param {object} values Financial model values
+   */
+  setGraduationLink: function( values ) {
+    var formattedSchoolName = values.school.replace( /\s/g, '-' );
+    var gradURL = 'https://collegescorecard.ed.gov/school/?' + values.schoolID +
+     '-' + formattedSchoolName + '#graduation';
+    if ( gradURL ) {
+      var $gradLink = $( '<a>', {
+        'href': gradURL,
+        'target': '_blank',
+        'class': this.$gradLinkText.attr( 'class' )
+      } )
+        .text( this.$gradLinkText.text() );
+      this.$gradLinkText.replaceWith( $gradLink );
+    }
   },
 
   /**

--- a/src/disclosures/js/views/links-view.js
+++ b/src/disclosures/js/views/links-view.js
@@ -5,6 +5,7 @@ var constructScorecardSearch = require( '../utils/construct-scorecard-search' );
 
 var linksView = {
   $gradLink: $( '.graduation-link' ),
+  $defaultLink: $( '.loan-default-link' ),
   $schoolLinkText: $( '.school-link' ),
   $scorecardLink: $( '.scorecard-link' ),
 
@@ -15,9 +16,11 @@ var linksView = {
    */
   updateLinks: function( values ) {
     this.$gradLinkText = $( '.graduation-link' );
+    this.$defaultLinkText = $( '.loan-default-link' );
     this.$schoolLinkText = $( '.school-link' );
     this.$scorecardLink = $( '.scorecard-link' );
     this.setGraduationLink( values );
+    this.setLoanDefaultLink( values );
     this.setSchoolLink( values );
     this.setScorecardSearch( values );
   },
@@ -39,6 +42,24 @@ var linksView = {
       } )
         .text( this.$gradLinkText.text() );
       this.$gradLinkText.replaceWith( $gradLink );
+    }
+  },
+
+  /**
+   * Creates a link in Step 2 to the school's loan default metrics
+   * @param {object} values Financial model values
+   */
+  setLoanDefaultLink: function( values ) {
+    var defaultURL = 'http://nces.ed.gov/collegenavigator/?id=' +
+      values.schoolID + '#fedloans';
+    if ( defaultURL ) {
+      var $defaultLink = $( '<a>', {
+        'href': defaultURL,
+        'target': '_blank',
+        'class': this.$defaultLinkText.attr( 'class' )
+      } )
+        .text( this.$defaultLinkText.text() );
+      this.$defaultLinkText.replaceWith( $defaultLink );
     }
   },
 

--- a/src/disclosures/js/views/links-view.js
+++ b/src/disclosures/js/views/links-view.js
@@ -4,8 +4,8 @@ var formatURL = require( '../utils/format-url' );
 var constructScorecardSearch = require( '../utils/construct-scorecard-search' );
 
 var linksView = {
-  $gradLink: $( '.graduation-link' ),
-  $defaultLink: $( '.loan-default-link' ),
+  $gradLinkText: $( '.graduation-link' ),
+  $defaultLinkText: $( '.loan-default-link' ),
   $schoolLinkText: $( '.school-link' ),
   $scorecardLink: $( '.scorecard-link' ),
 

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -38,6 +38,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
 
   it( 'should let a student verify their information and go on to Step 1 of the offer', function() {
     page.confirmVerification();
+    browser.sleep( 750 );
     expect( page.correctInfoButton.isDisplayed() ).toBeFalsy();
     expect( page.incorrectInfoButton.isDisplayed() ).toBeFalsy();
     expect( page.correctInfoSection.isDisplayed() ).toBeTruthy();
@@ -46,9 +47,9 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
     expect( page.optionsConsiderationsSection.isDisplayed() ).toBeFalsy();
   } );
 
-  // TODO - Add expectation that verification buttons disappear, that next steps for incorrect info are displayed, and that the trigger to notify the school is activated
   it( 'should let a student report incorrect aid offer information', function() {
     page.denyVerification();
+    browser.sleep( 750 );
     expect( page.correctInfoButton.isDisplayed() ).toBeFalsy();
     expect( page.incorrectInfoButton.isDisplayed() ).toBeFalsy();
     expect( page.correctInfoSection.isDisplayed() ).toBeFalsy();
@@ -334,6 +335,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
 
   it( 'should properly update when the federal subsidized loans are modified within the allowed limit', function() {
     page.confirmVerification();
+    browser.sleep( 750 );
     page.setSubsidizedLoans( 3000 );
     browser.sleep( 750 );
     expect( page.totalFederalLoans.getText() ).toEqual( '5,000' );

--- a/test/functional/dd-settlement-only-spec.js
+++ b/test/functional/dd-settlement-only-spec.js
@@ -28,6 +28,38 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
     expect( page.gradRateNotification.isDisplayed() ).toBeFalsy();
   } );
 
+  it( 'should contain a link to the College Scorecard graduation rate comparison', function() {
+    page.confirmVerification();
+    browser.sleep( 1000 );
+    page.continueStep2();
+    browser.sleep( 1000 );
+    expect( page.gradRateLink.getAttribute( 'href' ) ).toEqual( 'https://collegescorecard.ed.gov/school/?408039-Brown-Mackie-College-Fort-Wayne#graduation' );
+  } );
+
+  it( 'should open the link to the College Scorecard graduation rate comparison in a new tab with the graduation rate section open', function() {
+    page.confirmVerification();
+    browser.sleep( 1000 );
+    page.continueStep2();
+    browser.sleep( 1000 );
+    page.followGradRateLink();
+    browser.sleep( 1000 );
+    browser.getAllWindowHandles()
+      .then( function ( handles ) {
+        expect( handles.length ).toBe( 2 );
+        browser.switchTo().window( handles[1] )
+          .then( function () {
+            browser.wait( EC.titleContains( 'Brown Mackie College-Fort Wayne' ), 8000, 'Page title did not contain "Brown Mackie College-Fort Wayne" within 8 seconds' );
+            browser.sleep( 750 );
+            expect( element( by.id( 'grad-meter' ) ).isDisplayed() ).toBeTruthy();
+          } )
+          .then( function () {
+            browser.close();
+            browser.sleep( 750 );
+            browser.switchTo().window( handles[0] );
+          } );
+      } );
+  } );
+
   it( 'should display the first year salary and total debt at repayment', function() {
     page.confirmVerification();
     browser.sleep( 1000 );
@@ -59,7 +91,7 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
     browser.sleep( 1000 );
     page.continueStep2();
     browser.sleep( 1000 );
-    expect( page.schoolDefaultRatePoint.getCssValue( 'bottom' ) ).toEqual( '80.5px' );
+    expect( page.schoolDefaultRatePoint.getCssValue( 'bottom' ) ).toEqual( '130px' );
     expect( page.schoolDefaultRateValue.getText() ).toEqual( '55%' );
     expect( page.nationalDefaultRatePoint.isDisplayed() ).toBeFalsy();
   } );
@@ -70,6 +102,39 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
     page.continueStep2();
     browser.sleep( 1000 );
     expect( page.defaultRateNotification.isDisplayed() ).toBeFalsy();
+  } );
+
+  it( 'should contain a link to the College Navigator cohort loan default rates', function() {
+    page.confirmVerification();
+    browser.sleep( 1000 );
+    page.continueStep2();
+    browser.sleep( 1000 );
+    browser.wait( EC.visibilityOf( page.defaultRateLink ), 8000 );
+    expect( page.defaultRateLink.getAttribute( 'href' ) ).toEqual( 'http://nces.ed.gov/collegenavigator/?id=408039#fedloans' );
+  } );
+
+  it( 'should open the link to the College Navigator cohort loan default rates in a new tab with the loan default rates section open', function() {
+    page.confirmVerification();
+    browser.sleep( 1000 );
+    page.continueStep2();
+    browser.sleep( 1000 );
+    page.followDefaultRateLink();
+    browser.sleep( 1000 );
+    browser.getAllWindowHandles()
+      .then( function ( handles ) {
+        expect( handles.length ).toBe( 2 );
+        browser.switchTo().window( handles[1] )
+          .then( function () {
+            browser.wait( EC.titleContains( 'College Navigator' ), 8000, 'Page title did not contain "College Navigator" within 8 seconds' );
+            browser.sleep( 750 );
+            expect( element( by.id( 'divctl00_cphCollegeNavBody_ucInstitutionMain_ctl11' ) ).isDisplayed() ).toBeTruthy();
+          } )
+          .then( function () {
+            browser.close();
+            browser.sleep( 750 );
+            browser.switchTo().window( handles[0] );
+          } );
+      } );
   } );
 
 } );

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -450,6 +450,16 @@ settlementAidOfferPage.prototype = Object.create({}, {
         return element( by.css( '.metric.graduation-rate .metric_notification' ) );
       }
     },
+    gradRateLink: {
+      get: function() {
+        return element( by.css( '.graduation-link' ) );
+      }
+    },
+    followGradRateLink: {
+      value: function() {
+        this.gradRateLink.click();
+      }
+    },
     schoolSalaryValue: {
       get: function() {
         return element( by.css( '.salary-and-debt_projection-value [data-financial="medianSalary"]' ) );
@@ -498,6 +508,16 @@ settlementAidOfferPage.prototype = Object.create({}, {
     defaultRateNotification: {
       get: function() {
         return element( by.css( '.metric.loan-default-rates .metric_notification' ) );
+      }
+    },
+    defaultRateLink: {
+      get: function() {
+        return element( by.css( '.loan-default-link' ) );
+      }
+    },
+    followDefaultRateLink: {
+      value: function() {
+        this.defaultRateLink.click();
       }
     },
     monthlyRent: {


### PR DESCRIPTION
This adds national average comparison links to the settlement version of the tool, as well as changes the scale of the loan default rate graph to 40% 

![screen shot 2016-06-02 at 4 58 14 pm](https://cloud.githubusercontent.com/assets/1183435/15760871/48939838-28e3-11e6-95a7-dc5e44cf2f6e.png)

![screen shot 2016-06-02 at 4 58 26 pm](https://cloud.githubusercontent.com/assets/1183435/15760876/4bfbbafa-28e3-11e6-8d8b-3f5d1f7d7547.png)
## Additions
- College Scorecard national comparison link for graduation rate
- College Navigator school-wide comparison link for loan default rate
## Changes
- Loan default rate graph now has a maximum of 40%
- Update text in "What if I can't afford my student loan payments?" section
## Testing

Pull down the branch. Run `npm install` to be safe, then `gulp`, and then load up [any school that we have sample program data for](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=449898&pid=1509&oid=fa8283b5b7c939a058889f997949efa566c616c6&tuit=44565&ppl=0&subl=3500&gpl=0&perl=5500&book=500&gib=0&pelg=1500&ta=500&unsl=6000&insi=5.0&parl=7000&insl=3000&stag=2000&prvl=17000&prvi=4.55&wkst=1000&hous=3000&othg=100&tran=500&schg=2000&mta=0&othr=500).

Functional browser tests should give the following result, due to the front-end not pulling in the new BLS datapoint yet:

> 66 specs, 7 failures

`npm test` should have all NPM package security and all unit tests passing.
## Review
- @mistergone @amymok @higs4281 
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
