### PR TITLE
Calculation error notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - loanDefaultRate values (three of them) removed from national-stats API calls
 - metric-view refactored
 - 10/25 loan term toggles added to metrics section
+- Include half year options for program length
+- Shift line item dollar signs over to accommodate six figure values
 - add `operating` field to admin
 
 ## 2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - add `operating` field to admin
 - added a check to fetchProgramData() for offers with no pid
 - added capture of bad URS in the API program view
+- added error notifications for calculation errors
 
 ## 2.1.1
 - Parent PLUS loans separated from other family contributions

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -89,14 +89,14 @@
                                 <dd class="verify_value verify_estimate">
                                     <p class="verify_label-explanation">
                                         Select how long you expect it to take to
-                                        complete this program. This may be shorter
-                                        than the program length above if you
-                                        transferred in with credits that the school
-                                        accepts. It may be longer if you plan to
-                                        attend part time or do not successfully
-                                        complete your courses. We’ll use this to
-                                        help calculate your total debt after
-                                        graduation.
+                                        complete this program. This may be
+                                        shorter than the program length above if
+                                        you transferred in with credits that the
+                                        school accepts. It may be longer if you
+                                        plan to attend part time or do not
+                                        successfully complete your courses.
+                                        We’ll use this to help calculate your
+                                        total debt after graduation.
                                     </p>
                                     <div class="cf-select">
                                         <select id="estimated-years-attending">
@@ -106,20 +106,38 @@
                                             <option value="1">
                                                 1 year
                                             </option>
+                                            <option value="1.5">
+                                                1.5 years
+                                            </option>
                                             <option value="2">
                                                 2 years
+                                            </option>
+                                            <option value="2.5">
+                                                2.5 years
                                             </option>
                                             <option value="3">
                                                 3 years
                                             </option>
+                                            <option value="3.5">
+                                                3.5 years
+                                            </option>
                                             <option value="4">
                                                 4 years
+                                            </option>
+                                            <option value="4.5">
+                                                4.5 years
                                             </option>
                                             <option value="5">
                                                 5 years
                                             </option>
+                                            <option value="5.5">
+                                                5.5 years
+                                            </option>
                                             <option value="6">
                                                 6 years
+                                            </option>
+                                            <option value="6.5">
+                                                6.5 years
                                             </option>
                                         </select>
                                     </div>
@@ -358,11 +376,19 @@
                                         </div>
                                         <div class="aid-form_input-wrapper">
                                             <input class="aid-form_input
-                                            aid-form_input__currency"
+                                            aid-form_input__currency
+                                            aid-form_input__error"
                                             type="text" id="grants__pell"
                                             name="grants__pell"
                                             data-financial="pell"
                                             autocorrect="off" value="0">
+                                            <div data-calc-error="pell">
+                                                <span class="cf-icon cf-icon-error-round"></span> The maximum that can be awarded per year is <span data-cap="pell">$0</span>
+                                            </div>
+                                            <div data-calc-error="overBorrowing">
+                                                <span class="cf-icon cf-icon-error-round"></span>
+                                                The total of your federal aid can't be more than the total cost of attendance
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="form-group_item">
@@ -444,6 +470,10 @@
                                             name="grants__military"
                                             data-financial="militaryTuitionAssistance"
                                             autocorrect="off" value="0">
+                                            <div data-calc-error="militaryTuitionAssistance">
+                                                <span class="cf-icon cf-icon-error-round"></span>The maximum that can be borrowed per year is 
+                                                <span data-cap="militaryTuitionAssistance">$0</span>
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="form-group_item">
@@ -826,6 +856,10 @@
                                             name="contrib__perkins"
                                             data-financial="perkins"
                                             autocorrect="off" value="0">
+                                            <div data-calc-error="perkins">
+                                                <span class="cf-icon cf-icon-error-round"></span>The maximum that can be borrowed per year is 
+                                                <span data-cap="perkins">$0</span>
+                                            </div>
                                         </div>
                                         <div class="offer-part_terms">
                                             <p class="offer-part_term">
@@ -860,6 +894,10 @@
                                             name="contrib__subsidized"
                                             data-financial="directSubsidized"
                                             autocorrect="off" value="0">
+                                            <div data-calc-error="directSubsidized">
+                                                <span class="cf-icon cf-icon-error-round"></span>The maximum that can be borrowed per year is 
+                                                <span data-cap="directSubsidized">$0</span>
+                                            </div>
                                         </div>
                                         <div class="offer-part_terms">
                                             <p class="offer-part_term">
@@ -902,6 +940,10 @@
                                             name="contrib__unsubsidized"
                                             data-financial="directUnsubsidized"
                                             autocorrect="off" value="0">
+                                            <div data-calc-error="directUnsubsidized">
+                                                <span class="cf-icon cf-icon-error-round"></span>The maximum that can be borrowed per year is 
+                                                <span data-cap="directUnsubsidized">$0</span>
+                                            </div>
                                         </div>
                                         <div class="offer-part_terms">
                                             <p class="offer-part_term">

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -376,16 +376,15 @@
                                         </div>
                                         <div class="aid-form_input-wrapper">
                                             <input class="aid-form_input
-                                            aid-form_input__currency
-                                            aid-form_input__error"
+                                            aid-form_input__currency"
                                             type="text" id="grants__pell"
                                             name="grants__pell"
                                             data-financial="pell"
                                             autocorrect="off" value="0">
-                                            <div data-calc-error="pell">
+                                            <div class="aid-form_calc-error" data-calc-error="pell">
                                                 <span class="cf-icon cf-icon-error-round"></span> The maximum that can be awarded per year is <span data-cap="pell">$0</span>
                                             </div>
-                                            <div data-calc-error="overBorrowing">
+                                            <div class="aid-form_calc-error" data-calc-error="overBorrowing">
                                                 <span class="cf-icon cf-icon-error-round"></span>
                                                 The total of your federal aid can't be more than the total cost of attendance
                                             </div>
@@ -470,7 +469,7 @@
                                             name="grants__military"
                                             data-financial="militaryTuitionAssistance"
                                             autocorrect="off" value="0">
-                                            <div data-calc-error="militaryTuitionAssistance">
+                                            <div class="aid-form_calc-error" data-calc-error="militaryTuitionAssistance">
                                                 <span class="cf-icon cf-icon-error-round"></span>The maximum that can be borrowed per year is 
                                                 <span data-cap="militaryTuitionAssistance">$0</span>
                                             </div>
@@ -856,7 +855,7 @@
                                             name="contrib__perkins"
                                             data-financial="perkins"
                                             autocorrect="off" value="0">
-                                            <div data-calc-error="perkins">
+                                            <div class="aid-form_calc-error" data-calc-error="perkins">
                                                 <span class="cf-icon cf-icon-error-round"></span>The maximum that can be borrowed per year is 
                                                 <span data-cap="perkins">$0</span>
                                             </div>
@@ -894,7 +893,7 @@
                                             name="contrib__subsidized"
                                             data-financial="directSubsidized"
                                             autocorrect="off" value="0">
-                                            <div data-calc-error="directSubsidized">
+                                            <div class="aid-form_calc-error" data-calc-error="directSubsidized">
                                                 <span class="cf-icon cf-icon-error-round"></span>The maximum that can be borrowed per year is 
                                                 <span data-cap="directSubsidized">$0</span>
                                             </div>
@@ -940,7 +939,7 @@
                                             name="contrib__unsubsidized"
                                             data-financial="directUnsubsidized"
                                             autocorrect="off" value="0">
-                                            <div data-calc-error="directUnsubsidized">
+                                            <div class="aid-form_calc-error" data-calc-error="directUnsubsidized">
                                                 <span class="cf-icon cf-icon-error-round"></span>The maximum that can be borrowed per year is 
                                                 <span data-cap="directUnsubsidized">$0</span>
                                             </div>

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -340,9 +340,12 @@
 
   [data-calc-error] {
     font-size: unit(@small-font-size-px / @base-font-size-px, em);
+    line-height: 1.5;
+    margin-top: unit( 5px / @base-font-size-px, em );
     
     & > .cf-icon-error-round {
       color: @red-80;
+      margin-right: unit( 5px / @base-font-size-px, em );
     }
   }
 

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -338,10 +338,11 @@
     }
   }
 
-  [data-calc-error] {
+  &_calc-error {
     font-size: unit(@small-font-size-px / @base-font-size-px, em);
     line-height: 1.5;
     margin-top: unit( 5px / @base-font-size-px, em );
+    display: none;
     
     & > .cf-icon-error-round {
       color: @red-80;

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -331,6 +331,19 @@
       -webkit-text-fill-color: @black;
       opacity: 1;
     }
+
+    &&__error {
+     border-color: @red-80;
+     border-width: unit( 2px / @base-font-size-px, em );
+    }
+  }
+
+  [data-calc-error] {
+    font-size: unit(@small-font-size-px / @base-font-size-px, em);
+    
+    & > .cf-icon-error-round {
+      color: @red-80;
+    }
   }
 
   &_unit {
@@ -455,7 +468,7 @@
 
   &_currency {
     position: absolute;
-    right: unit(77px / @font-size, em);
+    right: unit(88px / @font-size, em);
   }
 
   &_explanation {
@@ -1605,4 +1618,5 @@
       .grid_column(6);
     });
   }
+
 }

--- a/src/disclosures/js/index.js
+++ b/src/disclosures/js/index.js
@@ -48,6 +48,9 @@ var app = {
               // Update expenses model bases on region and salary
               region = schoolValues.BLSAverage.substr( 0, 2 );
               $( '#bls-region-select' ).val( region ).change();
+
+              // set financial caps based on data
+              financialView.setCaps( getFinancial.values() );
             } );
         }
         questionView.init();

--- a/src/disclosures/js/models/financial-model.js
+++ b/src/disclosures/js/models/financial-model.js
@@ -69,6 +69,7 @@ var financialModel = {
     this.roundValues();
     this.reportErrors();
     this.sumDirectCost();
+    console.log( this.values );
   },
 
   /**

--- a/src/disclosures/js/models/financial-model.js
+++ b/src/disclosures/js/models/financial-model.js
@@ -67,9 +67,7 @@ var financialModel = {
     this.values = recalculate( this.values );
     this.sumTotals();
     this.roundValues();
-    this.reportErrors();
     this.sumDirectCost();
-    console.log( this.values );
   },
 
   /**
@@ -104,15 +102,6 @@ var financialModel = {
       schoolValues.undergrad = false;
     }
     $.extend( this.values, schoolValues );
-  },
-
-  /**
-   * Report errors to the user
-   */
-  reportErrors: function() {
-    // This is something of a placeholder for future code.
-    // For now, feel free to uncomment the following and view the errors object.
-    // console.log( this.values.errors );
   }
 
 };

--- a/src/disclosures/js/utils/query-handler.js
+++ b/src/disclosures/js/utils/query-handler.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var stringToNum = require( './handle-string-input.js' );
-var getFinancial = require( '../dispatchers/get-financial-values.js' );
 
 /**
  * Handles URL questy string to turn key-value pairs into an object.
@@ -11,7 +10,6 @@ var getFinancial = require( '../dispatchers/get-financial-values.js' );
 function queryHandler( queryString ) {
   var valuePairs = {};
   var parameters = {};
-  var directFee = getFinancial.values().DLOriginationFee - 1;
   var numericKeys = [
     'iped', 'pid', 'tuit', 'hous', 'book', 'tran', 'othr',
     'pelg', 'schg', 'stag', 'othg', 'mta', 'gib', 'fam', 'wkst', 'parl',

--- a/src/disclosures/js/utils/query-handler.js
+++ b/src/disclosures/js/utils/query-handler.js
@@ -104,7 +104,7 @@ function queryHandler( queryString ) {
   valuePairs.privateLoanMulti = [
     { amount: valuePairs.privateLoan || 0,
       rate:   valuePairs.privateLoanRate / 100 || 0.079,
-      fees:   valuePairs.privateLoanFee / 100 || directFee || 0,
+      fees:   valuePairs.privateLoanFee / 100 || 0,
       deferPeriod: 6 }
   ];
   delete valuePairs.privateLoan;

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -47,7 +47,32 @@ var financialView = {
    * @param {object} financials - the financials model
    */
   setCaps: function( financials ) {
-    
+    var capMap = {
+          pell: 'pellCap',
+          pellGrad: 'pellCap',
+          perkins: 'perkinsUnderCap',
+          perkinsGrad: 'perkinsGradCap',
+          militaryTuitionAssistance: 'militaryAssistanceCap',
+          militaryTuitionGrad: 'militaryAssistanceCap',
+          directSubsidized: 'subsidizedCapYearOne',
+          directSubsidizedGrad: 'subsidizedCapYearOne',
+          directUnsubsidized: 'unsubsidizedCapYearOne',
+          directUnsubsidizedGrad: 'unsubsidizedCapIndepYearOne'
+        },
+        $elems = $( '[data-cap]' );
+
+    $elems.each( function() {
+      var $cap = $( this ),
+          prop = $cap.attr( 'data-cap' ),
+          capKey = capMap[prop],
+          text;
+      if ( financials.undergrad === false ) {
+        capKey += 'Grad';
+      }
+      console.log( capKey, financials[capKey] );
+      text = formatUSD( { amount: financials[capKey], decimalPlaces: 0 } );
+      $cap.text( text );
+    } );
   },
 
   /**

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -43,6 +43,14 @@ var financialView = {
   },
 
   /**
+   * Sets all the values for caps in the errors notifications
+   * @param {object} financials - the financials model
+   */
+  setCaps: function( financials ) {
+    
+  },
+
+  /**
    * A better rounding function
    * @param {number} n - Number to be rounded
    * @param {number} decimals - Number of decimal places
@@ -338,6 +346,9 @@ var financialView = {
       var programLength = Number( $( this ).val() ),
           values = getFinancial.values(),
           yearsAttending = numberToWords.toWords( programLength );
+      if( programLength % 1 != 0 ) {
+        yearsAttending = yearsAttending + ' and a half';
+      }
       publish.financialData( 'programLength', programLength );
       publish.financialData( 'yearsAttending', yearsAttending );
       financialView.updateView( values );

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -503,12 +503,20 @@ it( 'should properly update when more than one private loans is modified', funct
     expect( page.totalRepayment.getText() ).toEqual( '29,889' );
   } );
 
-  it( 'should update total borrowing and verbiage when program length is changed', function() {
+  it( 'should update total borrowing and verbiage when program length is changed to a whole year number', function() {
      page.confirmVerification();
      page.setProgramLength( 4 );
      browser.sleep( 1000 );
      expect( page.futureYearsAttending.getText() ).toEqual( 'four' );
      expect( page.totalProgramDebt.getText() ).toEqual( '46,000' );
+  });
+
+  it( 'should update total borrowing and verbiage when program length is changed to a partial year number', function() {
+     page.confirmVerification();
+     page.setProgramLength( 4.5 );
+     browser.sleep( 1000 );
+     expect( page.futureYearsAttending.getText() ).toEqual( 'four and a half' );
+     expect( page.totalProgramDebt.getText() ).toEqual( '51,750' );
   });
 
   it( 'should properly describe a future based on not covering enough of the cost of college that is needed', function() {


### PR DESCRIPTION
This PR adds error notifications for calculation errors (when the user goes over a federal cap, or borrows more in federal loans than the cost of attendance). There might be some tweaking necessary, but we won't know until folks get a chance to play around with it, I think.

This PR also removes the code that set the Private Loan Fees to default to the Direct Loan Origination Fees. This will now default to 0 if it is not set in the offer URL.
## Additions
- Error notification elements
- Handlers that set the text of various caps in the notifications
- Handlers that show errors based on the `errors` property returned by `student-debt-calc`
## Removals
- Code which set Private Loan Fees from url offers to equal Direct Loan Origination Fee.
## Testing
- Passes all functional and unit tests!
## Review
- @marteki and @higs4281 and @amymok 
- Pull it down, `gulp`, and check out those errors!
## Screenshots

<img width="671" alt="screen shot 2016-06-17 at 10 11 30 am" src="https://cloud.githubusercontent.com/assets/1490703/16153332/e9bc4e80-3473-11e6-9f3e-b86605d5f678.png">
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
## Animated GIF

![blues-brothers-toast](https://cloud.githubusercontent.com/assets/1490703/16153367/0911de26-3474-11e6-927a-2e86af0afebd.gif)
