### PR TITLE
Add logging and messaging to Notification model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Error checking added to program view
 - Error checking added to verification view
 - removed 6 unneeded fields from school json payload
+- Added notifications script and 2 fields to Notification model for errors
 
 ## 2.1.2
 - Parent PLUS loans separated from other family contributions

--- a/paying_for_college/disclosures/scripts/notifications.py
+++ b/paying_for_college/disclosures/scripts/notifications.py
@@ -1,0 +1,55 @@
+import datetime
+from django.utils import timezone
+import json
+from string import Template
+
+from django.core.mail import send_mail
+
+from paying_for_college.models import Notification
+
+INTRO = ('Notification failures \n'
+         'Notification delivery failed for the following offer IDs:\n\n')
+NOTE_TEMPLATE = Template(('Offer ID $oid:\n'
+                          '    timestamp: $time\n'
+                          '    app errors: $errors\n'
+                          '    send log: $log\n\n'))
+
+
+def retry_notifications():
+    """attempt to resend recent notifications that failed"""
+    pass
+
+    day_old = timezone.now() - datetime.timedelta(days=1)
+    failed_notifications = Notification.objects.filter(sent=False,
+                                                       timestamp__gt=day_old)
+    for each in failed_notifications:
+        each.notify_school()
+
+
+def send_stale_notifications(add_email=[]):
+    """Gather up notifications that have failed and are more than a day old."""
+
+    stale_date = timezone.now() - datetime.timedelta(days=1)
+    stale_notifications = Notification.objects.filter(sent=False,
+                                                      timestamp__lt=stale_date)
+    contacts = {notification.institution.contact: [] for notification
+                in stale_notifications if notification.institution.contact}
+    for noti in stale_notifications:
+        payload = {
+            'oid':    noti.oid,
+            'time':   noti.timestamp.isoformat(),
+            'errors': noti.errors,
+            'log':    noti.log
+        }
+        clist = contacts[noti.institution.contact]
+        clist.append(payload)
+    for contact in contacts:
+        msg = INTRO
+        for msgdict in contacts[contact]:
+            msg += NOTE_TEMPLATE.substitute(msgdict)
+        recipients = [contact.contact] + add_email
+        send_mail("CFPB notification failures",
+                  msg,
+                  "no-reply@cfpb.gov",
+                  recipients,
+                  fail_silently=False)

--- a/paying_for_college/disclosures/scripts/update_colleges.py
+++ b/paying_for_college/disclosures/scripts/update_colleges.py
@@ -27,14 +27,6 @@ FIELDS = sorted(MODEL_MAP.keys())
 FIELDSTRING = ",".join(FIELDS)
 
 
-def fix_json(jstring):
-    """attempt to fix a misquoted data_json string"""
-    try:
-        return ast.literal_eval(jstring)
-    except:
-        return {}
-
-
 def fix_zip5(zip5):
     """add leading zeros if they have been stripped by the scorecard db"""
     if len(zip5) == 4:
@@ -114,12 +106,13 @@ def update(exclude_ids=[], single_school=None):
                 print("request not OK, returned {0}".format(resp.reason))
                 FAILED.append(school)
                 if resp.status_code == 429:
-                    print("API limit reached")
+                    endmsg = "API limit reached"
+                    print(endmsg)
                     print(resp.content)
-                    break
+                    return (FAILED, NO_DATA, endmsg)
                 else:
-                    print("request for {0} returned {1}".format(school,
-                                                              resp.status_code))
+                    print("request for {0} "
+                          "returned {1}".format(school, resp.status_code))
                     continue
     endmsg = """\nTried to get new data for {0} school(s):\n\
     updated {1} and found no data for {2}\n\

--- a/paying_for_college/fixtures/test_fixture.json
+++ b/paying_for_college/fixtures/test_fixture.json
@@ -1,6 +1,16 @@
 [
 {
     "fields": {
+        "contact": "wwen@edmc.edu",
+        "endpoint": "https://exml.edmc.edu/cfpb",
+        "name": "EDMC",
+        "internal_note": ""
+    },
+    "model": "paying_for_college.contact",
+    "pk": 1
+},
+{
+    "fields": {
         "city": "Mayaguez",
         "accreditor": "",
         "url": "",
@@ -9,6 +19,7 @@
         "degrees_predominant": "",
         "degrees_highest": "4",
         "state": "PR",
+        "contact": 1,
         "operating": true,
         "data_json": "{\"NETPRICEOK\": \"12964\", \"ONCAMPUSAVAIL\": \"Yes\", \"TUITIONGRADOSS\": \"\", \"NETPRICE110K\": \"19303\", \"TUITIONGRADINDIS\": \"\", \"AVGMONTHLYPAY\": \"1225\", \"GRADRATERANK\": \"465\", \"INDICATORGROUP\": \"1\", \"OTHERONCAMPUS\": \"3568\", \"NETPRICE48K\": \"18475\", \"BAH\": \"1311\", \"CONTROL\": \"Public\", \"ZIP\": \"66045\", \"AVGSTULOANDEBTRANK\": \"233.26\", \"OFFERBA\": \"Yes\", \"OFFERAA\": \"Yes\", \"ONLINE\": \"No\", \"OTHEROFFCAMPUS\": \"3568\", \"OFFERGRAD\": \"Yes\", \"SCHOOL_ID\": \"155317\", \"TUITIONUNDERINDIS\": \"10107\", \"TUITIONGRADINS\": \"\", \"ROOMBRDONCAMPUS\": \"7702\", \"GRADRATE\": \"64\", \"CITY\": \"Lawrence\", \"TUITIONUNDERINS\": \"10107\", \"ALIAS\": \"University of Kansas | Univ of Kansas | Kansas University | KU | Kansas Jayhawks | Univ of KS |University of KS | Kansas Univ | Kansas U | KUMC | University of Kansas Medical Center | KU Medical Center | Kansas University Medical Center\", \"STATE\": \"KS\", \"NETPRICEGENERAL\": \"16326\", \"NETPRICE3OK\": \"15089\", \"OTHERWFAMILY\": \"3568\", \"SCHOOL\": \"University of Kansas\", \"NETPRICE75K\": \"19303\", \"BADALIAS\": \"\", \"TUITIONUNDEROSS\": \"24873\", \"DEFAULTRATE\": \"5.6\", \"AVGSTULOANDEBT\": \"20269\", \"BOOKS\": \"900\", \"ROOMBRDOFFCAMPUS\": \"8852\", \"RETENTRATE\": \"79\", \"KBYOSS\": \"Yes\"}",
         "KBYOSS": true
@@ -49,6 +60,82 @@
     },
     "model": "paying_for_college.school",
     "pk": 155317
+},
+{
+    "fields": {
+        "control": "Public",
+        "ownership": "",
+        "offers_perkins": false,
+        "under_investigation": false,
+        "data_json": "{\"NETPRICEOK\": \"\", \"GRADRATERANK\": \"\", \"ONCAMPUSAVAIL\": \"Yes\", \"TUITIONGRADOSS\": \"\", \"NETPRICE110K\": \"\", \"TUITIONGRADINDIS\": \"\", \"AVGMONTHLYPAY\": \"\", \"NETPRICE48K\": \"\", \"INDICATORGROUP\": \"\", \"OTHERONCAMPUS\": \"\", \"OTHEROFFCAMPUS\": \"\", \"BAH\": \"1119\", \"CONTROL\": \"Public\", \"GRADRATE\": \"\", \"AVGSTULOANDEBTRANK\": \"\", \"OFFERBA\": \"Yes\", \"BOOKS\": \"\", \"ONLINE\": \"No\", \"OFFERGRAD\": \"No\", \"SCHOOL_ID\": \"100636\", \"TUITIONUNDERINDIS\": \"\", \"TUITIONGRADINS\": \"\", \"ROOMBRDONCAMPUS\": \"\", \"ZIP\": \"36114\", \"OTHERWFAMILY\": \"\", \"TUITIONUNDERINS\": \"\", \"ALIAS\": \"CCAF\", \"STATE\": \"AL\", \"NETPRICEGENERAL\": \"\", \"NETPRICE3OK\": \"\", \"CITY\": \"Montgomery\", \"SCHOOL\": \"Community College of the Air Force\", \"NETPRICE75K\": \"\", \"BADALIAS\": \"\", \"TUITIONUNDEROSS\": \"\", \"DEFAULTRATE\": \"\", \"AVGSTULOANDEBT\": \"\", \"OFFERAA\": \"Yes\", \"ROOMBRDOFFCAMPUS\": \"\", \"RETENTRATE\": \"\", \"KBYOSS\": \"\"}",
+        "degrees_predominant": "",
+        "avg_net_price": null,
+        "zip5": "",
+        "city": "Montgomery",
+        "accreditor": "",
+        "degrees_highest": "",
+        "grad_rate_lt4": null,
+        "state": "AL",
+        "settlement_school": "",
+        "ope6_id": null,
+        "ope8_id": null,
+        "tuition_out_of_state": null,
+        "operating": true,
+        "main_campus": null,
+        "median_monthly_debt": null,
+        "grad_rate_4yr": null,
+        "median_total_debt": null,
+        "grad_rate": null,
+        "repay_3yr": null,
+        "url": "",
+        "enrollment": null,
+        "default_rate": null,
+        "online_only": null,
+        "contact": null,
+        "median_annual_pay": null,
+        "tuition_in_state": null,
+        "KBYOSS": false
+    },
+    "model": "paying_for_college.school",
+    "pk": 100636
+},
+{
+    "fields": {
+        "control": "Public",
+        "ownership": "1",
+        "offers_perkins": true,
+        "under_investigation": false,
+        "data_json": "{\"NETPRICEOK\": \"10931\", \"ONCAMPUSAVAIL\": \"Yes\", \"TUITIONGRADOSS\": \"\", \"NETPRICE110K\": \"16147\", \"TUITIONGRADINDIS\": \"\", \"AVGMONTHLYPAY\": \"1466\", \"GRADRATERANK\": \"1470\", \"INDICATORGROUP\": \"1\", \"RETENTRATELT4\": null, \"NETPRICE48K\": \"13267\", \"OTHERONCAMPUS\": \"2748\", \"BAH\": \"1191\", \"CONTROL\": \"Public\", \"GRADRATE\": \"32.2\", \"AVGSTULOANDEBTRANK\": \"258.93\", \"OFFERBA\": \"Yes\", \"BOOKS\": \"1800\", \"ONLINE\": \"No\", \"OTHEROFFCAMPUS\": \"2748\", \"OFFERGRAD\": \"Yes\", \"SCHOOL_ID\": \"100654\", \"TUITIONUNDERINDIS\": \"7182\", \"TUITIONGRADINS\": \"\", \"ROOMBRDONCAMPUS\": \"10119\", \"ZIP\": \"35762\", \"OTHERWFAMILY\": \"1300\", \"TUITIONUNDERINS\": \"7182\", \"ALIAS\": \"AAMU\", \"STATE\": \"AL\", \"BADALIAS\": \"\", \"NETPRICEGENERAL\": \"11108\", \"NETPRICE3OK\": \"12470\", \"MEDIANDEBTCOMPLETER\": 373.156553575, \"CITY\": \"Normal\", \"SCHOOL\": \"Alabama A & M University\", \"NETPRICE75K\": \"16147\", \"REPAY3YR\": 0.444713870029, \"TUITIONUNDEROSS\": \"12774\", \"DEFAULTRATE\": 0.163, \"AVGSTULOANDEBT\": 19500.0, \"OFFERAA\": \"Yes\", \"ROOMBRDOFFCAMPUS\": \"10119\", \"RETENTRATE\": 0.6314, \"KBYOSS\": \"\"}",
+        "degrees_predominant": "3",
+        "avg_net_price": 13415,
+        "zip5": "35762",
+        "city": "Normal",
+        "accreditor": "Southern Association of Colleges and Schools Commission on Colleges",
+        "degrees_highest": "4",
+        "grad_rate_lt4": 0.25,
+        "state": "AL",
+        "settlement_school": "",
+        "ope6_id": 1002,
+        "ope8_id": 100200,
+        "tuition_out_of_state": 12774,
+        "operating": true,
+        "main_campus": true,
+        "median_monthly_debt": "373.156553575",
+        "grad_rate_4yr": "0.309",
+        "median_total_debt": "19500.0",
+        "grad_rate": "0.310",
+        "repay_3yr": "0.4447138700",
+        "url": "www.aamu.edu/",
+        "enrollment": 4051,
+        "default_rate": "0.163",
+        "online_only": false,
+        "contact": null,
+        "median_annual_pay": 31400,
+        "tuition_in_state": 7182,
+        "KBYOSS": false
+    },
+    "model": "paying_for_college.school",
+    "pk": 100654
 },
 {
     "fields": {
@@ -148,6 +235,19 @@
     },
     "model": "paying_for_college.nickname",
     "pk": 265
+},
+{
+    "fields": {
+        "errors": "INVALID: student indicated the offer information is wrong",
+        "log": "",
+        "timestamp": "2016-05-26T01:53:04.082Z",
+        "oid": "fa8283b5b7c939a058889f997949efa566c616c6",
+        "email": "",
+        "institution": 243197,
+        "sent": false
+    },
+    "model": "paying_for_college.notification",
+    "pk": 1
 },
 {
     "fields": {

--- a/paying_for_college/migrations/0004_auto_20160626_0342.py
+++ b/paying_for_college/migrations/0004_auto_20160626_0342.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('paying_for_college', '0003_auto_20160525_2048'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='notification',
+            name='log',
+            field=models.TextField(blank=True),
+        ),
+        migrations.AddField(
+            model_name='notification',
+            name='sent',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/paying_for_college/tests/test_commands.py
+++ b/paying_for_college/tests/test_commands.py
@@ -15,6 +15,9 @@ class CommandTests(unittest.TestCase):
         self.assertTrue(mock_update.call_count == 1)
         call_command('update_via_api', '--school_id', '99999')
         self.assertTrue(mock_update.call_count == 2)
+        mock_update.side_effect = IndexError("no such school ID")
+        call_command('update_via_api', '--school_id', '99999')
+        self.assertTrue(mock_update.call_count == 3)
 
     @mock.patch('paying_for_college.management.commands.load_programs.load_programs.load')
     def test_load_programs(self, mock_load):

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -304,13 +304,19 @@ class VerifyViewTest(django.test.TestCase):
     def test_verify_view(self):
         resp = client.post(self.url, data=self.post_data)
         self.assertTrue(resp.status_code == 200)
-        self.assertTrue('verification' in resp.content)
+        self.assertTrue('Verification' in resp.content)
         resp2 = client.post(self.url, data=self.post_data)
         self.assertTrue(resp2.status_code == 400)
         self.assertTrue('already' in resp2.content)
 
     def test_verify_view_bad_id(self):
         self.post_data['iped'] = ''
+        resp = client.post(self.url, data=self.post_data)
+        self.assertTrue(resp.status_code == 400)
+
+    def test_verify_view_bad_oid(self):
+        self.post_data['iped'] = '408039'
+        self.post_data['oid'] = 'f38283b5b7c939a058889f997949efa566script'
         resp = client.post(self.url, data=self.post_data)
         self.assertTrue(resp.status_code == 400)
 


### PR DESCRIPTION
We need to track and retry notification failures, so we're adding a log
entry to each Notification record to track its own transmission attempts.
We're also adding a "sent" boolean that is True
if a notification was successful. In this way we can regularly poll the
database to see if there are send failures and retry them or, if they're
getting old, collect them for troubleshooting and for notifying schools.
## Additions
- notifications.py script to resend and gather stale notifications.
- tests to match
## Testing

This is tough to test locally, because you need some notification records locally, resending notifications will fail (EDMC will reject any postings from outside EXT) and sending email for stale notifications requires an email host to be configured. These will be more easily tested in Jenkins once we push to servers.
## Review
- @amymok 
- anyone else who'd like to look it over.
## Checklist
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
## Note

Since this PR makes a model change, `./manage.py migrate paying_for_college` is needed to keep your local db in sync.
## To do
- create a mangement command to run notifications
