### PR TITLE
Configure JMeter Properties

### DIFF
--- a/test/load_testing/jmeter.properties
+++ b/test/load_testing/jmeter.properties
@@ -1,4 +1,3 @@
-
 # Override JMeter defaults
 jmeter.save.saveservice.output_format=xml
 jmeter.save.saveservice.thread_counts=true

--- a/test/load_testing/jmeter.properties
+++ b/test/load_testing/jmeter.properties
@@ -1,0 +1,7 @@
+
+# Override JMeter defaults
+jmeter.save.saveservice.output_format=xml
+jmeter.save.saveservice.thread_counts=true
+jmeter.save.saveservice.url=true
+jmeter.save.saveservice.requestHeaders=true
+jmeter.save.saveservice.response_data.on_error=true


### PR DESCRIPTION
Currently jmeter creates a jtl file which is in csv format, which causes a number format java exception when running the load test in jenkins.  To prevent this exception to occur, the jtl file needs to be a xml file, and this properties file will help configure that if using performance report plugin.
## Additions
- Added JMeter properties to emit xml in jtl file
## Review
- @higs4281 @OrlandoSoto
