### PR TITLE
Tweak program loader to handle most likely error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Refactored the offer view to allow bad school, program and offer IDs
 - Set total program debt multiplier minimum to 1.
 - Refactored the load_programs script to handle non-utf-8 encoding
+- Tweaked load_programs to fall back to windows-1252
 
 ## 2.1.4
 - Added string checking for program codes

--- a/paying_for_college/disclosures/scripts/load_programs.py
+++ b/paying_for_college/disclosures/scripts/load_programs.py
@@ -61,10 +61,11 @@ def get_school(iped):
         return (school, '')
 
 
-def read_in_latin_1(filename):
+def read_in_encoding(filename, encoding='windows-1252'):
+    """Throw a lifeline if the college just exported from Excel"""
     try:
         with open(filename, 'r') as f:
-            reader = cdr(f, encoding='latin-1')
+            reader = cdr(f, encoding=encoding)
             data = [row for row in reader]
     except:
         data = [{}]
@@ -72,17 +73,18 @@ def read_in_latin_1(filename):
 
 
 def read_in_data(filename):
-    try_latin = False
+    """Reads in utf-8 CSV (as per our spec)"""
+    try_encoding = False
     with open(filename, 'r') as f:
         try:
             reader = cdr(f)
             data = [row for row in reader]
         except UnicodeDecodeError:
-            try_latin = True
+            try_encoding = True
         except:
             data = [{}]
-    if try_latin:
-        data = read_in_latin_1(filename)
+    if try_encoding:  # sigh
+        data = read_in_encoding(filename)
     return data
 
 

--- a/paying_for_college/tests/test_load_programs.py
+++ b/paying_for_college/tests/test_load_programs.py
@@ -7,7 +7,7 @@ from mock import mock_open, patch
 from paying_for_college.models import Program, School
 from paying_for_college.disclosures.scripts.load_programs import (get_school,
                                                                   read_in_data,
-                                                                  read_in_latin_1,
+                                                                  read_in_encoding,
                                                                   clean_number_as_string,
                                                                   clean_string_as_string,
                                                                   clean, load,
@@ -73,7 +73,7 @@ class TestLoadPrograms(django.test.TestCase):
         self.assertEqual(result, '')
 
     @mock.patch('paying_for_college.disclosures.scripts.load_programs.'
-                'read_in_latin_1')
+                'read_in_encoding')
     def test_read_in_data(self, mock_latin):
         mock_latin.return_value = [{'a': 'd', 'b': 'e', 'c': 'f'}]
         m = mock_open(read_data='a,b,c\nd,e,f')
@@ -90,7 +90,7 @@ class TestLoadPrograms(django.test.TestCase):
         self.assertTrue(data == [{'a': 'd', 'b': 'e', 'c': 'f'}])
 
     @mock.patch('paying_for_college.disclosures.scripts.load_programs.'
-                'read_in_latin_1')
+                'read_in_encoding')
     @mock.patch('paying_for_college.disclosures.scripts.load_programs.'
                 'cdr')
     def test_try_latin(self, mock_cdr, mock_latin):
@@ -109,15 +109,15 @@ class TestLoadPrograms(django.test.TestCase):
         self.assertTrue(m.call_count == 2)
         self.assertTrue(data == [{}])
 
-    def test_read_in_latin_1(self):
+    def test_read_in_encoding(self):
         m = mock_open(read_data='a,b,c\nd,e,f')
         with patch("__builtin__.open", m, create=True):
-            data = read_in_latin_1('mockfile.csv')
+            data = read_in_encoding('mockfile.csv')
         self.assertTrue(m.call_count == 1)
         self.assertTrue(data == [{'a': 'd', 'b': 'e', 'c': 'f'}])
         m.side_effect = Exception("OPEN ERROR")
         with patch("__builtin__.open", m, create=True):
-            data = read_in_latin_1('mockfile.csv')
+            data = read_in_encoding('mockfile.csv')
         self.assertTrue(m.call_count == 2)
         self.assertTrue(data == [{}])
 


### PR DESCRIPTION
Try as we might to require utf-8 CSVs, it is inevitable that some schools (including EDMC) will send us CSVs straight out of Excel, encoded in windows-1252.
## Changes
- Tweaks load_programs and related tests
## Review
- @amymok 
## Checklist
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
