### PR TITLE
Make the tuition and fees field editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Added an 'update_ipeds' script and manage.py command for annual updates
 - Updated standalone requirements to Django==1.8.13 to match our servers
 - Added 2 new fields, 'completion_cohort' and 'completers' to Program object
+- Make the tuition and fees field editable
 
 ## 2.1.3
 - Added load tests

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -264,7 +264,6 @@
                                             type="text" id="costs__tuition"
                                             name="costs__tuition"
                                             data-financial="tuitionFees"
-                                            disabled
                                             autocorrect="off" value="0">
                                         </div>
                                     </div>

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -85,9 +85,9 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
     expect( page.schoolName.getText() ).toEqual( 'Brown Mackie College-Fort Wayne' );
   } );
 
-  it( 'should not let a student edit the tuition', function() {
+  it( 'should let a student edit the tuition and fees', function() {
     page.confirmVerification();
-    expect( page.tuitionFeesCosts.isEnabled() ).toEqual( false );
+    expect( page.tuitionFeesCosts.isEnabled() ).toEqual( true );
   } );
 
   it( 'should show correct totals on load', function() {
@@ -95,6 +95,20 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
     expect( page.totalCostOfAttendance.getText() ).toEqual( '43,626' );
     expect( page.studentTotalCost.getText() ).toEqual( '32,026' );
     expect( page.remainingCostFinal.getText() ).toEqual( '2,526' );
+  } );
+
+  it( 'should properly update when the tuition and fees are modified', function() {
+    page.confirmVerification();
+    browser.wait(
+      page.setTuitionFeesCosts( 48976 ).then(
+        function() {
+          browser.sleep(500);
+          expect( page.totalCostOfAttendance.getText() ).toEqual( '53,626' );
+          expect( page.studentTotalCost.getText() ).toEqual( '42,026' );
+          expect( page.remainingCostFinal.getText() ).toEqual( '12,526' );
+        }
+      ), 10000
+    );
   } );
 
   it( 'should properly update when the housing and meals are modified', function() {


### PR DESCRIPTION
Like the title says, this makes the tuition and fees input field editable. The field is currently disabled in the codebase, but there is a use case to support it being able to be changed.
## Changes
- Make the tuition and fees field editable
## Testing

Pull down the branch, and spin up any of our sample URLs.

You should see a white background in the tuition and fees box, and you should be able to change the number in it.
## Review
- @mistergone @higs4281 @amymok 
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
