### PR TITLE
show 'operating'  field for schools in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - loanDefaultRate values (three of them) removed from national-stats API calls
 - metric-view refactored
 - 10/25 loan term toggles added to metrics section
+- add `operating` field to admin
 
 ## 2.1.1
 - Parent PLUS loans separated from other family contributions

--- a/paying_for_college/admin.py
+++ b/paying_for_college/admin.py
@@ -22,10 +22,11 @@ class ConstantCapAdmin(admin.ModelAdmin):
 class SchoolAdmin(admin.ModelAdmin):
     list_display = ('primary_alias',
                     'school_id',
+                    'operating',
                     'city',
                     'state',
                     'settlement_school')
-    list_filter = ('settlement_school', 'state')
+    list_filter = ('settlement_school', 'operating', 'state')
     list_editable = ('settlement_school',)
     search_fields = ['school_id', 'city', 'state']
     ordering = ['state']


### PR DESCRIPTION
Adds `operating` field to admin for schools
## Review
- @amymok 
## Screenshots

`operating` field for viewing and sorting
<img width="1423" alt="admin" src="https://cloud.githubusercontent.com/assets/515885/16081734/bd8f765e-32dc-11e6-8b4e-18aaa724d293.png">
## Checklist
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
