### PR TITLE
Refine input of Pell Grants and family contributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
+- Refine input of Pell Grants and family contributions
+
+## 2.1.3
 - Added load tests
 - Error checking added to program view
 - Error checking added to verification view

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -362,7 +362,7 @@
                                             Money you don’t have to pay back
                                         </p>
                                     </div>
-                                    <div class="form-group_item">
+                                    <div class="form-group_item" data-section="pellgrant">
                                         <div class="aid-form_label-wrapper">
                                             <label class="form-label"
                                             for="grants__pell">

--- a/src/disclosures/js/index.js
+++ b/src/disclosures/js/index.js
@@ -46,7 +46,7 @@ var app = {
 
               // Add url values to the financial model
               publish.extendFinancialData( urlValues );
-              if ( urlValues.totalCost === undefined ) {
+              if ( typeof urlValues.totalCost === 'undefined' ) {
                 publish.financialData( 'totalCost', null );
               }
               financialView.updateViewWithURL( urlValues );

--- a/src/disclosures/js/models/financial-model.js
+++ b/src/disclosures/js/models/financial-model.js
@@ -54,6 +54,7 @@ var financialModel = {
   calc: function() {
     this.sumScholarships();
     this.checkPerkins();
+    this.sumFamilyTotal();
     this.values = recalculate( this.values );
     this.sumTotals();
     this.roundValues();

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -21,6 +21,7 @@ var financialView = {
   $aboutThisTool: $( '.instructions_about a' ),
   $addPrivateButton: $( '.private-loans_add-btn' ),
   $totalDirectCostSection: $( '.verify_direct-cost' ),
+  $pellGrantSection: $( '[data-section="pellgrant"]' ),
   $gradPlusSection: $( '[data-section="gradPlus"]' ),
   $perkinsSection: $( '[data-section="perkins"]' ),
   $privateContainer: $( '.private-loans' ),
@@ -218,9 +219,10 @@ var financialView = {
     this.$programLength.val( values.programLength ).change();
     // Update links
     linksView.updateLinks( values );
-    // Update availability of gradPLUS loans
+    // Update availability of Pell grants, Perkins loans, and gradPLUS loans
     this.gradPlusVisible( values.level.indexOf( 'Graduate' ) !== -1 );
     this.perkinsVisible( values.offersPerkins );
+    this.pellGrantsVisible( values.level.indexOf( 'Graduate' ) == -1 );
   },
 
   /**
@@ -255,7 +257,7 @@ var financialView = {
       subsidizedOverCap: 'directSubsidized',
       unsubsidizedOverCap: 'directUnsubsidized',
       perkinsOverCap: 'perkins',
-      pellOverCap: 'pellOverCap',
+      pellOverCap: 'pell',
       mtaOverCap: 'militaryTuitionAssistance'
     };
 
@@ -467,6 +469,10 @@ var financialView = {
     }
   },
 
+  /**
+   * Sets visibility of Grad Plus loan section (hidden if not graduate program)
+   * @param {boolean} visibility - Whether or not `values.level` is 'Graduate'
+   */
   gradPlusVisible: function( visibility ) {
     if ( visibility === false ) {
       this.$gradPlusSection.hide();
@@ -476,11 +482,28 @@ var financialView = {
     }
   },
 
+  /**
+   * Sets visibility of Perkins section (hidden if school does not offer it)
+   * @param {boolean} visibility - Value of `values.offerPerkins`
+   */
   perkinsVisible: function( visibility ) {
     if ( visibility === false ) {
       this.$perkinsSection.hide();
     } else {
       this.$perkinsSection.show();
+    }
+  },
+
+  /**
+   * Sets visibility of Pell Grant section (hidden for graduate programs)
+   * @param {boolean} visibility - Is `values.level` not 'Graduate'?
+   */
+  pellGrantsVisible: function( visibility ) {
+    if ( visibility === false ) {
+      this.$pellGrantSection.hide();
+      publish.financialData( 'pell', 0 );
+    } else {
+      this.$pellGrantSection.show();
     }
   },
 

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -222,7 +222,7 @@ var financialView = {
     // Update availability of Pell grants, Perkins loans, and gradPLUS loans
     this.gradPlusVisible( values.level.indexOf( 'Graduate' ) !== -1 );
     this.perkinsVisible( values.offersPerkins );
-    this.pellGrantsVisible( values.level.indexOf( 'Graduate' ) == -1 );
+    this.pellGrantsVisible( values.level.indexOf( 'Graduate' ) === -1 );
   },
 
   /**

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -229,7 +229,7 @@ var financialView = {
    * @param {object} values - An object with URL values
    */
   updateViewWithURL: function( values ) {
-    this.totalDirectCostVisible( values.totalCost !== undefined );
+    this.totalDirectCostVisible( typeof values.totalCost !== 'undefined' );
   },
 
   /**

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -272,6 +272,15 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
     expect( page.remainingCostFinal.getText() ).toEqual( '1,526' );
   } );
 
+  it( 'should properly update when both the Parent PLUS loan and the cash a student\'s family will provide are modified', function() {
+    page.confirmVerification();
+    page.setFamilyContribution( 4000 );
+    page.setParentPlusContribution( 2000 );
+    browser.sleep( 750 );
+    expect( page.totalContributions.getText() ).toEqual( '9,000' );
+    expect( page.remainingCostFinal.getText() ).toEqual( '11,526' );
+  } );
+
   it( 'should properly update when the work study earnings are modified within the allowed limit', function() {
     page.confirmVerification();
     page.setWorkStudyContribution( 2000 );

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -141,6 +141,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
     page.confirmVerification();
     page.setFederalPellGrants( 5500 );
     browser.sleep( 750 );
+    expect( page.pellGrantCapWarning.isDisplayed() ).toBeFalsy;
     expect( page.totalGrantsScholarships.getText() ).toEqual( '15,600' );
     expect( page.studentTotalCost.getText() ).toEqual( '28,026' );
     expect( page.remainingCostFinal.getText() ).toEqual( '-1,474' );
@@ -150,8 +151,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
     page.confirmVerification();
     page.setFederalPellGrants( 10000 );
     browser.sleep( 750 );
-    // TODO: expect student is informed about the Pell Grant cap
-    // expect( EC.visibilityOf( page.pellGrantCapWarning ) );
+    expect( page.pellGrantCapWarning.isDisplayed() ).toBeTruthy;
     expect( page.totalGrantsScholarships.getText() ).toEqual( '15,915' );
     expect( page.studentTotalCost.getText() ).toEqual( '27,711' );
     expect( page.remainingCostFinal.getText() ).toEqual( '-1,789' );

--- a/test/functional/settlementAidOfferPage.js
+++ b/test/functional/settlementAidOfferPage.js
@@ -149,6 +149,11 @@ settlementAidOfferPage.prototype = Object.create({}, {
         return this.federalPellGrants.sendKeys(pellgrant);
       }
     },
+    pellGrantCapWarning: {
+      get: function() {
+        return element( by.css( '[data-calc-error="pell"]' ) );
+      }
+    },
     schoolScholarships: {
       get: function() {
         return element( by.id( 'grants__school' ) );


### PR DESCRIPTION
This addresses a few small bugs for Pell Grants and contributions to a student from their family.
## Changes
- Pell Grants should not appear for graduate programs
- Pell Grants should give a warning if the amount entered is over the cap
- Family contributions and Parent Plus loans should show up in the summary together as "Money your family will provide"
- Improvements to commenting and treating `undefined` values properly
## Testing

Pull down the branch. The first three items above under the "Changes" section should be true.

[Here is a graduate program for testing the non visibility of Pell Grants.](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=205647&pid=9&totl=123456&tuit=30000&hous=20000&book=10000&tran=5000&othr=500&pelg=6000&schg=2000&stag=2000&othg=2000&wkst=0&ppl=0&parl=0&perl=0&subl=0&unsl=0&gpl=0&prvl=0&prvi=8&prvf=0&insl=1000&insi=3&inst=50&oid=9e0280139f3238cbc9702c7b0d62e5c238a835d0)

[Here is an undergraduate program.](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=101116&pid=1455&oid=fa8283b5b7c939a058889f997949efa566c616a4&book=1500&gib=0&gpl=0&hous=5611&insi=5.0&insl=3000&inst=36&mta=0&othg=100&othr=6079&parl=7000&pelg=1500&perl=5500&ppl=0&prvl=2000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&totl=83450&tran=500&tuit=20862&unsl=2000&wkst=1000)

All unit and browser tests should pass.
## Review
- @mistergone @higs4281 @amymok 
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
