### PR TITLE
Add unicode-aware csv handling

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,7 @@ omit =
     */python2.7/*
     *setup.py
     */data_sources/*
+    */csvkit/*
 
 [report]
 exclude_lines = 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Fixes for 0% interest rates, perkins visibility, and grad overcap messages
 - Updated collegedata fixture to make sure all EDMC schools are marked as non-Perkins
 - Update debt summary text for program durations less than one year.
+- Added unicode-aware csv module
 
 ## 2.1.4
 - Added string checking for program codes

--- a/paying_for_college/csvkit/csvkit.py
+++ b/paying_for_college/csvkit/csvkit.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python
+
+"""
+This module is borrowed from the mighty csvkit tool,
+which is now part of [agate](https://github.com/wireservice/agate)
+"""
+import codecs
+import csv
+
+import six
+
+EIGHT_BIT_ENCODINGS = [
+    'utf-8', 'u8', 'utf', 'utf8',
+    'latin-1', 'iso-8859-1', 'iso8859-1', '8859', 'cp819', 'latin', 'latin1', 'l1'
+]
+
+POSSIBLE_DELIMITERS = [',', '\t', ';', ' ', ':', '|']
+
+
+class FieldSizeLimitError(Exception):  # pragma: no cover
+    """
+    A field in a CSV file exceeds the maximum length.
+    This length may be the default or one set by the user.
+    """
+    def __init__(self, limit):
+        super(FieldSizeLimitError, self).__init__(
+            'CSV contains fields longer than maximum length of %i characters. Try raising the maximum with the field_size_limit parameter, or try setting quoting=csv.QUOTE_NONE.' % limit
+        )
+
+
+class UTF8Recoder(six.Iterator):
+    """
+    Iterator that reads an encoded stream and reencodes the input to UTF-8.
+    """
+    def __init__(self, f, encoding):
+        self.reader = codecs.getreader(encoding)(f)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self.reader).encode('utf-8')
+
+
+class UnicodeReader(object):
+    """
+    A CSV reader which will read rows from a file in a given encoding.
+    """
+    def __init__(self, f, encoding='utf-8', field_size_limit=None, line_numbers=False, header=True, **kwargs):
+        self.line_numbers = line_numbers
+        self.header = header
+
+        f = UTF8Recoder(f, encoding)
+
+        self.reader = csv.reader(f, **kwargs)
+
+        if field_size_limit:
+            csv.field_size_limit(field_size_limit)
+
+    def next(self):
+        try:
+            row = next(self.reader)
+        except csv.Error as e:
+            # Terrible way to test for this exception, but there is no subclass
+            if 'field larger than field limit' in str(e):
+                raise FieldSizeLimitError(csv.field_size_limit())
+            else:
+                raise e
+
+        if self.line_numbers:
+            if self.header and self.line_num == 1:
+                row.insert(0, 'line_numbers')
+            else:
+                row.insert(0, str(self.line_num - 1 if self.header else self.line_num))
+
+        return [six.text_type(s, 'utf-8') for s in row]
+
+    def __iter__(self):
+        return self
+
+    @property
+    def dialect(self):
+        return self.reader.dialect
+
+    @property
+    def line_num(self):
+        return self.reader.line_num
+
+
+class UnicodeWriter(object):
+    """
+    A CSV writer which will write rows to a file in the specified encoding.
+
+    NB: Optimized so that eight-bit encodings skip re-encoding. See:
+        https://github.com/onyxfish/csvkit/issues/175
+    """
+    def __init__(self, f, encoding='utf-8', **kwargs):
+        self.encoding = encoding
+        self._eight_bit = (self.encoding.lower().replace('_', '-') in EIGHT_BIT_ENCODINGS)
+
+        if self._eight_bit:
+            self.writer = csv.writer(f, **kwargs)
+        else:
+            # Redirect output to a queue for reencoding
+            self.queue = six.StringIO()
+            self.writer = csv.writer(self.queue, **kwargs)
+            self.stream = f
+            self.encoder = codecs.getincrementalencoder(encoding)()
+
+    def writerow(self, row):
+        if self._eight_bit:
+            self.writer.writerow([six.text_type(s if s is not None else '').encode(self.encoding) for s in row])
+        else:
+            self.writer.writerow([six.text_type(s if s is not None else '').encode('utf-8') for s in row])
+            # Fetch UTF-8 output from the queue...
+            data = self.queue.getvalue()
+            data = data.decode('utf-8')
+            # ...and reencode it into the target encoding
+            data = self.encoder.encode(data)
+            # write to the file
+            self.stream.write(data)
+            # empty the queue
+            self.queue.truncate(0)
+
+    def writerows(self, rows):
+        for row in rows:
+            self.writerow(row)
+
+
+class UnicodeDictReader(csv.DictReader):
+    """
+    Defer almost all implementation to :class:`csv.DictReader`, but wraps our
+    unicode reader instead of :func:`csv.reader`.
+    """
+    def __init__(self, f, fieldnames=None, restkey=None, restval=None, *args, **kwargs):
+        reader = UnicodeReader(f, *args, **kwargs)
+
+        if 'encoding' in kwargs:
+            kwargs.pop('encoding')
+
+        csv.DictReader.__init__(self, f, fieldnames, restkey, restval, *args, **kwargs)
+
+        self.reader = reader
+
+
+class UnicodeDictWriter(csv.DictWriter):
+    """
+    Defer almost all implementation to :class:`csv.DictWriter`, but wraps our
+    unicode writer instead of :func:`csv.writer`.
+    """
+    def __init__(self, f, fieldnames, restval='', extrasaction='raise', *args, **kwds):
+        self.fieldnames = fieldnames
+        self.restval = restval
+
+        if extrasaction.lower() not in ('raise', 'ignore'):
+            raise ValueError('extrasaction (%s) must be "raise" or "ignore"' % extrasaction)
+
+        self.extrasaction = extrasaction
+
+        self.writer = UnicodeWriter(f, *args, **kwds)
+
+
+class Reader(UnicodeReader):
+    """
+    A unicode-aware CSV reader.
+    """
+    pass
+
+
+class Writer(UnicodeWriter):
+    """
+    A unicode-aware CSV writer.
+    """
+    def __init__(self, f, encoding='utf-8', line_numbers=False, **kwargs):
+        self.row_count = 0
+        self.line_numbers = line_numbers
+
+        if 'lineterminator' not in kwargs:
+            kwargs['lineterminator'] = '\n'
+
+        UnicodeWriter.__init__(self, f, encoding, **kwargs)
+
+    def _append_line_number(self, row):
+        if self.row_count == 0:
+            row.insert(0, 'line_number')
+        else:
+            row.insert(0, self.row_count)
+
+        self.row_count += 1
+
+    def writerow(self, row):
+        if self.line_numbers:
+            row = list(row)
+            self._append_line_number(row)
+
+        # Convert embedded Mac line endings to unix style line endings so they get quoted
+        row = [i.replace('\r', '\n') if isinstance(i, six.string_types) else i for i in row]
+
+        UnicodeWriter.writerow(self, row)
+
+    def writerows(self, rows):
+        for row in rows:
+            self.writerow(row)
+
+
+class DictReader(UnicodeDictReader):
+    """
+    A unicode-aware CSV DictReader.
+    """
+    pass
+
+
+class DictWriter(UnicodeDictWriter):
+    """
+    A unicode-aware CSV DictWriter.
+    """
+    def __init__(self, f, fieldnames, encoding='utf-8', line_numbers=False, **kwargs):
+        self.row_count = 0
+        self.line_numbers = line_numbers
+
+        if 'lineterminator' not in kwargs:
+            kwargs['lineterminator'] = '\n'
+
+        UnicodeDictWriter.__init__(self, f, fieldnames, encoding=encoding, **kwargs)
+
+    def _append_line_number(self, row):
+        if self.row_count == 0:
+            row['line_number'] = 0
+        else:
+            row['line_number'] = self.row_count
+
+        self.row_count += 1
+
+    def writerow(self, row):
+        if self.line_numbers:
+            row = list(row)
+            self._append_line_number(row)
+
+        # Convert embedded Mac line endings to unix style line endings so they get quoted
+        row = dict([(k, v.replace('\r', '\n')) if isinstance(v, basestring) else (k, v) for k, v in row.items()])
+
+        UnicodeDictWriter.writerow(self, row)
+
+    def writerows(self, rows):
+        for row in rows:
+            self.writerow(row)
+
+
+class Sniffer(object):
+    """
+    A functinonal wrapper of ``csv.Sniffer()``.
+    """
+    def sniff(self, sample):
+        """
+        A functional version of ``csv.Sniffer().sniff``, that extends the
+        list of possible delimiters to include some seen in the wild.
+        """
+        try:
+            dialect = csv.Sniffer().sniff(sample, POSSIBLE_DELIMITERS)
+        except:
+            dialect = None
+
+        return dialect
+
+
+def reader(*args, **kwargs):
+    """
+    A replacement for Python's :func:`csv.reader` that uses
+    :class:`.csv_py2.Reader`.
+    """
+    return Reader(*args, **kwargs)
+
+
+def writer(*args, **kwargs):
+    """
+    A replacement for Python's :func:`csv.writer` that uses
+    :class:`.csv_py2.Writer`.
+    """
+    return Writer(*args, **kwargs)

--- a/paying_for_college/data_sources/bls_processing.py
+++ b/paying_for_college/data_sources/bls_processing.py
@@ -1,6 +1,6 @@
 import json
-from csv import DictReader as cdr
 
+from paying_for_college.csvkit.csvkit import DictReader as cdr
 from paying_for_college.models import School
 
 """
@@ -98,7 +98,6 @@ def add_bls_dict_with_region(base_bls_dict, region, csvfile):
                 print "amount: {}".format(amount)
                 base_bls_dict[CATEGORIES_KEY_MAP[item]][region].setdefault(income_json_key, 0)
                 base_bls_dict[CATEGORIES_KEY_MAP[item]][region][income_json_key] += amount
-
 
 
 def bls_as_dict(we_csvfile, ne_csvfile, mw_csvfile, so_csvfile):

--- a/paying_for_college/data_sources/perkins_processing.py
+++ b/paying_for_college/data_sources/perkins_processing.py
@@ -1,5 +1,4 @@
-from csv import DictReader as cdr
-
+from paying_for_college.csvkit.csvkit import DictReader as cdr
 from paying_for_college.models import School
 
 """

--- a/paying_for_college/disclosures/scripts/load_programs.py
+++ b/paying_for_college/disclosures/scripts/load_programs.py
@@ -1,13 +1,9 @@
 from __future__ import print_function
 import os
 
-try:
-    from csvkit import CSVKitDictReader as cdr
-except:
-    from csv import DictReader as cdr
-# from csv import DictReader as cdr
 from rest_framework import serializers
 
+from paying_for_college.csvkit.csvkit import DictReader as cdr
 from paying_for_college.models import Program, School
 from paying_for_college.views import validate_pid
 

--- a/paying_for_college/disclosures/scripts/update_ipeds.py
+++ b/paying_for_college/disclosures/scripts/update_ipeds.py
@@ -7,15 +7,18 @@ from subprocess import call
 
 import requests
 from unipath import Path
-try:
-    from csvkit import CSVKitDictReader as cdr
-except:  # pragma: no cover
-    from csv import DictReader as cdr
-try:
-    from csvkit import CSVKitWriter as cwriter
-except:  # pragma: no cover
-    from csv import writer as cwriter
 
+# try:
+#     from csvkit import CSVKitDictReader as cdr
+# except:  # pragma: no cover
+#     from csv import DictReader as cdr
+# try:
+#     from csvkit import CSVKitWriter as cwriter
+# except:  # pragma: no cover
+#     from csv import writer as cwriter
+
+from paying_for_college.csvkit.csvkit import DictReader as cdr
+from paying_for_college.csvkit.csvkit import Writer as cwriter
 from paying_for_college.views import get_school
 from paying_for_college.models import School, Alias
 from django.contrib.humanize.templatetags.humanize import intcomma

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,4 +7,4 @@ PyYAML==3.11
 elasticsearch==2.3.0
 csvkit==0.9.1
 djangorestframework==3.3.3
-
+six==1.10.0


### PR DESCRIPTION
The csv reader and writer classes from the csvkit python package  provide 
more reliable handling of encoding issues by reading in unicode by default, 
including encoding options for reading files, and writing out utf-8 by default.
csvkit and its successor, agate, carry some heavy dependencies and 
would be overkill for this app's needs.
## Additions
- csvkit reader and writer classes
## Removals
- dependencies on full csvkit package
## Review
- @amymok 
## Checklist
- [x] CHANGELOG updated
