### PR TITLE
Add a private loan fee value to our constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Fixes for 0% interest rates, perkins visibility, and grad overcap messages
 - Updated collegedata fixture to make sure all EDMC schools are marked as non-Perkins
 - Update debt summary text for program durations less than one year.
+- Added privateLoanFee constant to the database
 
 ## 2.1.4
 - Added string checking for program codes


### PR DESCRIPTION
Following up on a [PR comment](https://github.com/cfpb/college-costs/pull/182#issuecomment-226844101) by Patrick about future-proofing, this gives us a future home for private loan fees, if they ever become a thing. 
The current value is 0, because we're not aware of any private loans that are charging fee points.
## Additions
- New constant, `privateLoanFee`, with an initial value of 0.
- This affects only our database content -- no code.
## Testing
- After pulling and running `./manage.py loaddata collegedata`, `privateLoanFee` should show up in [constants](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/constants/)
## Review
- @saintsoup52 @amymok 
## Screenshots

<img width="281" alt="private_loan_fee" src="https://cloud.githubusercontent.com/assets/515885/17196470/d03d17ee-5432-11e6-900d-f3f1423bebb7.png">
## Checklist
- [x] CHANGELOG updated
