### PR TITLE
Percentage, private loan fee fixes

### DIFF
--- a/src/disclosures/js/utils/query-handler.js
+++ b/src/disclosures/js/utils/query-handler.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var stringToNum = require( './handle-string-input.js' );
+var getFinancial = require( '../dispatchers/get-financial-values.js' );
 
 /**
  * Handles URL questy string to turn key-value pairs into an object.
@@ -10,10 +11,12 @@ var stringToNum = require( './handle-string-input.js' );
 function queryHandler( queryString ) {
   var valuePairs = {};
   var parameters = {};
+  var directFee = getFinancial.values().DLOriginationFee - 1;
   var numericKeys = [
     'iped', 'pid', 'tuit', 'hous', 'book', 'tran', 'othr',
     'pelg', 'schg', 'stag', 'othg', 'mta', 'gib', 'fam', 'wkst', 'parl',
-    'perl', 'subl', 'unsl', 'ppl', 'gpl', 'prvl', 'prvi', 'insl', 'insi', 'sav'
+    'perl', 'subl', 'unsl', 'ppl', 'gpl', 'prvl', 'prvi', 'prvf', 'insl',
+    'insi', 'sav'
   ];
   var keyMaps = {
     iped: 'collegeID',
@@ -40,6 +43,7 @@ function queryHandler( queryString ) {
     gpl:  'gradPlus',
     prvl: 'privateLoan',
     prvi: 'privateLoanRate',
+    prvf: 'privateLoanFee',
     insl: 'institutionalLoan',
     insi: 'institutionalLoanRate'
   };
@@ -92,20 +96,25 @@ function queryHandler( queryString ) {
       }
     }
   }
+
   getPairs();
   remapKeys();
+
   // move private loan properties to privateLoanMulti
   valuePairs.privateLoanMulti = [
     { amount: valuePairs.privateLoan || 0,
       rate:   valuePairs.privateLoanRate / 100 || 0.079,
-      fees:   0,
+      fees:   valuePairs.privateLoanFee / 100 || directFee || 0,
       deferPeriod: 6 }
   ];
   delete valuePairs.privateLoan;
   delete valuePairs.privateLoanRate;
+  delete valuePairs.privateLoanFee;
+
   // family contributions = parent loan
   valuePairs.family = valuePairs.parentLoan;
   valuePairs.institutionalLoanRate /= 100;
+
   return valuePairs;
 }
 

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -43,6 +43,16 @@ var financialView = {
   },
 
   /**
+   * A better rounding function
+   * @param {number} n - Number to be rounded
+   * @param {number} decimals - Number of decimal places
+   */
+  round: function( n, decimals ) {
+    var number = n + 'e' + decimals;
+    return Number( Math.round( number )+ 'e-' + decimals );
+  },
+
+  /**
    * Helper function that updates the value or text of an element
    * @param {object} $ele - jQuery object of the element to update
    * @param {number|string} value - The new value
@@ -71,7 +81,7 @@ var financialView = {
     $percents.not( '#' + financialView.currentInput ).each( function() {
       var $ele = $( this ),
           name = $ele.attr( 'data-financial' ),
-          value = values[name] * 100;
+          value = financialView.round( values[name] * 100, 2 );
       financialView.updateElement( $ele, value, false );
     } );
   },
@@ -104,20 +114,23 @@ var financialView = {
    */
   updatePrivateLoans: function( values, $privateLoans ) {
     $privateLoans.each( function() {
-      var index = $( this ).index(),
-          $fields = $( this ).find( '[data-private-loan_key]' );
+      var $loanElements = $( this ),
+          index = $loanElements.index(),
+          $fields = $loanElements.find( '[data-private-loan_key]' );
       $fields.not( '#' + financialView.currentInput ).each( function() {
-        var key = $( this ).attr( 'data-private-loan_key' ),
+        var $ele = $( this ),
+            key = $ele.attr( 'data-private-loan_key' ),
             val = values.privateLoanMulti[index][key],
-            isntCurrentInput =
-            $( this ).attr( 'id' ) !== financialView.currentInput;
-        if ( $( this ).is( '[data-percentage_value="true"]' ) ) {
+            id = $ele.attr( 'id' ),
+            isntCurrentInput = id !== financialView.currentInput,
+            len;
+        if ( $ele.is( '[data-percentage_value="true"]' ) ) {
           val *= 100;
-          $( this ).val( val );
+          $ele.val( financialView.round( val, 3 ) );
         } else if ( isntCurrentInput && key === 'amount' ) {
-          $( this ).val( formatUSD( { amount: val, decimalPlaces: 0 } ) );
+          $ele.val( formatUSD( { amount: val, decimalPlaces: 0 } ) );
         } else {
-          $( this ).val( val );
+          $ele.val( val );
         }
       } );
     } );

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -46,6 +46,7 @@ var financialView = {
    * A better rounding function
    * @param {number} n - Number to be rounded
    * @param {number} decimals - Number of decimal places
+   * @returns {number} rounded value
    */
   round: function( n, decimals ) {
     var number = n + 'e' + decimals;


### PR DESCRIPTION
This fixes a bug in percent fields and brings in private loan fees from the URL (or Direct Loan rate).
## Additions
- Added `prvf` to query handler
- Added a fix for floating point imprecision showing in the percent input fields
  - Added `round()` function to fix this imprecision
## Testing
- Passes existing functional and unit tests
## Review
- @marteki and @higs4281 and @amymok and anyone who loves floating point errors
- Pull it down, `gulp` it, and check out the `prvf` URL parameter or try to type numbers like `3.666` in percent fields and watch the lack of floating point errors!
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
## Animated GIF

It seems like a **MEGASHARK** kind of day.

![megashark-bites-bridge](https://cloud.githubusercontent.com/assets/1490703/16046059/1494da12-3219-11e6-8d21-99e4065872e6.gif)
