### PR TITLE
Mark all EDMC schools as non-Perkins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Changed the Contact model's 'contact' field to a 'contacts' field to allow multiple school contacts
 - Fixes for gradPlus fields, tuition payment plans, and the expenses section
 - Fixes for 0% interest rates, perkins visibility, and grad overcap messages
+- Updated collegedata fixture to make sure all EDMC schools are marked as non-Perkins
 
 ## 2.1.4
 - Added string checking for program codes

--- a/paying_for_college/disclosures/scripts/update_ipeds.py
+++ b/paying_for_college/disclosures/scripts/update_ipeds.py
@@ -67,6 +67,10 @@ DATA_POINTS = {
     'tuitionUnderInDis': 'TUITION1'
 }
 
+STARTER_DICT = {key.upper(): None for key in DATA_POINTS}
+STARTER_DICT['ROOM'] = None
+STARTER_DATA_JSON = json.dumps(STARTER_DICT)
+
 NEW_SCHOOL_DATA_POINTS = {
     "alias": "INSTNM",
     "city": "CITY",
@@ -189,7 +193,7 @@ def create_alias(alias, school):
 
 
 def create_school(id, data):
-    school = School(school_id=id, data_json=json.dumps({}))
+    school = School(school_id=id, data_json=STARTER_DATA_JSON)
     for field in data:
         if field == 'alias':
             ALIAS = data['alias']
@@ -233,7 +237,10 @@ def load_values(dry_run=True):
         if school:
             school_data = json.loads(school.data_json)
             for data_key in new_data:
-                school_data[data_key.upper()] = new_data[data_key]
+                val = new_data[data_key]
+                if val == '.':
+                    val = None
+                school_data[data_key.upper()] = val
                 points += 1
             school.data_json = json.dumps(school_data)
             if not dry_run:

--- a/paying_for_college/tests/test_scripts.py
+++ b/paying_for_college/tests/test_scripts.py
@@ -284,7 +284,8 @@ class TestScripts(django.test.TestCase):
         msg = update_ipeds.load_values()
         self.assertTrue('DRY' in msg)
         self.assertTrue(mock_process.call_count == 1)
-        mock_process.return_value = {'243197': {'onCampusAvail': '2'}}
+        mock_process.return_value = {'243197': {'onCampusAvail': '2',
+                                                'books': '.'}}
         msg = update_ipeds.load_values()
         self.assertTrue('DRY' in msg)
         self.assertTrue(mock_process.call_count == 2)


### PR DESCRIPTION
This is mostly a data fixture update, but it also cleans up
an IPEDS data_json loading issue and some related tests.
The Department of Ed spreadsheet we used to identify Perkins schools
was for 2014-2015, the latest available, but it turns out EDMC schools
were denied access to Perkins loans since then. Thus this PR updates
all EDMC schools to make sure their `offersPerkins` value is `false`.
## Changes
- collegedata.json updated
- update_ipeds script tweaked to make sure new schools get a base data_json string to avoid key errors when calling the API.
## Testing
- run `./manage.py loaddata collegedata` and then check the [Art Institute of Colorado](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/school/126702/), which should show `offersPerkins: false`  
  On [build](http://build.consumerfinance.gov/paying-for-college2/understanding-your-financial-aid-offer/api/school/126702/) AI Colorado currently shows `true`
## Review
- @amymok
## Checklist
- [x] [Project documentation](https://github.cfpb.gov/paying-for-college/dynamic-disclosures-documentation/wiki/Perkins-data-intake) and CHANGELOG updated
