### PR TITLE
Adjust update_ipeds to create new schools first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Refactored the offer view to allow bad school, program and offer IDs
 - Set total program debt multiplier minimum to 1.
 - Refactored the load_programs script to handle non-utf-8 encoding
+- Adjust the update_ipeds script to create new schools first, so they get updated with IPEDS data too
 
 ## 2.1.4
 - Added string checking for program codes

--- a/paying_for_college/management/commands/update_ipeds.py
+++ b/paying_for_college/management/commands/update_ipeds.py
@@ -3,17 +3,17 @@ import datetime
 from django.core.management.base import BaseCommand, CommandError
 from paying_for_college.disclosures.scripts.update_ipeds import load_values
 
-COMMAND_HELP = "Update_ipeds will download, parse and load the latest "
-"data files from the IPEDS data center. If run without arguments, it will "
-"make a dry run and report how many schools and data points would have been "
-"updated. If run with '--dry-run false' it will update the school records "
-"in the PFC database. The script always fetches the latest academic year "
-"available, which is 2 years behind the calendar year. So in 2016, it fetches "
-"2014 data, which represents data from the 2014-2015 academic year."
-PARSER_HELP = "This command acquires the latest IPEDS values and will "
-"load them if provided the '--dry-run false' argument. If no argument is "
-"passed, the script makes a dry run and reports what would have happened. "
-"Passing arguments other than 'false' or 'true' will return this help message."
+COMMAND_HELP = """Update_ipeds will download, parse and load the latest
+data files from the IPEDS data center. If run without arguments, it will
+make a dry run and report how many schools and data points would have been
+updated. If run with '--dry-run false' it will update the school records
+in the PFC database. The script always fetches the latest academic year
+available, which is 2 years behind the calendar year. So in 2016, it fetches
+2014 data, which represents data from the 2014-2015 academic year.
+"""
+PARSER_HELP = """The --dry-run argument defaults to 'true' and makes no
+changes to the database. To update the database, pass '--dry-run false'
+"""
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
The update_ipeds command is our method of acquiring new schools that
show up in IPEDS data, and this changes the sequence of updates so that
schools are added as a first step. This allows the created schools to
benefit from the IPEDS data update that follows, so they'll have a
starter set of information that can be fleshed out later when the new
schools show up in the scorecard API.

Also fixes the help text for udpate_ipeds and its --dry-run option.
## Review
- @amymok 
## Checklist
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
