### PR TITLE
Fix error handling in program view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
+- Error checking added to program view
 
 ## 2.1.2
 - Parent PLUS loans separated from other family contributions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
 - Error checking added to program view
+- Error checking added to verification view
 
 ## 2.1.2
 - Parent PLUS loans separated from other family contributions

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -305,6 +305,9 @@ class VerifyViewTest(django.test.TestCase):
         resp = client.post(self.url, data=self.post_data)
         self.assertTrue(resp.status_code == 200)
         self.assertTrue('verification' in resp.content)
+        resp2 = client.post(self.url, data=self.post_data)
+        self.assertTrue(resp2.status_code == 400)
+        self.assertTrue('already' in resp2.content)
 
     def test_verify_view_bad_id(self):
         self.post_data['iped'] = ''

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -287,6 +287,10 @@ class APITests(django.test.TestCase):
         resp2 = client.get(bad_url)
         self.assertTrue(resp2.status_code == 400)
         self.assertTrue('Error' in resp2.content)
+        url3 = reverse('disclosures:program-json', args=['408039_xyz'])
+        resp3 = client.get(url3)
+        self.assertTrue(resp3.status_code == 400)
+        self.assertTrue('Error' in resp3.content)
 
 
 class VerifyViewTest(django.test.TestCase):

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -217,9 +217,8 @@ class ProgramRepresentation(View):
 
     def get_program(self, program_code):
         ids = program_code.split('_')
-        return get_object_or_404(Program,
-                                 institution__school_id=int(ids[0]),
-                                 program_code=ids[1])
+        return Program.objects.filter(institution__school_id=int(ids[0]),
+                                      program_code=ids[1]).first()
 
     def get(self, request, program_code, **kwargs):
         ids = program_code.split('_')
@@ -229,6 +228,9 @@ class ProgramRepresentation(View):
                      'is what was received: /program/{}/'.format(program_code))
             return HttpResponseBadRequest(error)
         program = self.get_program(program_code)
+        if not program:
+            p_error = "Error: No program found for code {}".format(program_code)
+            return HttpResponseBadRequest(p_error)
         return HttpResponse(program.as_json(),
                             content_type='application/json')
 


### PR DESCRIPTION
We needed to handle error states in program and verificaton views. This adds error handling for poorly formed URLs, URLs with the program ID missing, program IDs that don't exist and verifications for offer IDs that have already been used. The views will return status 400 and an error message. 
## Additions
- tests to match
## Changes
- program view
- verification view
## Testing

These urls should return 400 and error messages:
- http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/program/408039_xxx/
- http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/program/408039/
## Review
- @amymok 
- @marteki only if you have time
## Checklist
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
