### PR TITLE
Updates program length copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Changed the Contact model's 'contact' field to a 'contacts' field to allow multiple school contacts
 - Fixes for gradPlus fields, tuition payment plans, and the expenses section
 - Fixes for 0% interest rates, perkins visibility, and grad overcap messages
+- Update debt summary text for program durations less than one year.
 
 ## 2.1.4
 - Added string checking for program codes

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -1752,7 +1752,7 @@
                                 total cost of these loans after <span
                                 data-currency="false"
                                 data-financial="yearsAttending">[XX]</span>
-                                years plus interest and fees equals <span
+                                plus interest and fees equals <span
                                 id="future_total-debt"
                                 data-financial="loanLifetime">[XX]</span>.
                             </p>
@@ -1867,7 +1867,7 @@
                                         data-financial="yearsAttending"
                                         data-currency="false"
                                         >[XX]
-                                        </span> years (program length)
+                                        </span> (program length)
                                     </div>
                                     <div class="line-item_value">
                                         <span class="line-item_currency">

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -517,12 +517,23 @@ var financialView = {
    */
   estimatedYearsListener: function() {
     this.$programLength.on( 'change', function() {
-      var programLength = Number( $( this ).val() ),
-          values = getFinancial.values(),
-          yearsAttending = numberToWords.toWords( programLength );
-      if ( programLength % 1 !== 0 ) {
+      var programLength = Number( $( this ).val() );
+      var values = getFinancial.values();
+      var yearsAttending = numberToWords.toWords( programLength );
+
+      // Formats summary text, such as "half a year" or "one and a half years."
+      if ( programLength === 0.5 ) {
+        yearsAttending = 'half a';
+      } else if ( programLength % 1 !== 0 ) {
         yearsAttending += ' and a half';
       }
+
+      if ( programLength > 1 ) {
+        yearsAttending += ' years';
+      } else {
+        yearsAttending += ' year';
+      }
+
       publish.financialData( 'programLength', programLength );
       publish.financialData( 'yearsAttending', yearsAttending );
       financialView.updateView( values );


### PR DESCRIPTION
## Changes
- Update debt summary text for program durations less than one year.
## Testing
- `gulp build`
- Visit URL with data loaded.
- Select 6 months from estimated years to complete drop-down. 
- Scroll to bottom of page and see the `Loans for half a year (program length)` text in debt summary.
- Change the years to 1 year and to 1.5 years and see the updated summary text in debt summary.
## Review
- @mistergone 
- @marteki 
- @higs4281 
- @amymok 
## Screenshots

![screen shot 2016-07-25 at 2 34 08 pm](https://cloud.githubusercontent.com/assets/704760/17114121/918674c2-527b-11e6-8542-f91c170e7fc4.png)

![screen shot 2016-07-25 at 2 31 27 pm](https://cloud.githubusercontent.com/assets/704760/17114120/918502a4-527b-11e6-903c-51d658b11909.png)
## Notes
- Moves `years` text inside the yearsAttending span tag. I didn't see a problem with this.
