### PR TITLE
Make program lengths divisible by 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
 - Show recalculation updates on mobile screens
+- Altered the Program model to return only program lengths that are divisible by 6
 
 ## 2.1.4
 - Added string checking for program codes

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -68,12 +68,12 @@ def get_region(school):
     return ''
 
 
-def make_even(value):
-    """Makes sure a value, such as program_length, is even"""
-    if not value or value % 2 == 0:
+def make_divisible_by_6(value):
+    """Makes sure a value, such as program_length, is divisible by 6"""
+    if not value or value % 6 == 0:
         return value
     else:
-        return value + 1
+        return value + (6 - (value % 6))
 
 
 class ConstantRate(models.Model):
@@ -551,7 +551,7 @@ class Program(models.Model):
             'meanStudentLoanCompleters': self.mean_student_loan_completers,
             'privateDebt': self.private_debt,
             'programCode': self.program_code,
-            'programLength': make_even(self.program_length),
+            'programLength': make_divisible_by_6(self.program_length),
             'programName': self.program_name,
             'salary': self.salary,
             'schoolID': self.institution.school_id,

--- a/paying_for_college/tests/test_models.py
+++ b/paying_for_college/tests/test_models.py
@@ -11,18 +11,22 @@ from django.test import TestCase
 from paying_for_college.models import School, Contact, Program, Alias, Nickname
 from paying_for_college.models import ConstantCap, ConstantRate, Disclosure
 from paying_for_college.models import Notification, print_vals
-from paying_for_college.models import get_region, make_even
+from paying_for_college.models import get_region, make_divisible_by_6
 
 
-class MakeEvenTest(TestCase):
+class MakeDivisibleTest(TestCase):
 
-    def test_make_even(self):
+    def test_make_divisible(self):
         test_value = ''
-        self.assertTrue(make_even(test_value) == test_value)
+        self.assertTrue(make_divisible_by_6(test_value) == test_value)
         test_value = 0
-        self.assertTrue(make_even(test_value) == test_value)
+        self.assertTrue(make_divisible_by_6(test_value) == test_value)
+        test_value = 1
+        self.assertTrue(make_divisible_by_6(test_value) == 6)
         test_value = 3
-        self.assertTrue(make_even(test_value) == 4)
+        self.assertTrue(make_divisible_by_6(test_value) == 6)
+        test_value = 45
+        self.assertTrue(make_divisible_by_6(test_value) == 48)
 
 
 class SchoolRegionTest(TestCase):


### PR DESCRIPTION
We need program lengths to fit into half-year chunks, so this makes sure
any program lengths (which are in months) are divisible by 6. We round
up to the next-bigger divisible-by-6 number to accomplish this.
## Additions
- make_divisible_by_6 model function
- related test
## Removals
- make_even model function
## Changes
- Alters the Program "as_json" function to use "divisible_by_6"
## Testing

This school should work now, and its program API call should show 42 months, not 40:
- [standalone disclosure for Argosy Inland Empire](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=450526&pid=3353&oid=9e0280139f3238cbc1702c7b0d62e5c238a835d0&book=10000&gib=6000&gpl=0&hous=20000&insi=1&insl=0&inst=1&mta=4500&othg=2000&othr=500&parl=0&pelg=4000&perl=0&prvf=0&prvi=8&prvl=0&ppl=0&schg=2000&stag=2000&subl=1000&totl=62775&tran=5000&tuit=30000&unsl=1000&wkst=0)
- [standalone API call for that program](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/program/450526_3353/)
## Review
- @amymok  @marteki @mistergone 
## Checklist
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
