### PR TITLE
BLS Region SELECT added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - BLS data imported from expenses API
 - BLS data set by program BLSAverage region
 - BLS data set by program expected salary
+- Expenses section BLS region selecter added
 - Added "your salary and total student debt" section in step 2
 - Added graduation rate and loan default rate external links
 - Changed the scale of the loan default rate graph to 40%

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -2106,6 +2106,14 @@
                                             national</span> averages from the
                                             Bureau of Labor Statistics; adjust
                                             as needed</p>
+                                        <div class="cf-select">
+                                          <select id="bls-region-select">
+                                            <option value="WE">West Region</option>
+                                            <option value="SO">South Region</option>
+                                            <option value="NE">Northeast Region</option>
+                                            <option value="MW">Midwest Region</option>
+                                          </select>
+                                        </div>
                                     </div>
                                     <div class="form-group_item">
                                         <label class="form-label__wrapped">

--- a/src/disclosures/js/dispatchers/publish-update.js
+++ b/src/disclosures/js/dispatchers/publish-update.js
@@ -70,6 +70,17 @@ var publishUpdate = {
   expensesData: function( prop, val ) {
     expensesModel.values[prop] = val;
     expensesModel.calc();
+  },
+
+  /**
+   * Function which updates expenses model with a new
+   * region.
+   * @param {string} region - region code
+   */
+  updateRegion: function( region ) {
+    var salary = financialModel.values.medianSalary;
+    expensesModel.resetCurrentValues( region, salary );
+    expensesModel.calc();
   }
 
 };

--- a/src/disclosures/js/index.js
+++ b/src/disclosures/js/index.js
@@ -49,9 +49,7 @@ var app = {
 
               // Update expenses model bases on region and salary
               region = schoolValues.BLSAverage.substr( 0, 2 );
-              salary = schoolValues.medianSalary;
-              expensesModel.resetCurrentValues( region, salary );
-              expensesView.updateView( getExpenses.values() );
+              $( '#bls-region-select' ).val( region ).change();
             } );
         }
         questionView.init();

--- a/src/disclosures/js/index.js
+++ b/src/disclosures/js/index.js
@@ -6,7 +6,6 @@ var financialModel = require( './models/financial-model' );
 var schoolModel = require( './models/school-model' );
 var expensesModel = require( './models/expenses-model' );
 var getFinancial = require( './dispatchers/get-financial-values' );
-var getExpenses = require( './dispatchers/get-expenses-values' );
 var getUrlValues = require( './dispatchers/get-url-values' );
 var financialView = require( './views/financial-view' );
 var expensesView = require( './views/expenses-view' );
@@ -34,8 +33,7 @@ var app = {
             .done( function( schoolData, programData, nationalData ) {
               var data = {},
                   schoolValues,
-                  region,
-                  salary;
+                  region;
               $.extend( data, schoolData[0], programData[0], nationalData[0] );
               schoolValues = schoolModel.init( data );
               // Update the financial model and view based on data

--- a/src/disclosures/js/models/expenses-model.js
+++ b/src/disclosures/js/models/expenses-model.js
@@ -67,6 +67,13 @@ var expensesModel = {
     return false;
   },
 
+  /**
+   * Changes the various expenses values based on the region
+   * and salary parameters. Uses the 'stored' Object in this
+   * model to find correct values.
+   * @param {string} region - BLS region code
+   * @param {number} salary - Annual salary
+   */
   resetCurrentValues: function( region, salary ) {
     for ( var x = 0; x < this.expenseKeys.length; x++ ) {
       var key = this.expenseKeys[x],

--- a/src/disclosures/js/views/expenses-view.js
+++ b/src/disclosures/js/views/expenses-view.js
@@ -45,10 +45,9 @@ var expensesView = {
       var $ele = $( this ),
           name = $ele.attr( 'data-expenses' ),
           currency = true;
-      if ( expensesView.currentInput === $( this ).attr( 'id' ) ) {
-        currency = false;
+      if ( expensesView.currentInput !== $ele.attr( 'id' ) ) {
+        expensesView.updateElement( $ele, values[name], currency );
       }
-      expensesView.updateElement( $ele, values[name], currency );
     } );
   },
 

--- a/src/disclosures/js/views/expenses-view.js
+++ b/src/disclosures/js/views/expenses-view.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var getExpenses = require( '../dispatchers/get-expenses-values' );
+var getFinancials = require( '../dispatchers/get-financial-values' );
 var publish = require( '../dispatchers/publish-update' );
 var formatUSD = require( 'format-usd' );
 var stringToNum = require( '../utils/handle-string-input' );
@@ -12,6 +13,7 @@ var expensesView = {
 
   init: function() {
     this.keyupListener();
+    this.regionSelectListener();
   },
 
   /**
@@ -72,7 +74,7 @@ var expensesView = {
   },
 
   /**
-   * Listener function for keyup in financial model INPUT fields
+   * Listener function for keyup in expenses INPUT fields
    */
   keyupListener: function() {
     this.$reviewAndEvaluate.on( 'keyup', '[data-expenses]', function() {
@@ -83,7 +85,20 @@ var expensesView = {
         expensesView.updateView( getExpenses.values() );
       }, 500 );
     } );
+  },
+
+  /**
+   * Listener for the BLS region SELECT
+   */
+  regionSelectListener: function() {
+    $( '#bls-region-select' ).change( function() {
+      var region = $( this ).val();
+      publish.updateRegion( region );
+      expensesView.updateView( getExpenses.values() );
+    } );
   }
+
+
 };
 
 module.exports = expensesView;

--- a/src/disclosures/js/views/expenses-view.js
+++ b/src/disclosures/js/views/expenses-view.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var getExpenses = require( '../dispatchers/get-expenses-values' );
-var getFinancials = require( '../dispatchers/get-financial-values' );
 var publish = require( '../dispatchers/publish-update' );
 var formatUSD = require( 'format-usd' );
 var stringToNum = require( '../utils/handle-string-input' );

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -562,8 +562,6 @@ it( 'should properly update when more than one private loans is modified', funct
   } );
 
   // *** Step 2: Evaluate your offer ***
-
-  // TODO: Change monthly left over when student loan payment is added
   it( 'should properly display estimated monthly expenses', function() {
     page.confirmVerification();
     browser.sleep( 1000 );
@@ -571,6 +569,16 @@ it( 'should properly update when more than one private loans is modified', funct
     browser.sleep( 1000 );
     expect( page.totalMonthlyExpenses.getText() ).toEqual( '2,611' );
     expect( page.totalMonthlyLeftOver.getText() ).toEqual( '-943' );
+  } );
+
+  it( 'should properly change expenses when region is selected', function() {
+    page.confirmVerification();
+    browser.sleep( 1000 );
+    page.continueStep2();
+    browser.sleep( 1000 );
+    page.setExpensesRegion( 'SO' );
+    browser.sleep( 250 );
+    expect( page.monthlyRent.getText() ).toEqual( '$912')
   } );
 
   it( 'should properly update when estimated monthly mortage or rent is modified', function() {

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -577,8 +577,8 @@ it( 'should properly update when more than one private loans is modified', funct
     page.continueStep2();
     browser.sleep( 1000 );
     page.setExpensesRegion( 'SO' );
-    browser.sleep( 250 );
-    expect( page.monthlyRent.getText() ).toEqual( '$912')
+    browser.sleep( 500 );
+    expect( page.monthlyRent.getAttribute('value') ).toEqual( '$912')
   } );
 
   it( 'should properly update when estimated monthly mortage or rent is modified', function() {

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -520,6 +520,16 @@ settlementAidOfferPage.prototype = Object.create({}, {
         this.defaultRateLink.click();
       }
     },
+    expensesRegionSelect: {
+      get: function() {
+        return element ( by.css( '#bls-region-select' ) );
+      }
+    },
+    setExpensesRegion: {
+      value: function( region ) {
+        return this.expensesRegionSelect.element( by.css( '[value="' + region + '"]') ).click();
+      }
+    },
     monthlyRent: {
       get: function() {
         return element( by.id( 'expenses__rent' ) );


### PR DESCRIPTION
This PR adds a `SELECT` to the expenses section which allows the user to choose a BLS region. Changing this `SELECT` will reset the `INPUT`s in the expenses section to the values returned by our API. Initially, when a program loads, this `SELECT` will be set to the region associated with the program

**Note!** This PR does not include proper styling for the `SELECT` (it's too wide), and the expenses section has yet to be re-ordered. Those change are in a separate task and will be completed later.
## Additions
- Added the `#bls-region-select` element
- Added a handler to `expenses-view` for the `SELECT` element
- Functional test added for BLS region changing
## Testing
- Functional and unit tests are all passing!
## Review
- @marteki and @amymok  and @higs4281 and anyone who likes BLS data!
- Pull it down, run `gulp` (`npm install` shouldn't be necessary), and check it out!
## Screenshots

<img width="867" alt="screen shot 2016-06-06 at 3 11 34 pm" src="https://cloud.githubusercontent.com/assets/1490703/15834336/0693935c-2bf9-11e6-8e7e-a5b549083f5e.png">
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices 
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
## Animated GIF

(for @ascott1 ) Ladies and gentlemen, **The Selecter!!!**
<img src="https://49.media.tumblr.com/a5a3d27b08555fd431b7c9d1800f1071/tumblr_o1mr6mdouE1umn0yeo1_400.gif">
