### PR TITLE
Minor linter update/fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,38 @@
+# Enable ecmascript 6 features.
+ecmaFeatures:
+  arrowFunctions: false
+  binaryLiterals: false
+  blockBindings: false
+  classes: false
+  defaultParams: false
+  destructuring: false
+  forOf: true
+  generators: false
+  modules: false
+  objectLiteralComputedProperties: false
+  objectLiteralDuplicateProperties: false
+  objectLiteralShorthandMethods: false
+  objectLiteralShorthandProperties: false
+  octalLiterals: false
+  regexUFlag: false
+  regexYFlag: false
+  restParams: true
+  spread: false
+  superInFunctions: false
+  templateStrings: false
+  unicodeCodePointEscapes: false
+  globalReturn: false
+  jsx: true
+  experimentalObjectRestSpread: false
+
 parser: espree
 
 env:
   browser: true
   node: true
   commonjs: false
+  shared-node-browser: true
+  es6: true
   worker: false
   amd: true
   mocha: false
@@ -19,8 +48,10 @@ env:
   mongo: false
   applescript: false
   serviceworker: true
+  atomtest: false
   embertest: false
-  es6: false
+  webextensions: false
+  greasemonkey: false
 
 globals:
   $: false
@@ -32,15 +63,9 @@ rules:
 
   # Rules for flagging POSSIBLE ERRORS.
 
-  # Consistent use of trailing commas in object and array literals.
-  # This rule is needed for IE8- support.
-  comma-dangle:
-    - 2
-    - never
-
   # Disallows assignment in conditional expressions.
   no-cond-assign:
-    - 1
+    - 2
     - except-parens
 
   # Enforces flagging use of the console.
@@ -104,6 +129,9 @@ rules:
   # Disallows use of the global Math and JSON objects as functions.
   no-obj-calls: 2
 
+  # Disallow use of Object.prototypes builtins directly.
+  no-prototype-builtins: 0
+
   # Disallows multiple spaces in a regular expression literal.
   no-regex-spaces: 2
 
@@ -111,8 +139,14 @@ rules:
   # Array values should be explicitly defined.
   no-sparse-arrays: 2
 
+  # Disallow confusing multiline expressions.
+  no-unexpected-multiline: 2
+
   # Disallows unreachable statements after a return, throw, continue, or break.
   no-unreachable: 2
+
+  # Disallow control flow statements in finally blocks.
+  no-unsafe-finally: 2
 
   # Disallows comparisons with the value NaN.
   use-isnan: 2
@@ -126,12 +160,10 @@ rules:
       requireReturn: false
       requireParamDescription: true
       requireReturnDescription: true
+      requireReturnType: true
 
   # Enforces that the results of typeof are compared against a valid string.
   valid-typeof: 2
-
-  # Avoid code that looks like two expressions but is actually one.
-  no-unexpected-multiline: 2
 
 
   # Rules for encouraging BEST PRACTICES.
@@ -141,6 +173,9 @@ rules:
     - 1
     -
       getWithoutSet: false
+
+  # Enforces return statements in callbacks of array's methods.
+  array-callback-return: 2
 
   # Enforces treating var statements as if they were block scoped.
   block-scoped-var: 1
@@ -157,9 +192,15 @@ rules:
   curly:
     - 1
     - multi-line
+    - consistent
 
   # Enforces default case in switch statements.
   default-case: 2
+
+  # Enforces consistent newlines before or after dots.
+  dot-location:
+    - 2
+    - property
 
   # Enforces use of dot notation whenever possible.
   # `allowKeywords` = false follows ECMAScript version 3 compatible style.
@@ -168,11 +209,6 @@ rules:
     -
       allowKeywords: false
       allowPattern: ''
-
-  # Enforces consistent newlines before or after dots.
-  dot-location:
-    - 2
-    - property
 
   # Enforces use of === and !== over == and !=.
   eqeqeq:
@@ -188,11 +224,20 @@ rules:
   # Disallows use of arguments.caller or arguments.callee.
   no-caller: 2
 
+  # Disallow lexical declarations in case clauses.
+  no-case-declarations: 2
+
   # Disallows division operators explicitly at beginning of regex.
   no-div-regex: 2
 
   # Disallows else after a return in an if.
   no-else-return: 2
+
+  # Disallow use of empty functions.
+  no-empty-function: 2
+
+  # Disallow use of empty destructuring patterns.
+  no-empty-pattern: 2
 
   # Disallows comparisons to null without a type-checking operator.
   no-eq-null: 2
@@ -205,6 +250,9 @@ rules:
 
   # Disallows unnecessary function binding.
   no-extra-bind: 2
+
+  # Disallow unnecessary labels.
+  no-extra-label: 2
 
   # Disallows fallthrough of case statements.
   no-fallthrough: 1
@@ -220,6 +268,9 @@ rules:
       number: true
       string: true
 
+  # Disallow var and named functions in global scope.
+  no-implicit-globals: 2
+
   # Disallows use of eval()-like methods.
   no-implied-eval: 2
 
@@ -230,17 +281,21 @@ rules:
   no-iterator: 2
 
   # Disallows use of labeled statements.
-  no-labels:
-    - 2
-    -
-      allowLoop: true
-      allowSwitch: true
+  no-labels: 2
 
   # Disallows unnecessary nested blocks.
   no-lone-blocks: 2
 
   # Disallows creation of functions within loops.
   no-loop-func: 2
+
+  # Disallow the use of magic numbers.
+  no-magic-numbers:
+    - 0
+    -
+      ignoreArrayIndexes: true
+      enforceConst: true
+      detectObjects: true
 
   # Disallows use of multiple spaces.
   no-multi-spaces:
@@ -278,10 +333,6 @@ rules:
     -
       props: false
 
-  # Disallows use of process.env.
-  # Only applicable to Node.js.
-  no-process-env: 2
-
   # Disallows usage of __proto__ property.
   no-proto: 2
 
@@ -296,6 +347,9 @@ rules:
   # Disallows use of javascript: urls.
   no-script-url: 2
 
+  # Disallow assignments where both sides are exactly the same.
+  no-self-assign: 2
+
   # Disallows comparisons where both sides are exactly the same.
   no-self-compare: 2
 
@@ -305,17 +359,26 @@ rules:
   # Restrict what can be thrown as an exception.
   no-throw-literal: 2
 
+  # Disallow unmodified conditions of loops.
+  no-unmodified-loop-condition: 2
+
   # Disallows usage of expressions in statement position.
   no-unused-expressions: 2
+
+  # Disallow unused labels.
+  no-unused-labels: 2
 
   # Disallow unnecessary .call() and .apply().
   no-useless-call: 2
 
-  # Disallows use of void operator.
-  no-void: 2
-
   # Disallow unnecessary concatenation of literals or template literals.
   no-useless-concat: 2
+
+  # Disallow unnecessary escape characters.
+  no-useless-escape: 1
+
+  # Disallows use of void operator.
+  no-void: 2
 
   # Disallows use of configurable warning terms in comments, e. g. TODO.
   no-warning-comments:
@@ -354,6 +417,7 @@ rules:
   # Rules for STRICT MODE.
 
   # Controls location of Use Strict Directives.
+  # Ensures all function bodies are strict mode code, while global code is not.
   # Caveat: when run on pre-concatenated code, global mode may look like
   # function mode after concatenation.
   strict:
@@ -362,6 +426,9 @@ rules:
 
 
   # Rules for VARIABLES.
+
+  # Require or disallow initialization in var declarations.
+  init-declarations: 0
 
   # Disallows the catch clause parameter name being the same as a variable
   # in the outer scope.
@@ -374,17 +441,25 @@ rules:
   # Disallows labels that share a name with a variable.
   no-label-var: 2
 
+  # Disallow specified global variables.
+  no-restricted-globals: 2
+
   # Disallows shadowing of names such as arguments.
   no-shadow-restricted-names: 2
 
   # Disallows declaring variables already declared in the outer scope.
-  no-shadow: 1
+  no-shadow:
+    - 1
+    -
+      hoist: functions
 
   # Disallows use of undefined when initializing variables.
   no-undef-init: 2
 
   # Disallows use of undeclared vars unless mentioned in a /*global */ block.
-  no-undef: 2
+  no-undef:
+    - 2
+    - typeof: true
 
   # Disallows use of undefined variable.
   no-undefined: 2
@@ -394,15 +469,21 @@ rules:
     - 1
     -
       vars: all
+      varsIgnorePattern: ''
       args: after-used
+      argsIgnorePattern: ''
+      caughtErrors: 'none'
+      caughtErrorsIgnorePattern: ''
 
   # Disallows use of variables before they are defined.
   no-use-before-define:
     - 2
-    - nofunc
+    -
+      functions: false
+      classes: true
 
 
-  # Rules for NODE.JS.
+  # Rules for Node.js and CommonJS.
 
   # Enforce return after a callback.
   # callback, cb, and next are possible callback function names.
@@ -426,13 +507,19 @@ rules:
   # This rule may have inaccurate behavior in Node 0.6- and if UMD is used.
   no-mixed-requires:
     - 1
-    - true
+    -
+      grouping: true
+      allowCall: true
 
   # Disallows use of new operator with the require function.
   no-new-require: 2
 
   # Disallows string concatenation with __dirname and __filename.
   no-path-concat: 2
+
+  # Disallows use of process.env.
+  # Only applicable to Node.js.
+  no-process-env: 2
 
   # Disallows use of process.exit().
   no-process-exit: 1
@@ -470,6 +557,12 @@ rules:
     -
       properties: always
 
+  # Consistent use of trailing commas in object and array literals.
+  # This rule is needed for IE8- support.
+  comma-dangle:
+    - 2
+    - never
+
   # Enforce spacing before and after comma.
   comma-spacing:
     - 2
@@ -492,9 +585,12 @@ rules:
   # matching value in the future for the ^[_]?self regex.
   consistent-this:
     - 0
+    - 'self'
 
   # Enforce newline at the end of file, with no multiple empty lines.
-  eol-last: 2
+  eol-last:
+    - 2
+    - unix
 
   # Enforce function expressions not having a name.
   func-names: 0
@@ -504,6 +600,13 @@ rules:
   func-style:
     - 1
     - declaration
+    -
+      allowArrowFunctions: true
+
+  # Blacklist certain identifiers to prevent them being used.
+  id-blacklist:
+    - 1
+    - e
 
   # Enforces min/max identifier lengths (variable names, property names etc.).
   id-length:
@@ -514,6 +617,13 @@ rules:
       properties: never
       exceptions:
         - i
+
+  # Require identifiers to match the provided regular expression.
+  id-match:
+    - 0
+    - '^[a-z]+([A-Z][a-z]+)*$'
+    -
+      properties: false
 
   # Set a specific tab width for your code.
   indent:
@@ -539,12 +649,16 @@ rules:
       afterColon: true
       mode: minimum
 
-  # Requires a space around certain keywords.
+  # Enforce consistent spacing among keys/values in object literal properties.
   keyword-spacing:
-    - 2
+    - 1
     -
       before: true
-      after: true
+
+  # Disallow mixed 'LF' and 'CRLF' as linebreaks.
+  linebreak-style:
+    - 2
+    - unix
 
   # Enforces empty lines around comments.
   lines-around-comment:
@@ -557,15 +671,53 @@ rules:
       allowBlockStart: false
       allowBlockEnd: false
 
-  # Disallow mixed 'LF' and 'CRLF' as linebreaks.
-  linebreak-style:
-    - 2
-    - unix
+  # Specifies maximum depth that blocks can be nested.
+  max-depth:
+    - 1
+    - 5
+
+  # Specifies maximum length of a line in your program.
+  max-len:
+    - 1
+    -
+      code: 80
+      tabWidth: 4
+      comments: 80
+      ignorePattern: ''
+      ignoreTrailingComments: true
+      ignoreUrls: true
+
+  # Enforce a maximum file length.
+  max-lines:
+    - 0
+    -
+      max: 300
+      skipBlankLines: true
+      skipComments: true
 
   # Specify the maximum depth callbacks can be nested.
   max-nested-callbacks:
     - 2
     - 3
+
+  # Limits number of parameters that can be used in the function declaration.
+  max-params:
+    - 1
+    - 5
+
+  # Enforce a maximum number of statements allowed per line.
+  max-statements-per-line:
+    - 1
+    -
+      max: 2
+
+  # Specifies maximum number of statement allowed in a function.
+  max-statements:
+    - 1
+    - 25
+
+  # Enforce newlines between operands of ternary expressions.
+  multiline-ternary: 0
 
   # Require a capital letter for constructors.
   new-cap:
@@ -584,8 +736,21 @@ rules:
     - 0
     - always
 
+  # Require or disallow an empty line after var declarations.
+  newline-before-return:
+    - 0
+
+  # Require a newline after each call in a method chain.
+  newline-per-chained-call:
+    - 0
+    -
+      ignoreChainWithDepth: 2
+
   # Disallows use of the Array constructor.
   no-array-constructor: 2
+
+  # Disallows use of bitwise operators.
+  no-bitwise: 0
 
   # Disallow use of the continue statement.
   no-continue: 1
@@ -596,6 +761,9 @@ rules:
   # Disallows if as the only statement in an else block.
   no-lonely-if: 2
 
+  # Disallow mixes of different operators.
+  no-mixed-operators: 1
+
   # Disallows mixed spaces and tabs for indentation.
   # Include "smart-tabs" option to suppresses warnings tabs used for alignment.
   no-mixed-spaces-and-tabs: 2
@@ -605,12 +773,20 @@ rules:
     - 1
     -
       max: 2
+      maxEOF: 1
+      maxBOF: 0
+
+  # Disallows negated conditions.
+  no-negated-condition: 2
 
   # Disallows nested ternary expressions.
   no-nested-ternary: 2
 
   # Disallows use of the Object constructor.
   no-new-object: 2
+
+  # Disallows use of unary operators, ++ and --.
+  no-plusplus: 0
 
   # Disallow use of certain syntax in code.
   no-restricted-syntax:
@@ -634,6 +810,16 @@ rules:
   # Disallow the use of Boolean literals in conditional expressions.
   no-unneeded-ternary: 0
 
+  # Disallow whitespace before properties.
+  no-whitespace-before-property: 2
+
+  # Enforce consistent line breaks inside braces.
+  object-curly-newline:
+    - 0
+    -
+      multiline: true
+      minProperties: 3
+
   # Require or disallow padding inside curly braces.
   object-curly-spacing:
     - 1
@@ -641,6 +827,17 @@ rules:
     -
       objectsInObjects: false
       arraysInObjects: false
+
+  # Enforce placing object properties on separate lines.
+  object-property-newline:
+    - 1
+    -
+      allowMultiplePropertiesPerLine: true
+
+  # Require or disallow an newline around variable declarations.
+  one-var-declaration-per-line:
+    - 2
+    - initializations
 
   # Disallows multiple var statements per function.
   one-var:
@@ -681,13 +878,6 @@ rules:
   require-jsdoc:
     - 1
 
-  # Require identifiers to match the provided regular expression.
-  id-match:
-    - 0
-    - '^[a-z]+([A-Z][a-z]+)*$'
-    -
-      properties: false
-
   # Disallows space before semicolon.
   semi-spacing:
     - 2
@@ -706,7 +896,10 @@ rules:
   # Requires space before blocks.
   space-before-blocks:
     - 2
-    - always
+    -
+      functions: always
+      keywords: always
+      classes: always
 
   # Requires space before function parentheses.
   space-before-function-paren:
@@ -738,11 +931,23 @@ rules:
     - 2
     - always
     -
-      exceptions:
-        - '-'
-        - +
-      markers:
-        - /
+      line:
+        markers:
+          - '/'
+        exceptions:
+          - '-'
+          - '+'
+      block:
+        markers:
+          - '!'
+        exceptions:
+          - '*'
+        balanced: true
+
+  # Require or disallow the Unicode BOM.
+  unicode-bom:
+    - 2
+    - never
 
   # Requires regex literals to be wrapped in parentheses.
   wrap-regex: 2
@@ -751,8 +956,15 @@ rules:
   # Rules for ECMASCRIPT 6.
   # These rules are only relevant to ES6 environments.
 
+  # Require braces in arrow function body.
+  arrow-body-style:
+    - 2
+    - as-needed
+
   # Require parens in arrow function arguments.
-  arrow-parens: 2
+  arrow-parens:
+    - 2
+    - as-needed
 
   # Require space before/after arrow function's arrow.
   arrow-spacing:
@@ -774,14 +986,47 @@ rules:
   # Disallow modifying variables of class declarations.
   no-class-assign: 2
 
+  # Disallow arrow functions where they could be confused with comparisons.
+  no-confusing-arrow:
+    - 1
+    -
+      allowParens: true
+
   # Disallow modifying variables that are declared using const.
   no-const-assign: 2
 
   # Disallow duplicate name in class members.
   no-dupe-class-members: 2
 
+  # Disallow duplicate module imports.
+  no-duplicate-imports:
+    - 2
+    -
+      includeExports: true
+
+  # Disallow use of the new operator with the Symbol object.
+  # This rule should not be used in ES3/5 environments.
+  no-new-symbol: 0
+
+  # Restrict usage of specified node imports.
+  no-restricted-imports: 0
+
   # Disallow to use this/super before super() calling in constructors.
   no-this-before-super: 2
+
+  # Disallow unnecessary computed property keys in object literals.
+  no-useless-computed-key: 2
+
+  # Disallow unnecessary constructor.
+  no-useless-constructor: 2
+
+  # Disallow renaming import/export/destructured assignments to the same name.
+  no-useless-rename:
+    - 2
+    -
+      ignoreImport: false
+      ignoreExport: false
+      ignoreDestructuring: false
 
   # Requires using let or const instead of var.
   # This should be turned on when browser support is better.
@@ -799,13 +1044,17 @@ rules:
   # Suggest using of const declaration for variables that are never modified.
   prefer-const: 1
 
-  # Suggest using the spread operator instead of .apply().
-  # Should not be enabled in ES3/5 environments.
-  prefer-spread: 0
-
   # Suggest using Reflect methods where applicable.
   # Should not be enabled in ES3/5 environments.
   prefer-reflect: 0
+
+  # Suggest using the rest parameters instead of arguments.
+  # Should not be enabled in ES3/5 environments.
+  prefer-rest-params: 0
+
+  # Suggest using the spread operator instead of .apply().
+  # Should not be enabled in ES3/5 environments.
+  prefer-spread: 0
 
   # Suggest using template literals instead of strings concatenation.
   # Should not be enabled in ES3/5 environments.
@@ -814,33 +1063,31 @@ rules:
   # Disallow generator functions that do not have yield.
   require-yield: 1
 
+  # Enforce spacing between rest and spread operators and their expressions.
+  rest-spread-spacing:
+    - 2
+    - never
 
-  # Rules for LEGACY SUPPORT.
-  # These rules provide compatibility with JSHint/JSLint rules.
-
-  # Specifies maximum depth that blocks can be nested.
-  max-depth:
+  # Sort import declarations within module.
+  sort-imports:
     - 1
-    - 5
+    -
+      ignoreCase: false
+      ignoreMemberSort: false
+      memberSyntaxSortOrder:
+        - none
+        - all
+        - multiple
+        - single
 
-  # Specifies maximum length of a line in your program.
-  max-len:
+  # Enforce spacing around embedded expressions of template strings.
+  template-curly-spacing:
     - 1
-    - 80
-    - 4
+    - always
 
-  # Limits number of parameters that can be used in the function declaration.
-  max-params:
+  # Enforce spacing around the * in yield* expressions.
+  yield-star-spacing:
     - 1
-    - 5
-
-  # Specifies maximum number of statement allowed in a function.
-  max-statements:
-    - 1
-    - 25
-
-  # Disallows use of bitwise operators.
-  no-bitwise: 0
-
-  # Disallows use of unary operators, ++ and --.
-  no-plusplus: 0
+    -
+      before: true
+      after: false

--- a/src/disclosures/js/dispatchers/get-api-values.js
+++ b/src/disclosures/js/dispatchers/get-api-values.js
@@ -4,11 +4,10 @@ var getApiValues = {
 
   values: {},
 
-
   constants: function() {
     var urlBase = $( 'main' ).attr( 'data-context' );
     var url = '/' + urlBase +
-      '/understanding-your-financial-aid-offer/api/constants/';
+              '/understanding-your-financial-aid-offer/api/constants/';
     var constantsRequest = $.ajax( {
       url: url,
       dataType: 'json',
@@ -26,7 +25,7 @@ var getApiValues = {
   expenses: function() {
     var urlBase = $( 'main' ).attr( 'data-context' );
     var url = '/' + urlBase +
-      '/understanding-your-financial-aid-offer/api/expenses/';
+              '/understanding-your-financial-aid-offer/api/expenses/';
     var expensesRequest = $.ajax( {
       url: url,
       dataType: 'json',
@@ -44,7 +43,8 @@ var getApiValues = {
   fetchSchoolData: function( iped ) {
     var urlBase = $( 'main' ).attr( 'data-context' );
     var url = '/' + urlBase +
-      '/understanding-your-financial-aid-offer/api/school/' + iped + '/';
+              '/understanding-your-financial-aid-offer/api/school/' +
+              iped + '/';
     var schoolDataRequest = $.ajax( {
       url: url,
       dataType: 'json',
@@ -70,8 +70,8 @@ var getApiValues = {
 
     var urlBase = $( 'main' ).attr( 'data-context' );
     var url = '/' + urlBase +
-      '/understanding-your-financial-aid-offer/api/program/' + iped + '_' +
-      pid + '/';
+              '/understanding-your-financial-aid-offer/api/program/' +
+              iped + '_' + pid + '/';
     var programDataRequest = $.ajax( {
       url: url,
       dataType: 'json',
@@ -88,17 +88,17 @@ var getApiValues = {
   },
 
   fetchNationalData: function( iped, pid ) {
-    var urlBase = $( 'main' ).attr( 'data-context' ),
-        url;
-    if ( typeof pid !== 'undefined' ) {
-      url = '/' + urlBase +
-        '/understanding-your-financial-aid-offer/api/national-stats/' + iped +
-        '_' + pid + '/';
+    var urlBase = $( 'main' ).attr( 'data-context' );
+    var url = '/' + urlBase +
+              '/understanding-your-financial-aid-offer/api/national-stats/' +
+              iped;
+
+    if ( typeof pid === 'undefined' ) {
+      url += '/';
     } else {
-      url = '/' + urlBase +
-        '/understanding-your-financial-aid-offer/api/national-stats/' + iped +
-        '/';
+      url += '_' + pid + '/';
     }
+
     var nationalDataRequest = $.ajax( {
       url: url,
       dataType: 'json',

--- a/src/disclosures/js/models/expenses-model.js
+++ b/src/disclosures/js/models/expenses-model.js
@@ -61,12 +61,20 @@ var expensesModel = {
       '50000_to_69999': [ 50000, 69999 ],
       '70000_or_more':  [ 70000, Infinity ]
     };
+
+    var arr;
     for ( var key in rangeFinder ) {
-      var arr = rangeFinder[key];
-      if ( salary >= arr[0] && salary <= arr[1] ) {
-        return key;
+      if ( rangeFinder.hasOwnProperty( key ) ) {
+        arr = rangeFinder[key];
+        if ( salary >= arr[0] && salary <= arr[1] ) {
+          return key;
+        }
       }
     }
+
+    // TODO: Update to a string and check that nothing breaks.
+    //       Docs specify `getSalaryRange` returns a string,
+    //       but it returns a boolean here.
     return false;
   },
 

--- a/src/disclosures/js/utils/nemo-shim.js
+++ b/src/disclosures/js/utils/nemo-shim.js
@@ -4,7 +4,7 @@
 var bodyTag = document.getElementsByTagName( 'body' )[0];
 bodyTag.className += ' js';
 
-$( '.toggle-menu' ).on( 'click', function( e ) {
-  e.preventDefault();
+$( '.toggle-menu' ).on( 'click', function( evt ) {
+  evt.preventDefault();
   $( 'nav.main ul' ).toggleClass( 'vis' );
 } );

--- a/src/disclosures/js/utils/print-page.js
+++ b/src/disclosures/js/utils/print-page.js
@@ -16,8 +16,8 @@ function printAndroidPage() {
 }
 
 $( document ).ready( function() {
-  $( '.next-steps_controls > .btn' ).on( 'click', function( e ) {
-    e.preventDefault();
+  $( '.next-steps_controls > .btn' ).on( 'click', function( evt ) {
+    evt.preventDefault();
     if ( isAndroid ) {
       printAndroidPage();
     } else {

--- a/src/disclosures/js/utils/query-handler.js
+++ b/src/disclosures/js/utils/query-handler.js
@@ -82,7 +82,7 @@ function queryHandler( queryString ) {
 
     queryString.split( '+' ).join( ' ' );
 
-    while ( pair = regex.exec( queryString ) ) {
+    while ( pair = regex.exec( queryString ) ) { // eslint-disable-line no-cond-assign
       var key = decodeURIComponent( pair[1] );
       var value = decodeURIComponent( pair[2] );
 

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -254,10 +254,11 @@ var financialView = {
       typeof values.jobRate !== 'undefined' && values.jobRate !== 'None' &&
       values.jobRate !== ''
     );
-    if ( values.level.indexOf( 'degree' ) !== -1 ) {
-      this.$degreeType.text( 'degree' );
-    } else {
+
+    if ( values.level.indexOf( 'degree' ) === -1 ) {
       this.$degreeType.text( 'certificate' );
+    } else {
+      this.$degreeType.text( 'degree' );
     }
   },
 
@@ -416,20 +417,22 @@ var financialView = {
    * @param {string} id - The id attribute of the element to be handled
    */
   inputHandler: function( id ) {
-    var $ele = $( '#' + id ),
-        value = stringToNum( $ele.val() ),
-        key = $ele.attr( 'data-financial' ),
-        privateLoanKey = $ele.attr( 'data-private-loan_key' ),
-        percentage = $ele.attr( 'data-percentage_value' );
+    var $ele = $( '#' + id );
+    var value = stringToNum( $ele.val() );
+    var key = $ele.attr( 'data-financial' );
+    var privateLoanKey = $ele.attr( 'data-private-loan_key' );
+    var percentage = $ele.attr( 'data-percentage_value' );
+
     if ( percentage === 'true' ) {
       value /= 100;
     }
-    if ( typeof privateLoanKey !== 'undefined' ) {
-      var index = $ele.closest( '[data-private-loan]' ).index(),
-          privLoanKey = $ele.attr( 'data-private-loan_key' );
-      publish.updatePrivateLoan( index, privLoanKey, value );
-    } else {
+
+    if ( typeof privateLoanKey === 'undefined' ) {
       publish.financialData( key, value );
+    } else {
+      var index = $ele.closest( '[data-private-loan]' ).index();
+      var privLoanKey = $ele.attr( 'data-private-loan_key' );
+      publish.updatePrivateLoan( index, privLoanKey, value );
     }
   },
 
@@ -487,12 +490,12 @@ var financialView = {
    * Listener function for offer verification buttons
    */
   verificationListener: function() {
-    this.$verifyControls.on( 'click', '.btn', function( e ) {
+    this.$verifyControls.on( 'click', '.btn', function( evt ) {
       var values = getFinancial.values();
       // Graph points need to be visible before updating their positions
       // to get all the right CSS values, so we'll wait 100 ms
       if ( $( this ).attr( 'href' ) === '#info-right' ) {
-        e.preventDefault();
+        evt.preventDefault();
         financialView.$infoVerified.show();
         $( 'html, body' ).stop().animate( {
           scrollTop: financialView.$infoVerified.offset().top - 120
@@ -503,7 +506,7 @@ var financialView = {
           financialView.stickySummariesListener();
         } );
       } else {
-        e.preventDefault();
+        evt.preventDefault();
         financialView.$infoIncorrect.show();
         postVerification.verify( values.offerID, values.schoolID, true );
         $( 'html, body' ).stop().animate( {
@@ -689,7 +692,9 @@ var financialView = {
       financialView.$bigQuestion.show();
       $( 'html, body' ).stop().animate( {
         scrollTop: financialView.$evaluateSection.offset().top - 120
-      }, 900, 'swing', function() {} );
+      }, 900, 'swing', function() {
+        // Noop function.
+      } );
     } );
   },
 
@@ -700,11 +705,11 @@ var financialView = {
   stickySummariesListener: function() {
     var $stickyOffers = $( '.offer-part_summary-wrapper' );
     $stickyOffers.stick_in_parent()
-      .on( 'sticky_kit:bottom', function( e ) {
-        $( e.target ).addClass( 'is_bottomed' );
+      .on( 'sticky_kit:bottom', function( evt ) {
+        $( evt.target ).addClass( 'is_bottomed' );
       } )
-      .on( 'sticky_kit:unbottom', function( e ) {
-        $( e.target ).removeClass( 'is_bottomed' );
+      .on( 'sticky_kit:unbottom', function( evt ) {
+        $( evt.target ).removeClass( 'is_bottomed' );
       } );
   },
 

--- a/src/disclosures/js/views/question-view.js
+++ b/src/disclosures/js/views/question-view.js
@@ -88,7 +88,9 @@ var questionView = {
       questionView.$feedback.show();
       $( 'html, body' ).stop().animate( {
         scrollTop: questionView.$getOptions.offset().top - 120
-      }, 900, 'swing', function() {} );
+      }, 900, 'swing', function() {
+        // Noop function.
+      } );
     } );
   }
 


### PR DESCRIPTION
## Changes
- Update to latest eslintrc file.
- Give noop functions a body.
- Flip negated conditions.
- convert blacklisted `e` variable name to more searchable `evt`.
- Ignore no conditional assignment linting error in while loop.
- Break out long variable declaration strings to per-line declarations.
- Define reused variables outside of loop.
## Testing
- `gulp lint` should show no errors
## Review
- @mistergone 
- @marteki 
