### PR TITLE
Simplifies key for bls expense data on taxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Added string checking for program codes
 - Refined input of Pell Grants and family contributions
 - Added a test so that notifications can't be sent to non-settlement schools
+- Changed BLS json keyword for tax expenses to single word: "Taxes"
 
 ## 2.1.3
 - Added load tests

--- a/paying_for_college/data_sources/bls_processing.py
+++ b/paying_for_college/data_sources/bls_processing.py
@@ -54,14 +54,14 @@ def load_bls_data(csvfile):
 def add_bls_dict_with_region(base_bls_dict, region, csvfile):
 
     CATEGORIES_KEY_MAP = {
-        "Food" : "Food",
+        "Food": "Food",
         "Housing": "Housing",
         "Transportation": "Transportation",
         "Healthcare": "Healthcare",
         "Entertainment": "Entertainment",
         "Personal insurance and pensions": "Retirement",
         "Apparel and services": "Clothing",
-        "Personal taxes (contains some imputed values)": "Taxes (federal, state, local)",
+        "Personal taxes (contains some imputed values)": "Taxes",
         # Other
         "Alcoholic beverages": "Other",
         "Personal care products and services": "Other",
@@ -111,8 +111,9 @@ def bls_as_dict(we_csvfile, ne_csvfile, mw_csvfile, so_csvfile):
         "Entertainment": {"note": "Events, pets, hobbies, equipment"},
         "Retirement": {"note": "Pensions and personal insurance"},
         "Clothing": {"note": "Apparel and services"},
-        "Taxes (federal, state, local)": {"note": "Personal taxes (contains some imputed values)"},
-        "Other": {"note": "Other expeditures"}  
+        "Taxes": {"note": ("Personal federal, state, and local taxes; "
+                           "contains some imputed values")},
+        "Other": {"note": "Other expeditures"}
     }
 
     add_bls_dict_with_region(bls_dict, "WE", WE_CSVFILE)
@@ -125,8 +126,8 @@ def bls_as_dict(we_csvfile, ne_csvfile, mw_csvfile, so_csvfile):
     return bls_dict
 
 
-def create_bls_json_file(we_csvfile=WE_CSVFILE, ne_csvfile=NE_CSVFILE, 
-        mw_csvfile=MW_CSVFILE, so_csvfile=SO_CSVFILE):
+def create_bls_json_file(we_csvfile=WE_CSVFILE, ne_csvfile=NE_CSVFILE,
+                         mw_csvfile=MW_CSVFILE, so_csvfile=SO_CSVFILE):
 
     with open(OUT_FILE, 'w') as outfile:
         bls_dict = bls_as_dict(we_csvfile, ne_csvfile, mw_csvfile, so_csvfile)

--- a/paying_for_college/fixtures/bls_data.json
+++ b/paying_for_college/fixtures/bls_data.json
@@ -377,7 +377,7 @@
       }
    },
    "Taxes":{
-      "note":"Personal federal, state, andlocal taxes; contains some imputed values",
+      "note":"Personal federal, state, and local taxes; contains some imputed values",
       "MW":{
          "less_than_5000":-415,
          "50000_to_69999":5027,

--- a/paying_for_college/fixtures/bls_data.json
+++ b/paying_for_college/fixtures/bls_data.json
@@ -376,8 +376,8 @@
          "30000_to_39999":1845
       }
    },
-   "Taxes (federal, state, local)":{
-      "note":"Personal taxes (contains some imputed values)",
+   "Taxes":{
+      "note":"Personal federal, state, andlocal taxes; contains some imputed values",
       "MW":{
          "less_than_5000":-415,
          "50000_to_69999":5027,


### PR DESCRIPTION
This puts the tax expense data under a single-word key
## Changes
- bls.json keyword for tax expenses is "Taxes"
## Review
- @amymok 
- @marteki 
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
