### PR TITLE
Handle non-utf-8 encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Added unicode-aware csv module
 - Refactored the offer view to allow bad school, program and offer IDs
 - Set total program debt multiplier minimum to 1.
+- Refactored the load_programs script to handle non-utf-8 encoding
 
 ## 2.1.4
 - Added string checking for program codes

--- a/paying_for_college/disclosures/scripts/load_programs.py
+++ b/paying_for_college/disclosures/scripts/load_programs.py
@@ -62,12 +62,12 @@ def get_school(iped):
 
 
 def read_in_latin_1(filename):
-    with open(filename, 'r') as f:
-        try:
+    try:
+        with open(filename, 'r') as f:
             reader = cdr(f, encoding='latin-1')
             data = [row for row in reader]
-        except:
-            data = [{}]
+    except:
+        data = [{}]
     return data
 
 

--- a/paying_for_college/disclosures/scripts/load_programs.py
+++ b/paying_for_college/disclosures/scripts/load_programs.py
@@ -61,15 +61,29 @@ def get_school(iped):
         return (school, '')
 
 
+def read_in_latin_1(filename):
+    with open(filename, 'r') as f:
+        try:
+            reader = cdr(f, encoding='latin-1')
+            data = [row for row in reader]
+        except:
+            data = [{}]
+    return data
+
+
 def read_in_data(filename):
-    try:
-        with open(filename, 'r') as f:
+    try_latin = False
+    with open(filename, 'r') as f:
+        try:
             reader = cdr(f)
             data = [row for row in reader]
-    except:
-        return [{}]
-    else:
-        return data
+        except UnicodeDecodeError:
+            try_latin = True
+        except:
+            data = [{}]
+    if try_latin:
+        data = read_in_latin_1(filename)
+    return data
 
 
 def clean_number_as_string(string):

--- a/paying_for_college/tests/test_load_programs.py
+++ b/paying_for_college/tests/test_load_programs.py
@@ -7,6 +7,7 @@ from mock import mock_open, patch
 from paying_for_college.models import Program, School
 from paying_for_college.disclosures.scripts.load_programs import (get_school,
                                                                   read_in_data,
+                                                                  read_in_latin_1,
                                                                   clean_number_as_string,
                                                                   clean_string_as_string,
                                                                   clean, load,
@@ -71,15 +72,52 @@ class TestLoadPrograms(django.test.TestCase):
         result = clean_string_as_string("  No Data ")
         self.assertEqual(result, '')
 
-    def test_read_in_data(self):
-        m = mock_open(read_data='a , b, c \nd,e,f')
+    @mock.patch('paying_for_college.disclosures.scripts.load_programs.'
+                'read_in_latin_1')
+    def test_read_in_data(self, mock_latin):
+        mock_latin.return_value = [{'a': 'd', 'b': 'e', 'c': 'f'}]
+        m = mock_open(read_data='a,b,c\nd,e,f')
         with patch("__builtin__.open", m, create=True):
             data = read_in_data('mockfile.csv')
         self.assertTrue(m.call_count == 1)
-        self.assertTrue(data == [{'a ': 'd', ' b': 'e', ' c ': 'f'}])
-        m.side_effect = Exception("OPEN ERROR")
+        self.assertTrue(data == [{'a': 'd', 'b': 'e', 'c': 'f'}])
+        # m.side_effect = Exception("OPEN ERROR")
+        m2 = mock_open(read_data='a,b,c\nd,e,f')
+        m2.side_effect = UnicodeDecodeError('bad character', '2', 3, 4, '5')
         with patch("__builtin__.open", m, create=True):
             data = read_in_data('mockfile.csv')
+        self.assertTrue(m.call_count == 2)
+        self.assertTrue(data == [{'a': 'd', 'b': 'e', 'c': 'f'}])
+
+    @mock.patch('paying_for_college.disclosures.scripts.load_programs.'
+                'read_in_latin_1')
+    @mock.patch('paying_for_college.disclosures.scripts.load_programs.'
+                'cdr')
+    def test_try_latin(self, mock_cdr, mock_latin):
+        mock_cdr.side_effect = UnicodeDecodeError('bad character',
+                                                  '2', 3, 4, '5')
+        mock_latin.return_value = [{'a': 'd', 'b': 'e', 'c': 'f'}]
+        m = mock_open(read_data='a,b,c\nd,e,f')
+        with patch("__builtin__.open", m, create=True):
+            data = read_in_data('mockfile.csv')
+        self.assertTrue(m.call_count == 1)
+        self.assertTrue(mock_cdr.call_count == 1)
+        self.assertTrue(mock_latin.call_count == 1)
+        mock_cdr.side_effect = TypeError
+        with patch("__builtin__.open", m, create=True):
+            data = read_in_data('mockfile.csv')
+        self.assertTrue(m.call_count == 2)
+        self.assertTrue(data == [{}])
+
+    def test_read_in_latin_1(self):
+        m = mock_open(read_data='a,b,c\nd,e,f')
+        with patch("__builtin__.open", m, create=True):
+            data = read_in_latin_1('mockfile.csv')
+        self.assertTrue(m.call_count == 1)
+        self.assertTrue(data == [{'a': 'd', 'b': 'e', 'c': 'f'}])
+        m.side_effect = Exception("OPEN ERROR")
+        with patch("__builtin__.open", m, create=True):
+            data = read_in_latin_1('mockfile.csv')
         self.assertTrue(m.call_count == 2)
         self.assertTrue(data == [{}])
 


### PR DESCRIPTION
Although we specify utf-8 in our CSV spec, it is inevitable that we'll get CSVs saved straight out of Excel that are not utf-8. This should handle most such cases by decoding with latin-1 when reading in the CSV. If this doesn't work, we should reject the CSV.
## Additions
- read_in_latin_1 function
- related tests
## Testing
- With this change, the script loads the latest file from EDMC.
## Review
- @amymok 
## Checklist
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
