### PR TITLE
10/25 Year Loan toggle added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Added graduation rate and loan default rate external links
 - Changed the scale of the loan default rate graph to 40%
 - General code housekeeping (GitHub templates, linting improvements)
+- metric-view refactored
+- 10/25 loan term toggles added to metrics section
 
 ## 2.1.1
 - Parent PLUS loans separated from other family contributions

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -2199,6 +2199,9 @@
                                           </p>
                                       </div>
                                       <div id="estimated-debt-burden_term"  data-repayment-section="estimated-debt-burden">
+                                      <p>
+                                        See how loan length affects your debt burden
+                                      </p>
                                         <label for="estimated-debt-burden_term_10">
                                           <input id="estimated-debt-burden_term_10" type="radio" name="estimated-debt-burden_term"  value="ten" checked> 10 years
                                         </label>

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -2020,7 +2020,8 @@
                             </div>
                             <section class="metric salary-and-debt
                             column-well column-well__bleed
-                            column-well__not-stacked">
+                            column-well__not-stacked"
+                             data-repayment-section="monthly-payment">
                                 <div class="column-well_content">
                                     <h4 class="metric_heading">
                                         Calculate your monthly payment
@@ -2059,12 +2060,12 @@
                                       <p>
                                         See how loan length affects your payments
                                       </p>
-                                      <div id="monthly-payment_term" data-repayment-section="monthly-payment">
+                                      <div id="monthly-payment_term">
                                         <label for="monthly-payment_term_10">
-                                          <input id="monthly-payment_term_10" type="radio" name="monthly-payment_term"  value="10" checked> 10 years
+                                          <input id="monthly-payment_term_10" type="radio" name="monthly-payment_term"  value="ten" checked> 10 years
                                         </label>
                                         <label>
-                                          <input id="monthly-payment_term_25" type="radio" name="monthly-payment_term" value="25">
+                                          <input id="monthly-payment_term_25" type="radio" name="monthly-payment_term" value="twentyFive">
                                           25 years
                                         </label>
                                       </div>
@@ -2105,7 +2106,8 @@
                                 </p>
                             </div>
                             <section class="metric debt-burden column-well
-                              column-well__bleed column-well__not-stacked">
+                              column-well__bleed column-well__not-stacked"
+                              data-repayment-section="debt-burden">
                                   <div class="column-well_content">
                                       <h4 class="metric_heading">
                                           Your estimated debt burden
@@ -2123,9 +2125,9 @@
                                           </div>
                                           <div
                                           class="debt-burden_projection-value">
-                                              <span data-debt-burden="annual-salary"></span>
+                                              <span data-debt-burden="annualSalary"></span>
                                               / yr.<br>
-                                              <span data-debt-burden="monthly-salary"></span>
+                                              <span data-debt-burden="monthlySalary"></span>
                                               / mo.
                                           </div>
                                       </div>
@@ -2136,7 +2138,7 @@
                                           </div>
                                           <div
                                           class="debt-burden_projection-value">
-                                              <span data-debt-burden="monthly-payment"></span>
+                                              <span data-debt-burden="loanMonthly"></span>
                                               / mo.
                                           </div>
                                       </div>
@@ -2144,7 +2146,7 @@
                                           <div class="debt-equation_part
                                           debt-equation_part__loan">
                                               <div class="debt-equation_number">
-                                                  <span data-debt-burden="monthly-payment"></span>
+                                                  <span data-debt-burden="loanMonthly"></span>
                                               </div>
                                               <div class="debt-equation_label">
                                                   loan payment
@@ -2156,7 +2158,7 @@
                                           <div class="debt-equation_part
                                           debt-equation_part__income">
                                               <div class="debt-equation_number">
-                                                  <span data-debt-burden="monthly-salary"></span>
+                                                  <span data-debt-burden="monthlySalary"></span>
                                               </div>
                                               <div class="debt-equation_label">
                                                   monthly salary
@@ -2168,7 +2170,7 @@
                                           <div class="debt-equation_part
                                           debt-equation_part__percent">
                                               <div class="debt-equation_number">
-                                                  <span data-debt-burden="debt-burden"></span>
+                                                  <span data-debt-burden="debtBurden"></span>
                                               </div>
                                               <div class="debt-equation_label">
                                                   of your income
@@ -2198,10 +2200,10 @@
                                       </div>
                                       <div id="estimated-debt-burden_term"  data-repayment-section="estimated-debt-burden">
                                         <label for="estimated-debt-burden_term_10">
-                                          <input id="estimated-debt-burden_term_10" type="radio" name="estimated-debt-burden_term"  value="10" checked> 10 years
+                                          <input id="estimated-debt-burden_term_10" type="radio" name="estimated-debt-burden_term"  value="ten" checked> 10 years
                                         </label>
                                         <label>
-                                          <input id="estimated-debt-burden_term_25" type="radio" name="estimated-debt-burden_term" value="25">
+                                          <input id="estimated-debt-burden_term_25" type="radio" name="estimated-debt-burden_term" value="twentyFive">
                                           25 years
                                         </label>
                                       </div>

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -1972,6 +1972,112 @@
                             </section>
                         </div>
                     </section>
+                    <section class="criteria column-well_wrapper">
+                        <h3 class="criteria_heading">
+                            How much will I pay per month for all of my student loans?
+                        </h3>
+                        <div class="criteria_wrapper">
+                            <div class="criteria_intro">
+                                <p>
+                                  Currently, your projected monthly student
+                                  loan payment is
+                                  <span id="criteria_loan-monthly"
+                                  data-financial="loanMonthly">
+                                  [XXXX]</span>, based on standard
+                                  loan terms of 10 years. Once you leave
+                                  school, you have several different repayment
+                                  options for your federal loans that may help
+                                  reduce your monthly student loan payment.
+                                  You may also be eligible for a federal tax
+                                  credit or deduction.
+                                </p>
+                                <p>
+                                  Many of these alternative repayment plans
+                                  are based on income and family size, which
+                                  means the lower your salary, the lower your
+                                  student loan payment. For instance, if you
+                                  have a family of four with an annual income
+                                  of $50,000, your monthly student loan
+                                  payment would be $114. It could be as low as
+                                  $0, depending on your income and family
+                                  size. If you select one of these income-
+                                  based repayment plans you may be paying off
+                                  your loans for upwards of 20 to 25 years.
+                                </p>
+                                <p>
+                                  Another payment option extends your
+                                  repayment over 25 years, which means you
+                                  would have a lower monthly student loan
+                                  payment but a higher total cost of interest
+                                  over the life of the loan.
+                                </p>
+                                <p>
+                                  These repayment plans typically aren’t
+                                  available for private student loans. If
+                                  you’re still not able to make payments on
+                                  your loans, you could go into default.
+                                </p>
+                            </div>
+                            <section class="metric salary-and-debt
+                            column-well column-well__bleed
+                            column-well__not-stacked">
+                                <div class="column-well_content">
+                                    <h4 class="metric_heading">
+                                        Calculate your monthly payment
+                                    </h4>
+                                    <p>
+                                        Once you leave school, you can choose
+                                        one of several available repayment
+                                        options.
+                                    </p>
+                                    <div class="salary-and-debt_projection">
+                                        <div
+                                        class="salary-and-debt_projection-name">
+                                         Your projected loan payment
+                                        </div>
+                                        <div
+                                        class="salary-and-debt_projection-value">
+                                            <span
+                                            data-repayment="loanMonthly">
+                                            </span>
+                                        </div>
+                                    </div>
+                                    <div class="salary-and-debt_projection">
+                                        <div
+                                        class="salary-and-debt_projection-name">
+                                          Total cost of repayment with interest
+                                          and fees
+                                        </div>
+                                        <div
+                                        class="salary-and-debt_projection-value">
+                                            <span
+                                            data-repayment="loanLifetime">
+                                            </span>
+                                      </div>
+                                    </div>
+                                    <div>
+                                      <p>
+                                        See how loan length affects your payments
+                                      </p>
+                                      <div id="monthly-payment_term" data-repayment-section="monthly-payment">
+                                        <label for="monthly-payment_term_10">
+                                          <input id="monthly-payment_term_10" type="radio" name="monthly-payment_term"  value="10" checked> 10 years
+                                        </label>
+                                        <label>
+                                          <input id="monthly-payment_term_25" type="radio" name="monthly-payment_term" value="25">
+                                          25 years
+                                        </label>
+                                      </div>
+                                      <p>
+                                        <a href="?">
+                                          Learn about other repayment options
+                                        </a>
+                                      </p>
+                                    </div>
+                                </div>
+                            </section>
+                        </div>
+                    </section>
                     <section class="criteria
                     column-well_wrapper__overflow-small">
                         <h3 class="criteria_heading">
@@ -2089,6 +2195,15 @@
                                               Loan payment is higher than
                                               recommended 8% of salary
                                           </p>
+                                      </div>
+                                      <div id="estimated-debt-burden_term"  data-repayment-section="estimated-debt-burden">
+                                        <label for="estimated-debt-burden_term_10">
+                                          <input id="estimated-debt-burden_term_10" type="radio" name="estimated-debt-burden_term"  value="10" checked> 10 years
+                                        </label>
+                                        <label>
+                                          <input id="estimated-debt-burden_term_25" type="radio" name="estimated-debt-burden_term" value="25">
+                                          25 years
+                                        </label>
                                       </div>
                                   </div>
                               </section>

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -1801,7 +1801,7 @@
                                             </div>
                                             <div class="bar-graph_line"></div>
                                             <div class="bar-graph_value">
-                                                <div class="bar-graph_number"></div>
+                                                <div data-bar-graph_number="you" class="bar-graph_number"></div>
                                             </div>
                                         </div>
                                         <div class="bar-graph_point
@@ -1811,7 +1811,7 @@
                                             </div>
                                             <div class="bar-graph_line"></div>
                                             <div class="bar-graph_value">
-                                                <div class="bar-graph_number"></div>
+                                                <div data-bar-graph_number="average" class="bar-graph_number"></div>
                                             </div>
                                         </div>
                                     </div>
@@ -2501,7 +2501,7 @@
                                             </div>
                                             <div class="bar-graph_line"></div>
                                             <div class="bar-graph_value">
-                                                <div class="bar-graph_number"></div>
+                                                <div data-bar-graph_number="you" class="bar-graph_number"></div>
                                             </div>
                                         </div>
                                         <div class="bar-graph_point
@@ -2511,7 +2511,7 @@
                                             </div>
                                             <div class="bar-graph_line"></div>
                                             <div class="bar-graph_value">
-                                                <div class="bar-graph_number"></div>
+                                                <div data-bar-graph_number="average" class="bar-graph_number"></div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/disclosures/js/models/school-model.js
+++ b/src/disclosures/js/models/school-model.js
@@ -18,7 +18,8 @@ var schoolModel = {
   processAPIData: function( values ) {
     values.jobRate = values.jobRate || '';
     values.programLength /= 12;
-    values.medianSalary = values.salary || values.medianAnnualPay;
+    values.medianSalary = values.salary || values.medianAnnualPay
+      || values.earningsMedian;
     values.monthlySalary = Math.round( Number( values.medianSalary ) / 12 );
     values.medianSchoolDebt = values.medianStudentLoanCompleters ||
       values.medianTotalDebt;

--- a/src/disclosures/js/models/school-model.js
+++ b/src/disclosures/js/models/school-model.js
@@ -18,8 +18,8 @@ var schoolModel = {
   processAPIData: function( values ) {
     values.jobRate = values.jobRate || '';
     values.programLength /= 12;
-    values.medianSalary = values.salary || values.medianAnnualPay
-      || values.earningsMedian;
+    values.medianSalary = values.salary || values.medianAnnualPay ||
+      values.earningsMedian;
     values.monthlySalary = Math.round( Number( values.medianSalary ) / 12 );
     values.medianSchoolDebt = values.medianStudentLoanCompleters ||
       values.medianTotalDebt;

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -154,7 +154,8 @@ var financialView = {
     this.updateLeftovers( values, $leftovers );
     this.updatePrivateLoans( values, $privateLoans );
     this.updateRemainingCostContent();
-    metricView.updateDebtBurdenDisplay( values );
+    metricView.updateDebtBurden( values );
+    metricView.updateMonthlyPayment();
   },
 
   /**

--- a/src/disclosures/js/views/metric-view.js
+++ b/src/disclosures/js/views/metric-view.js
@@ -161,8 +161,6 @@ var metricView = {
   /**
    * Sets text of each point on a bar graph (or a class if a point is missing)
    * @param {object} $graph jQuery object of the graph containing the points
-   * @param {string} schoolText Text of the graph's school point
-   * @param {string} nationalText Text of the graph's school point
    */
   setGraphValues: function( $graph ) {
     var $school = $graph.find( '[data-bar-graph_number="you"]' ),
@@ -184,10 +182,6 @@ var metricView = {
   /**
    * Sets the position of each point on a bar graph
    * @param {object} $graph jQuery object of the graph containing the points
-   * @param {number|NaN} schoolValue Value reported by the school
-   * @param {number|NaN} nationalValue Average national value
-   * @param {object} $school jQuery object of the graph's school point
-   * @param {object} $national jQuery object of the graph's national point
    */
   setGraphPositions: function( $graph ) {
     // schoolValue, nationalValue, $school, $national

--- a/src/disclosures/js/views/metric-view.js
+++ b/src/disclosures/js/views/metric-view.js
@@ -20,22 +20,21 @@ var metricView = {
 
   /**
    * Calculates the CSS bottom positions of each point on a bar graph
-   * @param {number} minValue Bottom point of a graph
-   * @param {number} maxValue Top point of a graph
-   * @param {number} graphHeight Height of the graph
+   * @param {number} min Bottom point of a graph
+   * @param {number} max Top point of a graph
+   * @param {number} height Height of the graph
    * @param {number|NaN} schoolValue Value reported by the school
    * @param {number|NaN} nationalValue Average national value
    * @returns {object} Object with CSS bottom positions for each point
    */
-  calculateBottoms:
-  function( minValue, maxValue, graphHeight, schoolValue, nationalValue ) {
+  calculateBottoms: function( min, max, height, schoolValue, nationalValue ) {
     var bottoms = {},
         // Lines fall off the bottom of the graph if they sit right at the base
         bottomOffset = 20;
-    bottoms.school = ( graphHeight - bottomOffset ) / ( maxValue - minValue ) *
-      ( schoolValue - minValue ) + bottomOffset;
-    bottoms.national = ( graphHeight - bottomOffset ) /
-      ( maxValue - minValue ) * ( nationalValue - minValue ) + bottomOffset;
+    bottoms.school = ( height - bottomOffset ) / ( max - min ) *
+      ( schoolValue - min ) + bottomOffset;
+    bottoms.national = ( height - bottomOffset ) /
+      ( max - min ) * ( nationalValue - min ) + bottomOffset;
     return bottoms;
   },
 
@@ -63,29 +62,28 @@ var metricView = {
   /**
    * Fixes overlapping points on a bar graph
    * @param {object} $graph jQuery object of the graph containing the points
-   * @param {string} schoolAverageFormatted Text of the graph's school point
-   * @param {string} nationalAverageFormatted Text of the graph's school point
-   * @param {object} $schoolPoint jQuery object of the graph's school point
-   * @param {object} $nationalPoint jQuery object of the graph's national point
+   * @param {string} schoolText Text of the graph's school point
+   * @param {string} nationalText Text of the graph's school point
+   * @param {object} $school jQuery object of the graph's school point
+   * @param {object} $national jQuery object of the graph's national point
    */
-  fixOverlap: function( $graph, schoolAverageFormatted,
-    nationalAverageFormatted, $schoolPoint, $nationalPoint ) {
-    var schoolPointHeight = $schoolPoint.find( '.bar-graph_label' ).height(),
-        schoolPointTop = $schoolPoint.position().top,
+  fixOverlap: function( $graph, schoolText, nationalText, $school, $national ) {
+    var schoolPointHeight = $school.find( '.bar-graph_label' ).height(),
+        schoolPointTop = $school.position().top,
         nationalPointHeight = $nationalPoint.find(
           '.bar-graph_label' ).height(),
         nationalPointTop = $nationalPoint.position().top,
         $higherPoint = schoolPointTop > nationalPointTop ?
-        $nationalPoint : $schoolPoint,
+        $national : $school,
         $higherPointLabels = $higherPoint.find(
           '.bar-graph_label, .bar-graph_value' ),
         $lowerPoint = schoolPointTop > nationalPointTop ?
-        $schoolPoint : $nationalPoint,
+        $school : $nationalPoint,
         // nationalPointHeight is the smaller and gives just the right offset
         offset = nationalPointHeight -
         Math.abs( schoolPointTop - nationalPointTop );
     // If the values are equal, handle the display with CSS only
-    if ( schoolAverageFormatted === nationalAverageFormatted ) {
+    if ( schoolText === nationalText ) {
       $graph.addClass( 'bar-graph__equal' );
       return;
     }
@@ -107,22 +105,21 @@ var metricView = {
   /**
    * Sets text of each point on a bar graph (or a class if a point is missing)
    * @param {object} $graph jQuery object of the graph containing the points
-   * @param {string} schoolAverageFormatted Text of the graph's school point
-   * @param {string} nationalAverageFormatted Text of the graph's school point
+   * @param {string} schoolText Text of the graph's school point
+   * @param {string} nationalText Text of the graph's school point
    */
-  setGraphValues: function( $graph, schoolAverageFormatted,
-    nationalAverageFormatted ) {
+  setGraphValues: function( $graph, schoolText, nationalText ) {
     var $schoolPointNumber =
     $graph.find( '.bar-graph_point__you .bar-graph_number' ),
         $nationalPointNumber =
         $graph.find( '.bar-graph_point__average .bar-graph_number' );
-    if ( schoolAverageFormatted ) {
-      $schoolPointNumber.text( schoolAverageFormatted );
+    if ( schoolText ) {
+      $schoolPointNumber.text( schoolText );
     } else {
       $graph.addClass( 'bar-graph__missing-you' );
     }
-    if ( nationalAverageFormatted ) {
-      $nationalPointNumber.text( nationalAverageFormatted );
+    if ( nationalText ) {
+      $nationalPointNumber.text( nationalText );
     } else {
       $graph.addClass( 'bar-graph__missing-average' );
     }
@@ -131,26 +128,25 @@ var metricView = {
   /**
    * Sets the position of each point on a bar graph
    * @param {object} $graph jQuery object of the graph containing the points
-   * @param {number|NaN} schoolAverage Value reported by the school
-   * @param {number|NaN} nationalAverage Average national value
-   * @param {object} $schoolPoint jQuery object of the graph's school point
-   * @param {object} $nationalPoint jQuery object of the graph's national point
+   * @param {number|NaN} schoolValue Value reported by the school
+   * @param {number|NaN} nationalValue Average national value
+   * @param {object} $school jQuery object of the graph's school point
+   * @param {object} $national jQuery object of the graph's national point
    */
-  setGraphPositions: function( $graph, schoolAverage, nationalAverage,
-    $schoolPoint, $nationalPoint ) {
+  setGraphPositions: function( $graph, schoolValue, nationalValue, $school, $national ) {
     var graphHeight = $graph.height(),
         minValue = $graph.attr( 'data-graph-min' ),
         maxValue = $graph.attr( 'data-graph-max' ),
         bottoms = this.calculateBottoms( minValue, maxValue, graphHeight,
-          schoolAverage, nationalAverage );
+          schoolValue, nationalValue );
     // A few outlier schools have very high average salaries, so we need to
     // prevent those values from falling off the top of the graph
-    if ( schoolAverage > maxValue ) {
+    if ( schoolValue > maxValue ) {
       bottoms.school = graphHeight;
       $graph.addClass( 'bar-graph__high-point' );
     }
-    $schoolPoint.css( 'bottom', bottoms.school );
-    $nationalPoint.css( 'bottom', bottoms.national );
+    $school.css( 'bottom', bottoms.school );
+    $national.css( 'bottom', bottoms.national );
   },
 
   /**

--- a/src/disclosures/js/views/metric-view.js
+++ b/src/disclosures/js/views/metric-view.js
@@ -35,7 +35,6 @@ var metricView = {
    * Initiates the object
    */
   init: function() {
-    var values = getFinancial.values();
     this.settlementStatus =
       Boolean( getSchool.values().settlementSchool ) || false;
     this.setMetrics();
@@ -86,13 +85,12 @@ var metricView = {
     var $school = $graph.find( '[data-bar-graph_number="you"]' ),
         $national = $graph.find( '[data-bar-graph_number="average"]' ),
         metricKey = $graph.attr( 'data-metric' ),
-        metrics = metricView.metrics[ metricKey ],
+        metrics = metricView.metrics[metricKey],
         schoolHeight = $school.find( '.bar-graph_label' ).height(),
         schoolTop = $school.position().top,
         nationalHeight = $national.find( '.bar-graph_label' ).height(),
         nationalTop = $national.position().top,
         $higherPoint = $national,
-        hpselecter = '.bar-graph_label, .bar-graph_value',
         $higherLabels,
         $lowerPoint = $school,
         // nationalPointHeight is the smaller and gives just the right offset
@@ -103,7 +101,7 @@ var metricView = {
       $higherPoint = $school;
       $lowerPoint = $national;
     }
-    $higherLabels = $higherPoint.find(  '.bar-graph_label, .bar-graph_value' );
+    $higherLabels = $higherPoint.find( '.bar-graph_label, .bar-graph_value' );
 
     // If the values are equal, handle the display with CSS only
     if ( metrics.school === metrics.national ) {
@@ -135,7 +133,7 @@ var metricView = {
     var $school = $graph.find( '[data-bar-graph_number="you"]' ),
         $national = $graph.find( '[data-bar-graph_number="average"]' ),
         metricKey = $graph.attr( 'data-metric' ),
-        metrics = metricView.metrics[ metricKey ];
+        metrics = metricView.metrics[metricKey];
     if ( isNaN( metrics.school ) ) {
       $graph.addClass( 'bar-graph__missing-you' );
     } else {
@@ -157,7 +155,7 @@ var metricView = {
    * @param {object} $national jQuery object of the graph's national point
    */
   setGraphPositions: function( $graph ) {
-    //, schoolValue, nationalValue, $school, $national
+    // schoolValue, nationalValue, $school, $national
     var graphHeight = $graph.height(),
         metricKey = $graph.attr( 'data-metric' ),
         nationalValue = metricView.metrics[metricKey].national,
@@ -186,13 +184,11 @@ var metricView = {
 
   /**
    * Classifies school value in relation to the national average
-   * @param {number|NaN} schoolValue - Value reported by the school
-   * @param {string} metric - Metric for notifications
+   * @param {number|NaN} metricKey - metric to be checked
    * @returns {string} Classes to add to the notification box
    */
   getNotifications: function( metricKey ) {
-    var values = getFinancial.values(),
-        classes = 'cf-notification ',
+    var classes = 'cf-notification ',
         metrics = metricView.metrics[metricKey],
         schoolValue = metrics.school,
         nationalValue = metrics.national,
@@ -202,7 +198,6 @@ var metricView = {
         aboveMax = schoolValue > metrics.max,
         lowerIsBetter = metrics.better === 'lower',
         higherIsBetter = metrics.better === 'higher';
-    console.log( schoolValue, nationalValue )
     if ( isNaN( schoolValue ) && isNaN( nationalValue ) ) {
       classes += 'metric_notification__no-data cf-notification__warning';
     } else if ( isNaN( schoolValue ) ) {
@@ -248,13 +243,11 @@ var metricView = {
    * @param {boolean} settlementStatus Flag if this is a settlement school
    */
   updateGraphs: function() {
-    var $graphs = $( '.bar-graph' ),
-        financials = getFinancial.values();
+    var $graphs = $( '.bar-graph' );
     $graphs.each( function() {
       var $graph = $( this ),
           metricKey = $graph.attr( 'data-metric' ),
           notificationClasses = metricView.getNotifications( metricKey ),
-          metrics = metricView.metrics[metricKey],
           $notification = $graph.siblings( '.metric_notification' );
 
       metricView.setGraphValues( $graph );

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -472,12 +472,12 @@ settlementAidOfferPage.prototype = Object.create({}, {
     },
     debtBurdenPayment: {
       get: function() {
-        return element( by.css( '.debt-equation [data-debt-burden="monthly-payment"]' ) );
+        return element( by.css( '.debt-equation [data-debt-burden="loanMonthly"]' ) );
       }
     },
     debtBurdenSalary: {
       get: function() {
-        return element( by.css( '.debt-equation [data-debt-burden="monthly-salary"]' ) );
+        return element( by.css( '.debt-equation [data-debt-burden="monthlySalary"]' ) );
       }
     },
     debtBurdenNotification: {

--- a/test/js-unit/metric-view-spec.js
+++ b/test/js-unit/metric-view-spec.js
@@ -1,39 +1,76 @@
 var chai = require( 'chai' );
 var expect = chai.expect;
-var metricView = require( '../../src/disclosures/js/views/metric-view' );
+var view = require( '../../src/disclosures/js/views/metric-view' );
 
 describe( 'metric-view', function() {
 
   beforeEach( function() {
-    metricView.metrics.test = {
-      school: 'None',
+    view.metrics.defaultRate = {
+      school: 0.45,
       national: 0.5,
-      min: 0.4,
-      max: 0.6,
+      low: 0.4,
+      high: 0.6,
       better: 'higher'
     }
   } );
 
+  it( 'sets standing=same if school is about the same', function() {
+    view.metrics.defaultRate =
+      view.checkMetrics( view.metrics.defaultRate );
+    expect( view.metrics.defaultRate.standing ).to.equal( 'same' );
+  });
+
+  it( 'sets standing=better if school is higher and higher is better', function() {
+    view.metrics.defaultRate.school = 0.75;
+    view.metrics.defaultRate =
+      view.checkMetrics( view.metrics.defaultRate );
+    expect( view.metrics.defaultRate.standing ).to.equal( 'better' );
+  });
+
+  it( 'sets standing=worse if school is lower and higher is better', function() {
+    view.metrics.defaultRate.school = 0.15;
+    view.metrics.defaultRate =
+      view.checkMetrics( view.metrics.defaultRate );
+    expect( view.metrics.defaultRate.standing ).to.equal( 'worse' );
+  });
+
+  it( 'sets standing=better if school is lower and lower is better', function() {
+    view.metrics.defaultRate.school = 0.15;
+    view.metrics.defaultRate.better = 'lower';
+    view.metrics.defaultRate =
+      view.checkMetrics( view.metrics.defaultRate );
+    expect( view.metrics.defaultRate.standing ).to.equal( 'better' );
+  });
+
+  it( 'sets standing=worse if school is higher and lower is better', function() {
+    view.metrics.defaultRate.school = 0.75;
+    view.metrics.defaultRate.better = 'lower';
+    view.metrics.defaultRate =
+      view.checkMetrics( view.metrics.defaultRate );
+    expect( view.metrics.defaultRate.standing ).to.equal( 'worse' );
+  });
+
   it( 'gives the proper notification classes when no data is available', function() {
-    metricView.metrics.test.school = 'None';
-    metricView.metrics.test.national = undefined;
-    var notificationClasses = metricView.getNotifications( 'test' );
+    view.metrics.defaultRate.school = 'None';
+    view.metrics.defaultRate.national = undefined;
+    var notificationClasses = view.getNotifications( 'defaultRate' );
     expect( notificationClasses ).to.equal(
       'cf-notification metric_notification__no-data cf-notification__warning'
       );
   });
 
   it( 'gives the proper notification classes when school data is missing', function() {
-    var notificationClasses = metricView.getNotifications( 'test' );
+    view.metrics.defaultRate.school = 'None';
+    var notificationClasses = view.getNotifications( 'defaultRate' );
     expect( notificationClasses ).to.equal(
       'cf-notification metric_notification__no-you cf-notification__warning'
     );
   });
 
   it( 'gives the proper notification classes when national data is missing', function() {
-    metricView.metrics.test.national = undefined;
-    metricView.metrics.test.school = 0.5;
-    var notificationClasses = metricView.getNotifications( 'test' );
+    view.metrics.defaultRate.national = undefined;
+    view.metrics.defaultRate.school = 0.5;
+    var notificationClasses = view.getNotifications( 'defaultRate' );
     expect( notificationClasses ).to.equal(
       'cf-notification metric_notification__no-average cf-notification__warning'
     );
@@ -41,31 +78,39 @@ describe( 'metric-view', function() {
 
   it( 'gives the proper notification classes when the school value ' +
        'is near the national value', function() {
-    metricView.metrics.test.school = 0.55;
-    var notificationClasses = metricView.getNotifications( 'test' );
+    view.metrics.defaultRate.school = 0.55;
+    view.metrics.defaultRate =
+      view.checkMetrics( view.metrics.defaultRate );
+    var notificationClasses = view.getNotifications( 'defaultRate' );
     expect( notificationClasses ).to.equal( 'metric_notification__same' );
   });
 
   it( 'gives the proper notification classes when the school value ' +
        'is higher than the national value (and that\'s a good thing)', function() {
-    metricView.metrics.test.school = 0.7;
-    var notificationClasses = metricView.getNotifications( 'test' );
+    view.metrics.defaultRate.school = 0.7;
+    view.metrics.defaultRate =
+      view.checkMetrics( view.metrics.defaultRate );
+    var notificationClasses = view.getNotifications( 'defaultRate' );
     expect( notificationClasses ).to.equal( 'metric_notification__better' );
   });
 
   it( 'gives the proper notification classes when the school value ' +
        'is lower than the national value (and that\'s a good thing)', function() {
-    metricView.metrics.test.school = 0.2;
-    metricView.metrics.test.better = 'lower';
-    var notificationClasses = metricView.getNotifications( 'test' );
+    view.metrics.defaultRate.school = 0.2;
+    view.metrics.defaultRate.better = 'lower';
+    view.metrics.defaultRate =
+      view.checkMetrics( view.metrics.defaultRate );
+    var notificationClasses = view.getNotifications( 'defaultRate' );
     expect( notificationClasses ).to.equal( 'metric_notification__better' );
   });
 
   it( 'gives the proper notification classes when the school value is ' +
        'higher than the national value (and that\'s a bad thing)', function() {
-    metricView.metrics.test.school = 0.7;
-    metricView.metrics.test.better = 'lower';
-    var notificationClasses = metricView.getNotifications( 'test' );
+    view.metrics.defaultRate.school = 0.7;
+    view.metrics.defaultRate.better = 'lower';
+    view.metrics.defaultRate =
+      view.checkMetrics( view.metrics.defaultRate );
+    var notificationClasses = view.getNotifications( 'defaultRate' );
     expect( notificationClasses ).to.equal(
       'cf-notification metric_notification__worse cf-notification__error'
       );
@@ -73,34 +118,38 @@ describe( 'metric-view', function() {
 
   it( 'gives the proper notification classes when the school value is ' +
        'lower than the national value (and that\'s a bad thing)', function() {
-    metricView.metrics.test.national = 0.5;
-    metricView.metrics.test.school = 0.3;
-    var notificationClasses = metricView.getNotifications( 'test' );
+    view.metrics.defaultRate.national = 0.5;
+    view.metrics.defaultRate.school = 0.3;
+    view.metrics.defaultRate =
+      view.checkMetrics( view.metrics.defaultRate );
+    var notificationClasses = view.getNotifications( 'defaultRate' );
     expect( notificationClasses ).to.equal(
       'cf-notification metric_notification__worse cf-notification__error'
     );
   });
 
-  it( 'gives the proper notification classes when min and max ' +
+  it( 'gives the proper notification classes when low and high ' +
        'values are not numbers', function() {
-    metricView.metrics.test.national = 0.5;
-    metricView.metrics.test.school = 0.5;
-    metricView.metrics.test.min = undefined;
-    metricView.metrics.test.max = 'I like turtles';
-    var notificationClasses = metricView.getNotifications( 'test' );
+    view.metrics.defaultRate.national = 0.5;
+    view.metrics.defaultRate.school = 0.5;
+    view.metrics.defaultRate.low = undefined;
+    view.metrics.defaultRate.high = 'I like turtles';
+    view.metrics.defaultRate =
+      view.checkMetrics( view.metrics.defaultRate );
+    var notificationClasses = view.getNotifications( 'defaultRate' );
     expect( notificationClasses ).to.equal( '' );
   });
 
   it( 'calculates monthly salary', function() {
     var annualSalary = 34300,
-        monthlySalary = metricView.calculateMonthlySalary( annualSalary );
+        monthlySalary = view.calculateMonthlySalary( annualSalary );
     expect( monthlySalary.toFixed( 4 ) ).to.equal( '2858.3333' );
   });
 
   it( 'calculates debt burden', function() {
     var monthlyLoanPayment = 240,
         monthlySalary = 2858,
-        debtBurden = metricView.calculateDebtBurden( monthlyLoanPayment, monthlySalary );
+        debtBurden = view.calculateDebtBurden( monthlyLoanPayment, monthlySalary );
     expect( debtBurden.toFixed( 4 ) ).to.equal( '0.0840' );
   });
 

--- a/test/js-unit/metric-view-spec.js
+++ b/test/js-unit/metric-view-spec.js
@@ -4,151 +4,90 @@ var metricView = require( '../../src/disclosures/js/views/metric-view' );
 
 describe( 'metric-view', function() {
 
-  it( 'calculates graph point bottom positions for percent data', function() {
-    var minValue = 0,
-        maxValue = 1,
-        graphHeight = 130,
-        schoolValue = 0.55,
-        nationalValue = 0.137,
-        bottoms = metricView.calculateBottoms( minValue, maxValue, graphHeight, schoolValue, nationalValue );
-    expect( bottoms.school ).to.equal( 80.5 );
-    expect( bottoms.national ).to.equal( 35.07 );
-  });
-
-  it( 'calculates graph point bottom positions for salary data', function() {
-    var minValue = 0,
-        maxValue = 100000,
-        graphHeight = 130,
-        schoolValue = 23000,
-        nationalValue = 31080,
-        bottoms = metricView.calculateBottoms( minValue, maxValue, graphHeight, schoolValue, nationalValue );
-    expect( bottoms.school ).to.equal( 45.3 );
-    expect( bottoms.national ).to.equal( 54.188 );
-  });
-
-  it( 'formats percents', function() {
-    var valueType = 'decimal-percent',
-        rawValue = 0.137,
-        formattedValue = metricView.formatValue( valueType, rawValue );
-    expect( formattedValue ).to.equal( '14%' );
-  });
-
-  it( 'formats currencies', function() {
-    var valueType = 'currency',
-        rawValue = 31080,
-        formattedValue = metricView.formatValue( valueType, rawValue );
-    expect( formattedValue ).to.equal( '$31,080' );
-  });
-
-  it( 'does not try to format values that cannot be parsed into numbers', function() {
-    var valueType = 'decimal-percent',
-        rawValues = {
-          'string': 'None',
-          'empty': '',
-          'space': ' ',
-          'null': null,
-          'undefined': undefined
-        },
-        formattedValues = {};
-    for ( var valueType in rawValues ) {
-      var rawValue = rawValues[valueType],
-          parsedValue = parseFloat( rawValue );
-      formattedValues[valueType] = metricView.formatValue( valueType, parsedValue )
+  beforeEach( function() {
+    metricView.metrics.test = {
+      school: 'None',
+      national: 0.5,
+      min: 0.4,
+      max: 0.6,
+      better: 'higher'
     }
-    expect( formattedValues['string'] ).to.equal( false );
-    expect( formattedValues['empty'] ).to.equal( false );
-    expect( formattedValues['space'] ).to.equal( false );
-    expect( formattedValues['null'] ).to.equal( false );
-    expect( formattedValues['undefined'] ).to.equal( false );
-  });
+  } );
 
   it( 'gives the proper notification classes when no data is available', function() {
-    var schoolValue = parseFloat( 'None' ),
-        nationalValue = parseFloat( undefined ),
-        sameMin = 0.4,
-        sameMax = 0.6,
-        betterDirection = 'higher',
-        notificationClasses = metricView.getNotificationClasses( schoolValue, nationalValue, sameMin, sameMax, betterDirection );
-    expect( notificationClasses ).to.equal( 'metric_notification__no-data cf-notification cf-notification__warning' );
+    metricView.metrics.test.school = 'None';
+    metricView.metrics.test.national = undefined;
+    var notificationClasses = metricView.getNotifications( 'test' );
+    expect( notificationClasses ).to.equal(
+      'cf-notification metric_notification__no-data cf-notification__warning'
+      );
   });
 
   it( 'gives the proper notification classes when school data is missing', function() {
-    var schoolValue = parseFloat( 'None' ),
-        nationalValue = parseFloat( 0.5 ),
-        sameMin = 0.4,
-        sameMax = 0.6,
-        betterDirection = 'higher',
-        notificationClasses = metricView.getNotificationClasses( schoolValue, nationalValue, sameMin, sameMax, betterDirection );
-    expect( notificationClasses ).to.equal( 'metric_notification__no-you cf-notification cf-notification__warning' );
+    var notificationClasses = metricView.getNotifications( 'test' );
+    expect( notificationClasses ).to.equal(
+      'cf-notification metric_notification__no-you cf-notification__warning'
+    );
   });
 
   it( 'gives the proper notification classes when national data is missing', function() {
-    var schoolValue = parseFloat( 0.5 ),
-        nationalValue = parseFloat( undefined ),
-        sameMin = 0.4,
-        sameMax = 0.6,
-        betterDirection = 'higher',
-        notificationClasses = metricView.getNotificationClasses( schoolValue, nationalValue, sameMin, sameMax, betterDirection );
-    expect( notificationClasses ).to.equal( 'metric_notification__no-average cf-notification cf-notification__warning' );
+    metricView.metrics.test.national = undefined;
+    metricView.metrics.test.school = 0.5;
+    var notificationClasses = metricView.getNotifications( 'test' );
+    expect( notificationClasses ).to.equal(
+      'cf-notification metric_notification__no-average cf-notification__warning'
+    );
   });
 
-  it( 'gives the proper notification classes when the school value is near the national value', function() {
-    var schoolValue = parseFloat( 0.55 ),
-        nationalValue = parseFloat( 0.5 ),
-        sameMin = 0.4,
-        sameMax = 0.6,
-        betterDirection = 'higher',
-        notificationClasses = metricView.getNotificationClasses( schoolValue, nationalValue, sameMin, sameMax, betterDirection );
+  it( 'gives the proper notification classes when the school value ' +
+       'is near the national value', function() {
+    metricView.metrics.test.school = 0.55;
+    var notificationClasses = metricView.getNotifications( 'test' );
     expect( notificationClasses ).to.equal( 'metric_notification__same' );
   });
 
-  it( 'gives the proper notification classes when the school value is higher than the national value (and that\'s a good thing)', function() {
-    var schoolValue = parseFloat( 0.7 ),
-        nationalValue = parseFloat( 0.5 ),
-        sameMin = 0.4,
-        sameMax = 0.6,
-        betterDirection = 'higher',
-        notificationClasses = metricView.getNotificationClasses( schoolValue, nationalValue, sameMin, sameMax, betterDirection );
+  it( 'gives the proper notification classes when the school value ' +
+       'is higher than the national value (and that\'s a good thing)', function() {
+    metricView.metrics.test.school = 0.7;
+    var notificationClasses = metricView.getNotifications( 'test' );
     expect( notificationClasses ).to.equal( 'metric_notification__better' );
   });
 
-  it( 'gives the proper notification classes when the school value is lower than the national value (and that\'s a good thing)', function() {
-    var schoolValue = parseFloat( 0.3 ),
-        nationalValue = parseFloat( 0.5 ),
-        sameMin = 0.4,
-        sameMax = 0.6,
-        betterDirection = 'lower',
-        notificationClasses = metricView.getNotificationClasses( schoolValue, nationalValue, sameMin, sameMax, betterDirection );
+  it( 'gives the proper notification classes when the school value ' +
+       'is lower than the national value (and that\'s a good thing)', function() {
+    metricView.metrics.test.school = 0.2;
+    metricView.metrics.test.better = 'lower';
+    var notificationClasses = metricView.getNotifications( 'test' );
     expect( notificationClasses ).to.equal( 'metric_notification__better' );
   });
 
-  it( 'gives the proper notification classes when the school value is higher than the national value (and that\'s a bad thing)', function() {
-    var schoolValue = parseFloat( 0.7 ),
-        nationalValue = parseFloat( 0.5 ),
-        sameMin = 0.4,
-        sameMax = 0.6,
-        betterDirection = 'lower',
-        notificationClasses = metricView.getNotificationClasses( schoolValue, nationalValue, sameMin, sameMax, betterDirection );
-    expect( notificationClasses ).to.equal( 'metric_notification__worse cf-notification cf-notification__error' );
+  it( 'gives the proper notification classes when the school value is ' +
+       'higher than the national value (and that\'s a bad thing)', function() {
+    metricView.metrics.test.school = 0.7;
+    metricView.metrics.test.better = 'lower';
+    var notificationClasses = metricView.getNotifications( 'test' );
+    expect( notificationClasses ).to.equal(
+      'cf-notification metric_notification__worse cf-notification__error'
+      );
   });
 
-  it( 'gives the proper notification classes when the school value is lower than the national value (and that\'s a bad thing)', function() {
-    var schoolValue = parseFloat( 0.3 ),
-        nationalValue = parseFloat( 0.5 ),
-        sameMin = 0.4,
-        sameMax = 0.6,
-        betterDirection = 'higher',
-        notificationClasses = metricView.getNotificationClasses( schoolValue, nationalValue, sameMin, sameMax, betterDirection );
-    expect( notificationClasses ).to.equal( 'metric_notification__worse cf-notification cf-notification__error' );
+  it( 'gives the proper notification classes when the school value is ' +
+       'lower than the national value (and that\'s a bad thing)', function() {
+    metricView.metrics.test.national = 0.5;
+    metricView.metrics.test.school = 0.3;
+    var notificationClasses = metricView.getNotifications( 'test' );
+    expect( notificationClasses ).to.equal(
+      'cf-notification metric_notification__worse cf-notification__error'
+    );
   });
 
-  it( 'gives the proper notification classes when sameMin and sameMax values are not numbers', function() {
-    var schoolValue = parseFloat( 0.3 ),
-        nationalValue = parseFloat( 0.5 ),
-        sameMin = parseFloat( '' ),
-        sameMax = parseFloat( '' ),
-        betterDirection = 'higher',
-        notificationClasses = metricView.getNotificationClasses( schoolValue, nationalValue, sameMin, sameMax, betterDirection );
+  it( 'gives the proper notification classes when min and max ' +
+       'values are not numbers', function() {
+    metricView.metrics.test.national = 0.5;
+    metricView.metrics.test.school = 0.5;
+    metricView.metrics.test.min = undefined;
+    metricView.metrics.test.max = 'I like turtles';
+    var notificationClasses = metricView.getNotifications( 'test' );
     expect( notificationClasses ).to.equal( '' );
   });
 


### PR DESCRIPTION
This PR adds the 10/25 year loan term toggle to the appropriate metrics sections. I also went down the rabbit hole a bit and refactored `metrics-view`. **Note**: The styles are _mostly_ correct, but there are slight differences between the final design and the current look of the app.
## Additions
- 'How much will I pay per month for all of my student loans?' section
- Radio buttons in two sidebars of Step 2
- Handlers which update various values based on a 10 or 25-year loan term
## Changes
- `metric-view` refactored
  - Added an object property, `metrics`, which stores important numbers for later use
  - Refactored methods to use fewer parameters
  - Removed and/or changed the way several methods work
## Testing
- The app passes both existing and new functional and unit tests. (See the README for how to test.)
## Review
- @marteki and @higs4281 
- @niqjohnson - If you have some time, I'd love for you to check this out. I rewrote a lot of `metrics-view`, and if you can check whether I missed something, that'd be great!
## Screenshots

<img width="689" alt="screen shot 2016-06-09 at 11 22 11 am" src="https://cloud.githubusercontent.com/assets/1490703/15935192/76f74dcc-2e34-11e6-80d4-dd3afdb90ff9.png">
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
## Animated gif

**"Really, Chuck. You think now is a good time to refactor?"**

![spock-eye-raise](https://cloud.githubusercontent.com/assets/1490703/15935252/b06e1432-2e34-11e6-8c83-6d70f30f7205.gif)
