### PR TITLE
Ipeds fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
 - Show recalculation updates on mobile screens
+- Added a file-exists check to update_ipeds script
 
 ## 2.1.4
 - Added string checking for program codes

--- a/paying_for_college/disclosures/scripts/update_ipeds.py
+++ b/paying_for_college/disclosures/scripts/update_ipeds.py
@@ -91,13 +91,6 @@ def download_zip_file(url, zip_file):
         return False
 
 
-def read_csv(fpath):
-    with open(fpath, 'r') as f:
-        reader = cdr(f)
-        data = [row for row in reader]
-    return reader.fieldnames, data
-
-
 def write_clean_csv(fpath, fieldnames, clean_headings, data):
     with open(fpath, 'w') as f:
         writer = cwriter(f)
@@ -132,9 +125,17 @@ def download_files():
     clean_csv_headings()
 
 
+def read_csv(fpath):
+    if not os.path.isfile(fpath):
+        download_files()
+    with open(fpath, 'r') as f:
+        reader = cdr(f)
+        data = [row for row in reader]
+        return reader.fieldnames, data
+
+
 def process_datafiles():
     """Collect data points from 2 IPEDS csvs and deliver them as a dict"""
-    download_files()
     collector = {}
     snames, service_data = read_csv(DATA_VARS['services_cleaned'])
     for row in service_data:

--- a/paying_for_college/disclosures/scripts/update_ipeds.py
+++ b/paying_for_college/disclosures/scripts/update_ipeds.py
@@ -134,6 +134,7 @@ def download_files():
 
 def process_datafiles():
     """Collect data points from 2 IPEDS csvs and deliver them as a dict"""
+    download_files()
     collector = {}
     snames, service_data = read_csv(DATA_VARS['services_cleaned'])
     for row in service_data:

--- a/paying_for_college/tests/test_scripts.py
+++ b/paying_for_college/tests/test_scripts.py
@@ -155,16 +155,19 @@ class TestScripts(django.test.TestCase):
     def test_write_clean_csv(self):
         m = mock_open()
         with patch("__builtin__.open", m, create=True):
-            update_ipeds.write_clean_csv('mockfile.csv',
+            update_ipeds.write_clean_csv('/tmp/mockfile.csv',
                                          ['a ', ' b', ' c '],
                                          ['a', 'b', 'c'],
                                          [{'a ': 'd', ' b': 'e', ' c ': 'f'}])
         self.assertTrue(m.call_count == 1)
 
-    def test_read_csv(self):
+    @mock.patch('paying_for_college.disclosures.scripts.'
+                'update_ipeds.download_files')
+    def test_read_csv(self, mock_download):
         m = mock_open(read_data='a , b, c \nd,e,f')
         with patch("__builtin__.open", m, create=True):
             fieldnames, data = update_ipeds.read_csv('mockfile.csv')
+        self.assertTrue(mock_download.call_count == 1)
         self.assertTrue(m.call_count == 1)
         self.assertTrue(fieldnames == ['a ', ' b', ' c '])
         self.assertTrue(data == [{'a ': 'd', ' b': 'e', ' c ': 'f'}])

--- a/setup.py
+++ b/setup.py
@@ -63,9 +63,10 @@ setup(
     maintainer_email='tech@cfpb.gov',
     packages=find_packages(),
     package_data={'paying_for_college':
-                  ['fixtures/*.json',
-                   'templates/*.html',
+                  ['data_sources/ipeds/*cleaned.csv',
+                   'fixtures/*.json',
                    'templates/*.txt',
+                   'templates/*.html',
                    'static/paying_for_college/disclosures/static/css/*.css',
                    'static/paying_for_college/disclosures/static/css/*.map',
                    'static/paying_for_college/disclosures/static/fonts/*.eot',
@@ -77,7 +78,7 @@ setup(
                    'static/paying_for_college/disclosures/static/js/*.map',
                    'static/paying_for_college/disclosures/static/img/*.png',
                    ],
-    },
+                  },
     include_package_data=True,
     description=u'College cost tools',
     classifiers=[


### PR DESCRIPTION
This makes our IPEDS downloader check for an existing CSV before downloading and parsing a new one. Since we only need to run once a year, if it runs again there's no need to download raw files again.
## Additions
- Adds a file-exists check to the `read_csv` function
## Changes
- Adjusts tests to match, plus pep8 tweaks
## Review
- @amymok 
## Checklist
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
