### PR TITLE
We need to catch rates that are in the wrong form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Show and hide content or offer sections depending on the program values and passed URL values
 - Update Step 3 illustration for "think about working while you study"
 - Make the tuition and fees field editable
+- Adjust load_programs to fix rates > 1
 
 ## 2.1.3
 - Added load tests


### PR DESCRIPTION
Our CSV spec failed to explicitly say that rates should be in the form "0.55" instead of "55" 
to represent 55%. This PR catches any rates that are expressed as >1 numbers and converts them.
It also catches an encoding issue that cropped up in the first batch of EDMC programs.
## Additions
- Two helper functions to load_programs
- tests to match
## Review
- @amymok 
## Checklist
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
