### PR TITLE
Show recalculation update indicators on mobile screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
--
+- Show recalculation updates on mobile screens
 
 ## 2.1.4
 - Added string checking for program codes

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -238,6 +238,9 @@
                             </p>
                         </div>
                     </div>
+                    <div class="recalculating-mobile">
+                        <span>Updating...</span>
+                    </div>
                     <div class="offer-part cost-to-attend
                     column-well_wrapper__overflow-small">
                         <div class="offer-part_intro">

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -1395,6 +1395,22 @@
   }
 }
 
+.recalculating-mobile {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  padding: 15px;
+  background-color: @gold-20;
+  font-size: unit(14px / @base-font-size-px, em);
+
+  .respond-to-min(@bp-med-min, {
+    top: -100em;
+  });
+
+}
+
 .lt-ie9 {
 
   .estimated-expenses .line-item_title {

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -454,9 +454,7 @@ var financialView = {
    * @param {object} element - jQuery object of the recalculated summary element
    */
   addSummaryRecalculationMessage: function( element ) {
-    setTimeout( function() {
-      $( '.recalculating-mobile' ).text( 'Updating...' );
-    }, 2000 );
+    $( '.recalculating-mobile' ).text( 'Updating...' );
     $( '.recalculating-mobile' ).show();
     element.siblings().hide();
     element.text( 'Updating...' );

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -454,6 +454,10 @@ var financialView = {
    * @param {object} element - jQuery object of the recalculated summary element
    */
   addSummaryRecalculationMessage: function( element ) {
+    setTimeout( function() {
+      $( '.recalculating-mobile' ).text( 'Updating...' );
+    }, 2000 );
+    $( '.recalculating-mobile' ).show();
     element.siblings().hide();
     element.text( 'Updating...' );
   },
@@ -466,6 +470,7 @@ var financialView = {
   removeRecalculationMessage: function( element, value ) {
     element.text( value );
     element.siblings().show();
+    $( '.recalculating-mobile' ).hide();
   },
 
   /**


### PR DESCRIPTION
This adds an "Updating..." indicator to the summaries on non-mobile screens.
## Additions
- Show "Updating..." indicator pinned to the top of the browser screen on small width screens only
## Testing

Pull down the branch, and load up a sample URL.

Make your browser window between 320px and 600px wide. A banner with a gold-tinted background and the phrase "Updating.." should flash onto the screen for two seconds. The line item summary items should also briefly change to "Updating..." before displaying their new numbers.
- All unit tests should pass.
- No vulnerable paths should be found in our NPM security test.
- **Functional browser tests are still not passing. :-(**
## Review
- @mistergone @higs4281 @amymok @ans
## Screenshots

![screen shot 2016-07-20 at 3 00 53 pm](https://cloud.githubusercontent.com/assets/1183435/17022532/8ebbb28c-4f1c-11e6-8406-ab2be74bebe5.png)
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [ ] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
