### PR TITLE
Return 200 with messages instead of 400 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Update debt summary text for program durations less than one year.
 - Added privateLoanFee constant to the database
 - Added unicode-aware csv module
+- Refactored the offer view to allow bad school, program and offer IDs
 
 ## 2.1.4
 - Added string checking for program codes

--- a/paying_for_college/disclosures/scripts/update_colleges.py
+++ b/paying_for_college/disclosures/scripts/update_colleges.py
@@ -95,7 +95,6 @@ def update(exclude_ids=[], single_school=None):
                         CLOSED += 1
                     if UPDATED is True:
                         UPDATE_COUNT += 1
-                        # school.data_json = json.dumps(data_dict)
                         school.zip5 = fix_zip5(str(school.zip5))
                         school.save()
                 else:

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -45,7 +45,7 @@
         <section class="verify step content_wrapper">
             <div class="content_main">
                 <div class="verify_wrapper">
-                    <div class="verify_content">
+                    <div class="verify_content" data-warning="{{warning}}">
                         <h2 class="verify_prompt">
                             Make sure that the information below is correct
                             before reviewing your offer.
@@ -56,10 +56,10 @@
                                 {{school.primary_alias}}
                             </div>
                             <div class="verify_location">
-                                {{school.city}}, {{school.state}}
+                                {% if school %}{{school.city}}, {{school.state}}{% endif %}
                             </div>
                             <div class="verify_type">
-                                {{school.control}} school
+                                {% if school %}{{school.control}} school{% endif %}
                             </div>
                             <dl class="verify_list">
                                 <dt class="verify_heading">

--- a/paying_for_college/tests/test_load_programs.py
+++ b/paying_for_college/tests/test_load_programs.py
@@ -177,6 +177,11 @@ class TestLoadPrograms(django.test.TestCase):
         load('filename')
         self.assertEqual(mock_read_in.call_count, 3)
         self.assertEqual(mock_program.call_count, 1)  # loader bails before creating program
+        mock_clean.return_value['ipeds_unit_id'] = "408039"
+        mock_clean.return_value['program_code'] = "99982"
+        mock_program.return_value = (program, True)
+        load('filename')
+        self.assertEqual(mock_read_in.call_count, 4)
 
     @mock.patch('paying_for_college.disclosures.scripts.load_programs.'
                 'clean')

--- a/paying_for_college/tests/test_scripts.py
+++ b/paying_for_college/tests/test_scripts.py
@@ -60,11 +60,38 @@ class TestScripts(django.test.TestCase):
                    'degrees_predominant': '',
                    'degrees_highest': '',
                    'school.ownership': 2,
-                   'school.grad_rate_lt4': 0.25,
-                   'main_campus': True,
-                   'online_only': False,
-                   'operating': True,
-                   'under_investigation': False,
+                   '2013.completion.completion_rate_4yr_150nt_pooled': 0.45,
+                   '2013.completion.completion_rate_less_than_4yr_150nt_pooled': None,
+                   'school.main_campus': True,
+                   'school.online_only': False,
+                   'school.operating': True,
+                   'school.under_investigation': False,
+                   'RETENTRATE': '',
+                   'RETENTRATELT4': '',  # NEW
+                   'REPAY3YR': '',  # NEW
+                   'DEFAULTRATE': '',
+                   'AVGSTULOANDEBT': '',
+                   'MEDIANDEBTCOMPLETER': '',  # NEW
+                   'city': 'Lawrence'}],
+                 'metadata': {'page': 0}
+                 }
+
+    mock_lt_4 = {'results':
+                 [{'id': 155317,
+                   'ope6_id': 5555,
+                   'ope8_id': 55500,
+                   'enrollment': 10000,
+                   'accreditor': "Santa",
+                   'url': '',
+                   'degrees_predominant': '',
+                   'degrees_highest': '',
+                   'school.ownership': 2,
+                   '2013.completion.completion_rate_4yr_150nt_pooled': 0,
+                   '2013.completion.completion_rate_less_than_4yr_150nt_pooled': 0.25,
+                   'school.main_campus': True,
+                   'school.online_only': False,
+                   'school.operating': False,
+                   'school.under_investigation': False,
                    'RETENTRATE': '',
                    'RETENTRATELT4': '',  # NEW
                    'REPAY3YR': '',  # NEW
@@ -107,6 +134,9 @@ class TestScripts(django.test.TestCase):
         mock_response.json.return_value = self.no_data_dict
         (FAILED, NO_DATA, endmsg) = update_colleges.update()
         self.assertFalse(len(NO_DATA) == 0)
+        mock_response.json.return_value = self.mock_lt_4
+        (FAILED, NO_DATA, endmsg) = update_colleges.update()
+        self.assertTrue(len(NO_DATA) == 0)
 
     @mock.patch('paying_for_college.disclosures.scripts.'
                 'update_colleges.requests.get')

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -164,10 +164,14 @@ class SchoolSearchTest(django.test.TestCase):
 
     def test_get_school(self):
         """test grabbing a school by ID"""
+        closed_school = School(pk=999999, operating=False)
+        closed_school.save()
         test1 = get_school('155317')
         self.assertTrue(test1.pk == 155317)
         test2 = get_school('xxx')
-        self.assertTrue(test2 == '')
+        self.assertTrue(test2 is None)
+        test3 = get_school('999999')
+        self.assertTrue(test3 is None)
 
     def test_get_program(self):
         """test grabbing a program by school/program_code"""
@@ -234,22 +238,25 @@ class OfferTest(django.test.TestCase):
         self.assertTrue(resp.status_code == 200)
         resp2 = client.get(url+no_oid)
         self.assertTrue(resp2.status_code == 200)
+        self.assertTrue("Warning" in resp2.context['warning'])
         resp3 = client.get(url+bad_school)
-        self.assertTrue("No active school" in resp3.content)
-        self.assertTrue(resp3.status_code == 400)
+        self.assertTrue("Warning" in resp3.context['warning'])
+        self.assertTrue(resp3.status_code == 200)
         resp4 = client.get(url+bad_program)
         self.assertTrue(resp4.status_code == 200)
+        self.assertTrue("Warning" in resp4.context['warning'])
         resp5 = client.get(url+missing_oid_field)
         self.assertTrue(resp5.status_code == 200)
+        self.assertTrue("Warning" in resp5.context['warning'])
         resp6 = client.get(url+missing_school_id)
-        self.assertTrue("doesn't contain a school" in resp6.content)
-        self.assertTrue(resp6.status_code == 400)
-        resp8 = client.get(url+bad_oid)
-        self.assertTrue("Illegal offer" in resp8.content)
-        self.assertTrue(resp8.status_code == 400)
-        resp9 = client.get(url+illegal_program)
-        self.assertTrue("Illegal characters" in resp9.content)
-        self.assertTrue(resp8.status_code == 400)
+        self.assertTrue("Warning" in resp6.context['warning'])
+        self.assertTrue(resp6.status_code == 200)
+        resp7 = client.get(url+bad_oid)
+        self.assertTrue("Error" in resp7.context['warning'])
+        self.assertTrue(resp7.status_code == 200)
+        resp8 = client.get(url+illegal_program)
+        self.assertTrue("Error" in resp8.context['warning'])
+        self.assertTrue(resp8.status_code == 200)
 
 
 class APITests(django.test.TestCase):

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -37,9 +37,11 @@ class Validators(unittest.TestCase):
     """check the oid validator"""
     good_oid = '9e0280139f3238cbc9702c7b0d62e5c238a835d0'
     bad_oid = '9e0<script>console.log("hi")</script>5d0'
+    short_oid = '9e45a3e7'
 
     def test_validate_oid(self):
         self.assertFalse(validate_oid(self.bad_oid))
+        self.assertFalse(validate_oid(self.short_oid))
         self.assertTrue(validate_oid(self.good_oid))
 
     def test_validate_pid(self):
@@ -234,6 +236,8 @@ class OfferTest(django.test.TestCase):
                    '<script></script>f997949efa566c616c5')
         illegal_program = ('?iped=408039&pid=<981>&oid=f38283b'
                            '5b7c939a058889f997949efa566c616c5')
+        no_program = ('?iped=408039&pid=&oid=f38283b'
+                      '5b7c939a058889f997949efa566c616c5')
         resp = client.get(url+qstring)
         self.assertTrue(resp.status_code == 200)
         resp2 = client.get(url+no_oid)
@@ -257,6 +261,9 @@ class OfferTest(django.test.TestCase):
         resp8 = client.get(url+illegal_program)
         self.assertTrue("Error" in resp8.context['warning'])
         self.assertTrue(resp8.status_code == 200)
+        resp9 = client.get(url+no_program)
+        self.assertTrue("Warning" in resp9.context['warning'])
+        self.assertTrue(resp9.status_code == 200)
 
 
 class APITests(django.test.TestCase):

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -47,9 +47,9 @@ else:  # pragma: no cover
 URL_ROOT = 'paying-for-college2'
 EXPENSE_FILE = '{}/fixtures/bls_data.json'.format(BASEDIR)
 NO_SCHOOL_ERROR = "No active school could be found for iped ID {0}"
-OID_WARNING = "Error: Illegal characters in offer ID '{}'"
+OID_WARNING = "Error: Illegal offer ID '{}'"
 # only characters 0-9 and a-f are allowed in offer IDs
-PID_WARNING = "Error: Illegal characters in program code '{}'"
+PID_WARNING = "Error: Illegal program code '{}'"
 # Illegal program code characters: ; < > { }
 
 
@@ -63,14 +63,17 @@ def get_json_file(filename):
 
 def validate_oid(oid):
     """
-    make sure an oid contains only hex values 0-9 a-f A-F
+    make sure an oid contains only hex values 0-9 a-f A-F and is 40 characters
     return True if the oid is valid
     """
     find_illegal = re.search('[^0-9a-fA-F]+', oid)
     if find_illegal:
         return False
     else:
-        return True
+        if len(oid) == 40:
+            return True
+        else:
+            return False
 
 
 def validate_pid(pid):
@@ -168,9 +171,10 @@ class OfferView(TemplateView):
                             warning = ("Warning: No program could be found "
                                        "for program_code '{}'".format(PID))
                 else:
-                    warning = "Warning: URL doesn't contain a program ID"
+                    warning = "Warning: URL doesn't contain a program code"
             else:
-                warning = "Warning: No active school found for ID {}".format(iped)
+                warning = ("Warning: No active school found "
+                           "for ID {}".format(iped))
         else:
                 warning = "Warning: URL doesn't contain a school ID"
         return render_to_response('worksheet.html',

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -167,6 +167,8 @@ class OfferView(TemplateView):
                         else:
                             warning = ("Warning: No program could be found "
                                        "for program_code '{}'".format(PID))
+                else:
+                    warning = "Warning: URL doesn't contain a program ID"
             else:
                 warning = "Warning: No active school found for ID {}".format(iped)
         else:

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -47,10 +47,10 @@ else:  # pragma: no cover
 URL_ROOT = 'paying-for-college2'
 EXPENSE_FILE = '{}/fixtures/bls_data.json'.format(BASEDIR)
 NO_SCHOOL_ERROR = "No active school could be found for iped ID {0}"
-OID_WARNING = "Error: Illegal offer ID '{}'"
+OID_WARNING = "Error: Illegal offer ID"
 # only characters 0-9 and a-f are allowed in offer IDs
-PID_WARNING = "Error: Illegal program code '{}'"
-# Illegal program code characters: ; < > { }
+PID_WARNING = "Error: Illegal program code"
+# program code isn't 40 chars or contains Illegal characters: ; < > { }
 
 
 def get_json_file(filename):
@@ -149,7 +149,7 @@ class OfferView(TemplateView):
         else:
             warning = "Warning: URL doesn't contain an offer ID"
         if OID and validate_oid(OID) is False:
-            warning = OID_WARNING.format(OID)
+            warning = OID_WARNING
             OID = ''
         if 'iped' in request.GET and request.GET['iped']:
             iped = request.GET['iped']
@@ -159,7 +159,7 @@ class OfferView(TemplateView):
                 if 'pid' in request.GET and request.GET['pid']:
                     PID = request.GET['pid']
                     if not validate_pid(PID):
-                        warning = PID_WARNING.format(PID)
+                        warning = PID_WARNING
                         PID = ''
                     if PID:
                         programs = Program.objects.filter(program_code=PID,
@@ -266,7 +266,7 @@ class ProgramRepresentation(View):
             return HttpResponseBadRequest(format_error)
         PID = ids[1]
         if not validate_pid(PID):
-            return HttpResponseBadRequest(PID_WARNING.format(PID))
+            return HttpResponseBadRequest(PID_WARNING)
         program = self.get_program(program_code)
         if not program:
             p_error = ("Error: No program was found "


### PR DESCRIPTION
We need to trap school and program ID errors on the page instead of
in the back end, so we'll now return 200 and render the offer page
with a warning message.

These messages are available at `$('div.verify_content').attr('data-warning')`

| Problem | Message |
| :-- | :-- |
| Missing iped | Warning: URL doesn't contain a school ID |
| Bad iped `xxxxxx` | Warning: No active school found for ID xxxxxx |
| Missing pid | Warning: URL doesn't contain a program code |
| Bad pid `xxx` | Warning: No program could be found for program_code 'xxx' |
| Illegal pid `<script>` | Error: Illegal program code |
| Missing oid | Warning: URL doesn't contain an offer ID |
| Illegal oid `<script>` | Error: Illegal offer ID |
## Changes
- offer view refactored to return 200 and warning messages instead of 400
## Testing
- Try pages with bad or missing school ID or program code or offer ID
- Try pages with illegal characters (such as '<') in the program code or offer ID
## Review
- @amymok @mistergone @marteki @anselmbradford 
## Checklist
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
