### PR TITLE
Added string checking for program codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
+- Added string checking for program codes
 
 ## 2.1.3
 - Added load tests

--- a/paying_for_college/disclosures/scripts/load_programs.py
+++ b/paying_for_college/disclosures/scripts/load_programs.py
@@ -115,7 +115,8 @@ def load(filename):
         if serializer.is_valid():
             data = serializer.data
             if not validate_pid(data['program_code']):
-                print("invalid program code: {}".format(data['program_code']))
+                print("ERROR: invalid program code: "
+                      "{}".format(data['program_code']))
                 continue
             (school, error) = get_school(data['ipeds_unit_id'])
             if error:

--- a/paying_for_college/disclosures/scripts/notifications.py
+++ b/paying_for_college/disclosures/scripts/notifications.py
@@ -58,6 +58,5 @@ def send_stale_notifications(add_email=[]):
                   "no-reply@cfpb.gov",
                   recipients,
                   fail_silently=False)
-        return ("Found {} stale notifications; "
-                "emails sent to {}".format(stale_notifications.count(),
-                                           recipients))
+        return ("Found {} stale notifications; emails sent to "
+                "{}".format(stale_notifications.count(), recipients))

--- a/paying_for_college/disclosures/scripts/notifications.py
+++ b/paying_for_college/disclosures/scripts/notifications.py
@@ -12,7 +12,7 @@ INTRO = ('Notification failures \n'
 NOTE_TEMPLATE = Template(('Offer ID $oid:\n'
                           '    timestamp: $time\n'
                           '    app errors: $errors\n'
-                          '    send log: $log\n\n'))
+                          'SEND LOG:\n$log\n'))
 
 
 def retry_notifications(days=1):
@@ -58,5 +58,5 @@ def send_stale_notifications(add_email=[]):
                   "no-reply@cfpb.gov",
                   recipients,
                   fail_silently=False)
-        return "Found {} stale notifications; "
-        "emails sent to {}".format(stale_notifications.count(), recipients)
+        return ("Found {} stale notifications; emails sent to "
+                "{}".format(stale_notifications.count(), recipients))

--- a/paying_for_college/disclosures/scripts/notifications.py
+++ b/paying_for_college/disclosures/scripts/notifications.py
@@ -58,5 +58,6 @@ def send_stale_notifications(add_email=[]):
                   "no-reply@cfpb.gov",
                   recipients,
                   fail_silently=False)
-        return "Found {} stale notifications; "
-        "emails sent to {}".format(stale_notifications.count(), recipients)
+        return ("Found {} stale notifications; "
+                "emails sent to {}".format(stale_notifications.count(),
+                                           recipients))

--- a/paying_for_college/tests/test_load_programs.py
+++ b/paying_for_college/tests/test_load_programs.py
@@ -7,6 +7,7 @@ from decimal import *
 from paying_for_college.models import Program, School
 from paying_for_college.disclosures.scripts.load_programs import get_school, read_in_data, clean_number_as_string, clean_string_as_string, clean, load
 
+
 class TestLoadPrograms(django.test.TestCase):
     fixtures = ['test_program.json']
 
@@ -141,9 +142,7 @@ class TestLoadPrograms(django.test.TestCase):
         self.assertEqual(program.job_note, "The rate reflects employment status as of November 1, 2014 - Test")
         self.assertEqual(program.tuition, 40000)
         self.assertEqual(program.books, 1000)
-
-
-
-
-
-
+        mock_clean.return_value['program_code'] = '<904>'
+        load('filename')
+        self.assertEqual(mock_read_in.call_count, 2)
+        self.assertEqual(mock_program.call_count, 1)  # loader bails before creating program


### PR DESCRIPTION
Add validation for program codes
## Additions
- validation function for program and offer views
- related tests
## Testing
- try to call for a program ID with illegal characters:  ; < > { }
- [example illegal offer call](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=%3C981%3E&oid=f38283b5b7c939a058889f997949efa566c616c5&tuit=38976&hous=3000&book=650&tran=500&othr=500&pelg=1500&schg=2000&stag=2000&othg=100&ta=3000&mta=3000&gib=3000&wkst=3000&parl=10000&perl=3000&subl=15000&unsl=2000&ppl=1000&gpl=1000&prvl=3000&prvi=4.55&insl=3000&insi=4.55)
- [example illegal program call](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/program/408039_%7B981%7D/)
  ## Review
- @amymok @OrlandoSoto @lfatty
## Checklist
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

.
