### PR TITLE
Make Elasticsearch work in standalone mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Added string checking for program codes
 - Refined input of Pell Grants and family contributions
 - Added a test so that notifications can't be sent to non-settlement schools
+- Updated standalone search configs for running Elasticsearch locally
 
 ## 2.1.3
 - Added load tests

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For 2.x versions installed on a mac with homebrew, this is an example command:
 elasticsearch --path.conf=/Users/[MAC USERNAME]/homebrew/opt/elasticsearch/config/elasticsearch.yml
 ```
 
-1.x versions use a `--config` param instead of `path.conf`:
+1.x versions use a `--config=` param instead of `path.conf=`
 
 
 With elasticsearch running, you can now build an index of college data:

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Tools to help students make informed financial decisions about college.
 - [Django](https://www.djangoproject.com/)
 - [requests](http://docs.python-requests.org/en/latest/)
 - [Unipath](https://github.com/mikeorr/Unipath)
-- [haystack](http://haystacksearch.org/)
-- [elasticsearch](https://www.elastic.co/products/elasticsearch)
+- [Haystack](http://haystacksearch.org/)
+- [Elasticsearch](https://www.elastic.co/products/elasticsearch)
 
 <!-- - [django-haystack](http://haystacksearch.org/) -->
 
@@ -33,7 +33,6 @@ Tools to help students make informed financial decisions about college.
 ### Installation
 This project is not fully functional, but feel free to give it a spin. Here's how:
 - Install the setup dependencies if you don't have them.
-- Elasticsearch is optional for the standalone setup
 - Go to the local directory where you want the project to be created, make a virtual environment, clone this repository (or your own fork of it).
 ```bash
 mkvirtualenv college-costs
@@ -54,6 +53,34 @@ The college-cost tools should show up at [localhost:8000/paying-for-college2/](h
 
 The app is set up to run as a component of CFPB's website, [consumerfinance.gov](http://www.consumerfinance.gov), so if you run it locally, some fonts and font-related icons may not load because of [Cross-Origin Resource Sharing](http://www.w3.org/TR/cors/) policies.
 
+### Search
+The app has a simple API for searching schools by name or nickname. The endpoint, to which you can append a querystring, is:
+```
+/understanding-your-financial-aid-offer/api/search-schools.json
+```
+
+Elasticsearch needs to be running locally for search to work.  
+Your launch command will vary depending on which version of Elasticsearch is installed.
+
+For 2.x versions installed on a mac with homebrew, this is an example command:
+
+```
+elasticsearch --path.conf=/Users/[MAC USERNAME]/homebrew/opt/elasticsearch/config/elasticsearch.yml
+```
+
+1.x versions use a `--config` param instead of `path.conf`:
+
+
+With elasticsearch running, you can now build an index of college data:
+
+
+```
+./manage.py rebuild_index
+```
+
+Now you should get a json response when hitting the search API. You can search by school name or nickname, such as:
+
+http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/search-schools.json?q=jayhawks
 
 ### Running tests
 

--- a/paying_for_college/config/settings/standalone.py
+++ b/paying_for_college/config/settings/standalone.py
@@ -8,3 +8,10 @@ SECRET_KEY = "forstandaloneonly"
 STATICFILES_DIRS = (
     PROJECT_ROOT.child('local_static'),
 )
+
+HAYSTACK_CONNECTIONS = {'default':
+                        {'ENGINE':
+                         ('haystack.backends.elasticsearch_backend.'
+                          'ElasticsearchSearchEngine'),
+                         'URL': '127.0.0.1:9200',
+                         'INDEX_NAME': 'build_haystack'}}

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -328,6 +328,10 @@ class School(models.Model):
         else:
             return 'Not Available'
 
+    @property
+    def nicknames(self):
+        return ", ".join([nick.nickname for nick in self.nickname_set.all()])
+
 
 class Notification(models.Model):
     """record of a disclosure verification"""

--- a/paying_for_college/search_indexes.py
+++ b/paying_for_college/search_indexes.py
@@ -5,6 +5,7 @@ from models import School
 class SchoolIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.CharField(document=True, model_attr='primary_alias')
     school_id = indexes.IntegerField(model_attr='school_id')
+    nicknames = indexes.CharField(model_attr='nicknames')
     city = indexes.CharField(model_attr='city')
     state = indexes.CharField(model_attr='state')
     autocomplete = indexes.EdgeNgramField()

--- a/paying_for_college/tests/test_models.py
+++ b/paying_for_college/tests/test_models.py
@@ -96,6 +96,7 @@ class SchoolModelsTest(TestCase):
         n = self.create_nickname(s)
         self.assertTrue(isinstance(n, Nickname))
         self.assertTrue(n.nickname in n.__unicode__())
+        self.assertTrue(n.nickname in s.nicknames)
         p = self.create_program(s)
         self.assertTrue(isinstance(p, Program))
         self.assertTrue(p.program_name in p.__unicode__())

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -185,13 +185,13 @@ class SchoolSearchTest(django.test.TestCase):
 
         mock_school = School.objects.get(pk=155317)
         # mock the search returned value
-        solr_school = self.ElasticSchool()
-        solr_school.text = mock_school.primary_alias
-        solr_school.school_id = mock_school.school_id
-        solr_school.city = mock_school.city
-        solr_school.state = mock_school.state
-        solr_school.nicknames = 'Jayhawks'
-        solr_queryset = [solr_school]
+        elastic_school = self.ElasticSchool()
+        elastic_school.text = mock_school.primary_alias
+        elastic_school.school_id = mock_school.school_id
+        elastic_school.city = mock_school.city
+        elastic_school.state = mock_school.state
+        elastic_school.nicknames = 'Jayhawks'
+        solr_queryset = [elastic_school]
         mock_sqs_autocomplete.return_value = solr_queryset
         url = "%s?q=Kansas" % reverse('disclosures:school_search')
         request = RequestFactory().get(url)

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -154,12 +154,13 @@ class SchoolSearchTest(django.test.TestCase):
     fixtures = ['test_fixture.json',
                 'test_program.json']
 
-    class SolrSchool:
+    class ElasticSchool:
         def __init__(self):
             self.text = ''
             self.school_id = 0
             self.city = ''
             self.state = ''
+            self.nicknames = ''
 
     def test_get_school(self):
         """test grabbing a school by ID"""
@@ -183,12 +184,13 @@ class SchoolSearchTest(django.test.TestCase):
         """school_search_api should return json."""
 
         mock_school = School.objects.get(pk=155317)
-        # mock the solr returned value
-        solr_school = self.SolrSchool()
+        # mock the search returned value
+        solr_school = self.ElasticSchool()
         solr_school.text = mock_school.primary_alias
         solr_school.school_id = mock_school.school_id
         solr_school.city = mock_school.city
         solr_school.state = mock_school.state
+        solr_school.nicknames = 'Jayhawks'
         solr_queryset = [solr_school]
         mock_sqs_autocomplete.return_value = solr_queryset
         url = "%s?q=Kansas" % reverse('disclosures:school_search')
@@ -196,6 +198,7 @@ class SchoolSearchTest(django.test.TestCase):
         resp = school_search_api(request)
         self.assertTrue('Kansas' in resp.content)
         self.assertTrue('155317' in resp.content)
+        self.assertTrue('Jayhawks' in resp.content)
 
 
 class OfferTest(django.test.TestCase):

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -328,6 +328,7 @@ def school_search_api(request):
     document = [{'schoolname': school.text,
                  'id': school.school_id,
                  'city': school.city,
+                 'nicknames': school.nicknames,
                  'state': school.state,
                  'url': reverse('disclosures:school-json',
                                 args=[school.school_id])}


### PR DESCRIPTION
In order to play nice with servers, we need to make PFC search work with
Elasticsearch. This adds settings configs for standalone, updates the
README to explain local setups and tweaks index configurations.
## Additions
- Standalone settings for Elasticsearch
- A README section on enabling Elasticsearch
## Changes
- Index configs to handle nicknames
## Testing
- For anyone willing, give the Elasticsearch README section a try.  
  [?q=tarzans](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/search-schools.json?q=tarzans) should return this:

<img width="737" alt="tarzans" src="https://cloud.githubusercontent.com/assets/515885/16732105/7725d722-4749-11e6-93cd-120fe80430c4.png">
## Review
- @amymok 
## Checklist
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
