### PR TITLE
Prevents notifications for non-settlement schools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
 - Added string checking for program codes
-- Refine input of Pell Grants and family contributions
+- Refined input of Pell Grants and family contributions
+- Added a test so that notifications can't be sent to non-settlement schools
 
 ## 2.1.3
 - Added load tests

--- a/paying_for_college/fixtures/test_fixture.json
+++ b/paying_for_college/fixtures/test_fixture.json
@@ -53,6 +53,7 @@
         "ope8_id": 194800,
         "degrees_predominant": "",
         "degrees_highest": "",
+        "settlement_school": "",
         "state": "KS",
         "operating": true,
         "data_json": "{\"NETPRICEOK\": \"12964\", \"ONCAMPUSAVAIL\": \"Yes\", \"TUITIONGRADOSS\": \"\", \"NETPRICE110K\": \"19303\", \"TUITIONGRADINDIS\": \"\", \"AVGMONTHLYPAY\": \"1225\", \"GRADRATERANK\": \"465\", \"INDICATORGROUP\": \"1\", \"OTHERONCAMPUS\": \"3568\", \"NETPRICE48K\": \"18475\", \"BAH\": \"1311\", \"CONTROL\": \"Public\", \"ZIP\": \"66045\", \"AVGSTULOANDEBTRANK\": \"233.26\", \"OFFERBA\": \"Yes\", \"OFFERAA\": \"Yes\", \"ONLINE\": \"No\", \"OTHEROFFCAMPUS\": \"3568\", \"OFFERGRAD\": \"Yes\", \"SCHOOL_ID\": \"155317\", \"TUITIONUNDERINDIS\": \"10107\", \"TUITIONGRADINS\": \"\", \"ROOMBRDONCAMPUS\": \"7702\", \"GRADRATE\": \"64\", \"CITY\": \"Lawrence\", \"TUITIONUNDERINS\": \"10107\", \"ALIAS\": \"University of Kansas | Univ of Kansas | Kansas University | KU | Kansas Jayhawks | Univ of KS |University of KS | Kansas Univ | Kansas U | KUMC | University of Kansas Medical Center | KU Medical Center | Kansas University Medical Center\", \"STATE\": \"KS\", \"NETPRICEGENERAL\": \"16326\", \"NETPRICE3OK\": \"15089\", \"OTHERWFAMILY\": \"3568\", \"SCHOOL\": \"University of Kansas\", \"NETPRICE75K\": \"19303\", \"BADALIAS\": \"\", \"TUITIONUNDEROSS\": \"24873\", \"DEFAULTRATE\": \"5.6\", \"AVGSTULOANDEBT\": \"20269\", \"BOOKS\": \"900\", \"ROOMBRDOFFCAMPUS\": \"8852\", \"RETENTRATE\": \"79\", \"KBYOSS\": \"Yes\"}",

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -345,13 +345,16 @@ class Notification(models.Model):
                                       self.institution.pk)
 
     def notify_school(self):
+        school = self.institution
+        if not school.settlement_school:
+            nonmsg = "No notification required; {} is not a settlement school"
+            return nonmsg.format(school.primary_alias)
         payload = {
             'oid':    self.oid,
             'time':   self.timestamp.isoformat(),
             'errors': self.errors
         }
         now = datetime.datetime.now()
-        school = self.institution
         no_contact_msg = ("School notification failed: "
                           "No endpoint or email info {}".format(now))
         # we prefer to use endpount notification, so use it first if existing


### PR DESCRIPTION
This makes sure a school is a settlement school before proceeding with
any of the notification routine. If a verification is received for a
non-settlement school, the API returns a message to the app saying
"No notification required; `[SCHOOL NAME]` is not a settlement school"
## Additions
- test for `settlement_school` value at the start of the Notification model's `notify_school()` method
- code test to match
## Testing
- Currently can't be tested via the app because verification ajax calls have stopped working.
## Review
- @amymok 
## Checklist
- [x] [Project documentation](https://github.cfpb.gov/paying-for-college/dynamic-disclosures-documentation/wiki/API-documentation#verifications) updated
- [x] CHANGELOG updated
