### PR TITLE
Remove loanDefaultRate values from payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Added graduation rate and loan default rate external links
 - Changed the scale of the loan default rate graph to 40%
 - General code housekeeping (GitHub templates, linting improvements)
+- loanDefaultRate values (three of them) removed from national-stats API calls
 
 ## 2.1.1
 - Parent PLUS loans separated from other family contributions

--- a/paying_for_college/disclosures/scripts/nat_stats.py
+++ b/paying_for_college/disclosures/scripts/nat_stats.py
@@ -11,9 +11,9 @@ import requests
 import yaml
 from paying_for_college.models import ConstantRate
 
-COLLEGE_CHOICE_NATIONAL_DATA_URL = '\
+COLLEGE_CHOICE_NATIONAL_DATA_URL = """\
 https://raw.githubusercontent.com/18F/\
-college-choice/dev/_data/national_stats.yaml'
+college-choice/dev/_data/national_stats.yaml"""
 FIXTURES_DIR = Path(__file__).ancestor(3)
 NAT_DATA_FILE = '{0}/fixtures/national_stats.json'.format(FIXTURES_DIR)
 BACKUP_FILE = '{0}/fixtures/national_stats_backup.json'.format(FIXTURES_DIR)
@@ -73,20 +73,9 @@ def get_national_stats(update=False):
 def get_prepped_stats(program_length=None):
     """deliver only the national stats we need for worksheets"""
     full_data = get_national_stats()
-    try:
-        default_rate = float(ConstantRate.objects.get(slug='nationalLoanDefaultRate').value)
-        default_rate_low = float(ConstantRate.objects.get(slug='loanDefaultRateLow').value)
-        default_rate_high = float(ConstantRate.objects.get(slug='loanDefaultRateHigh').value)
-    except:
-        default_rate = 0
-        default_rate_low = 0
-        default_rate_high = 0
     natstats = {
         'completionRateMedian': full_data['completion_rate']['median'],
         'completionRateMedianLow': full_data['completion_rate']['average_range'][0],
-        'loanDefaultRate': default_rate,
-        'loanDefaultRateLow': default_rate_low,
-        'loanDefaultRateHigh': default_rate_high,
         'completionRateMedianHigh': full_data['completion_rate']['average_range'][1],
         'earningsMedian': full_data['median_earnings']['median'],
         'earningsMedianLow': full_data['median_earnings']['average_range'][0],

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -255,7 +255,6 @@ class APITests(django.test.TestCase):
 
         url = reverse('disclosures:national-stats-json', args=['408039'])
         resp = client.get(url)
-        self.assertTrue('loanDefaultRate' in resp.content)
         self.assertTrue('retentionRateMedian' in resp.content)
         url2 = reverse('disclosures:national-stats-json', args=['000000'])
         resp2 = client.get(url2)


### PR DESCRIPTION
This simplifies the national-stats API call for a school.
## Removals

These values disappear from `/national-stats/[SCHOOLID_PROGRAMID]/`
- loanDefaultRate
- loanDefaultRateHigh
- loanDefaultRateLow 
## Changes
- Test adjusted
## Testing

In standalone, `http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/national-stats/408039_981/` should not deliver 3 loanDefaultRate values.
## Review
- @mistergone (thanks for catching)
- @amymok 
- @marteki 
## Checklist
- [x] Visually tested in supported browsers and devices
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
