### PR TITLE
Remove 6 fields from school json payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
+- removed 6 unneeded fields from school json payload
 
 ## 2.1.2
 - Parent PLUS loans separated from other family contributions

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -238,22 +238,16 @@ class School(models.Model):
         ordered_out = OrderedDict()
         jdata = json.loads(self.data_json)
         dict_out = {
-            'avg_net_price': self.avg_net_price,
             'books': jdata['BOOKS'],
             'city': self.city,
             'control': self.control,
             'defaultRate': "{0}".format(self.default_rate),
             'gradRate': "{0}".format(self.grad_rate),
             'highestDegree': self.get_highest_degree(),
-            'indicatorGroup': jdata['INDICATORGROUP'],
-            'KBYOSS': self.KBYOSS,
             'medianAnnualPay': self.median_annual_pay,
             'medianMonthlyDebt': "{0}".format(self.median_monthly_debt),
             'medianTotalDebt': "{0}".format(self.median_total_debt),
             'nicknames': ", ".join([nick.nickname for nick in self.nickname_set.all()]),
-            'offerAA': jdata['OFFERAA'],
-            'offerBA': jdata['OFFERBA'],
-            'offerGrad': jdata['OFFERGRAD'],
             'offersPerkins': self.offers_perkins,
             'onCampusAvail': jdata['ONCAMPUSAVAIL'],
             'online': self.online_only,


### PR DESCRIPTION
The deleted fields are not being used or can be derived from current data from
the Ed API.
## Removals

These fields are dropped from the school payload:
- KBYOSS
- avg_net_price
- indicatorGroup
- offerAA
- offerBA
- offerGrad
## Testing
- hit a school endpoint, and the values should be gone.

```
http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/school/130794/
```

<img width="437" alt="yale_json" src="https://cloud.githubusercontent.com/assets/515885/16310640/57fa72d4-393b-11e6-86a5-40057dbb3f45.png">
## Review
- @amymok @marteki @mistergone 
## Checklist
- [x] Data dictionary and CHANGELOG updated
