### PR TITLE
Allow purging of notifications and programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Update NPM packages and security policy
 - Only hide total direct cost and tuition payment plans if the URL value is $0 or missing
 - Tuition repayment plan calculations integrated into front-end
+- Added purge functions for notifications and programs
+- Added function to deliver program_length as even value
 
 ## 2.1.3
 - Added load tests

--- a/paying_for_college/disclosures/scripts/purge_objects.py
+++ b/paying_for_college/disclosures/scripts/purge_objects.py
@@ -1,0 +1,21 @@
+from paying_for_college.models import Notification, Program
+
+error_msg = "Only Notification and Program objects may be purged"
+no_args_msg = ("You must supply an object type to purge, "
+               "either notifications or programs")
+object_map = {
+    'notifications': Notification,
+    'programs': Program
+}
+
+
+def purge(objects):
+    """purge notification or program data"""
+    objects = objects.lower()
+    if not objects:
+        return no_args_msg
+    if objects not in object_map.keys():
+        return error_msg
+    msg = "Purging {} {}".format(object_map[objects].objects.count(), objects)
+    object_map[objects].objects.all().delete()
+    return msg

--- a/paying_for_college/disclosures/scripts/purge_objects.py
+++ b/paying_for_college/disclosures/scripts/purge_objects.py
@@ -1,6 +1,7 @@
 from paying_for_college.models import Notification, Program
 
-error_msg = "Only Notification and Program objects may be purged"
+error_msg = ("The only purge arguments that can be passed "
+             "are 'notifications' and 'programs.'")
 no_args_msg = ("You must supply an object type to purge, "
                "either notifications or programs")
 object_map = {

--- a/paying_for_college/management/commands/purge.py
+++ b/paying_for_college/management/commands/purge.py
@@ -1,0 +1,23 @@
+import datetime
+
+from django.core.management.base import BaseCommand, CommandError
+from paying_for_college.disclosures.scripts.purge_objects import purge
+
+COMMAND_HELP = ("Purge will wipe out all notifications or programs "
+                "in the local Django database. "
+                "It can't be run against any other models, "
+                "and you must provide an object type to purge. "
+                "Use it by running 'manage.py purge notifications' "
+                "or 'manage.py purge projects'")
+
+
+class Command(BaseCommand):
+    help = COMMAND_HELP
+
+    def add_arguments(self, parser):
+        parser.add_argument('objects',
+                            type=str)
+
+    def handle(self, *args, **options):
+        msg = purge(options['objects'])
+        self.stdout.write(msg)

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -68,6 +68,14 @@ def get_region(school):
     return ''
 
 
+def make_even(value):
+    """Makes sure a value, such as program_length, is even"""
+    if not value or value % 2 == 0:
+        return value
+    else:
+        return value + 1
+
+
 class ConstantRate(models.Model):
     """Rate values that generally only change annually"""
     name = models.CharField(max_length=255)
@@ -543,7 +551,7 @@ class Program(models.Model):
             'meanStudentLoanCompleters': self.mean_student_loan_completers,
             'privateDebt': self.private_debt,
             'programCode': self.program_code,
-            'programLength': self.program_length,
+            'programLength': make_even(self.program_length),
             'programName': self.program_name,
             'salary': self.salary,
             'schoolID': self.institution.school_id,

--- a/paying_for_college/tests/test_commands.py
+++ b/paying_for_college/tests/test_commands.py
@@ -8,10 +8,24 @@ from paying_for_college.management.commands import (update_ipeds,
                                                     update_via_api,
                                                     load_programs,
                                                     retry_notifications,
-                                                    send_stale_notifications)
+                                                    send_stale_notifications,
+                                                    purge)
 
 
 class CommandTests(unittest.TestCase):
+
+    @mock.patch('paying_for_college.management.commands.'
+                'purge.purge')
+    def test_purges(self, mock_purge):
+        mock_purge.return_value = 'Aye Aye'
+        call_command('purge', 'notifications')
+        self.assertEqual(mock_purge.call_count, 1)
+        call_command('purge', 'programs')
+        self.assertEqual(mock_purge.call_count, 2)
+        call_command('purge', '')
+        self.assertEqual(mock_purge.call_count, 3)
+        call_command('purge', 'schools')
+        self.assertEqual(mock_purge.call_count, 4)
 
     @mock.patch('paying_for_college.management.commands.'
                 'update_ipeds.load_values')

--- a/paying_for_college/tests/test_models.py
+++ b/paying_for_college/tests/test_models.py
@@ -11,7 +11,18 @@ from django.test import TestCase
 from paying_for_college.models import School, Contact, Program, Alias, Nickname
 from paying_for_college.models import ConstantCap, ConstantRate, Disclosure
 from paying_for_college.models import Notification, print_vals
-from paying_for_college.models import get_region
+from paying_for_college.models import get_region, make_even
+
+
+class MakeEvenTest(TestCase):
+
+    def test_make_even(self):
+        test_value = ''
+        self.assertTrue(make_even(test_value) == test_value)
+        test_value = 0
+        self.assertTrue(make_even(test_value) == test_value)
+        test_value = 3
+        self.assertTrue(make_even(test_value) == 4)
 
 
 class SchoolRegionTest(TestCase):

--- a/paying_for_college/tests/test_scripts.py
+++ b/paying_for_college/tests/test_scripts.py
@@ -12,7 +12,8 @@ from django.utils import timezone
 from paying_for_college.models import School, Notification
 from paying_for_college.disclosures.scripts import (api_utils, update_colleges,
                                                     nat_stats, notifications,
-                                                    update_ipeds)
+                                                    update_ipeds,
+                                                    purge_objects)
 from paying_for_college.disclosures.scripts.ping_edmc import (notify_edmc,
                                                               EDMC_DEV,
                                                               OID, ERRORS)
@@ -27,6 +28,22 @@ completion_rate:\n\
   median: 0.4379\n\
   average_range: [.3180, .5236]\n
 """
+
+
+class PurgeTests(django.test.TestCase):
+
+    fixtures = ['test_fixture.json', 'test_program.json']
+
+    def test_purges(self):
+        self.assertTrue(purge_objects.purge('schools') ==
+                        purge_objects.error_msg)
+        self.assertTrue(purge_objects.purge('') ==
+                        purge_objects.no_args_msg)
+        self.assertTrue("Purging" in purge_objects.purge('programs'))
+        self.assertTrue("programs" in purge_objects.purge('programs'))
+        self.assertTrue("Purging" in purge_objects.purge('notifications'))
+        self.assertTrue("notifications" in
+                        purge_objects.purge('notifications'))
 
 
 class TestScripts(django.test.TestCase):


### PR DESCRIPTION
We need to be able to purge notification and program objects via Jenkins
in order to prepare for live testing by a school. This adds manage.py
commands for doing that, plus a model function for ensuring that
program_length values that are delivered as json are always even.
## Additions
- purge command and purge_objects script to support it
- related tests
- model function to deliver even values for program_lengths
## Testing
- Try wiping programs and notifications from your local db.

```
./manage.py purge notifications
./manage.py purge programs
```
## Review
- @amymok and any purge-happy folk
## Checklist
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
