### PR TITLE
Add constant to track year when constants are updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Renamed salary variables to 'programSalary,' 'schoolSalary,' and 'nationalSalary' to distinguish data sources
 - Adjust the update_ipeds script to create new schools first, so they get updated with IPEDS data too
 - Tweaked load_programs to fall back to windows-1252
+- Added new constant `constantsYear` and changed API and salary year vars to `apiYear` and `salaryYear` 
 
 ## 2.1.4
 - Added string checking for program codes

--- a/paying_for_college/admin.py
+++ b/paying_for_college/admin.py
@@ -10,12 +10,12 @@ class DisclosureAdmin(admin.ModelAdmin):
 
 
 class ConstantRateAdmin(admin.ModelAdmin):
-    list_display = ('name', 'slug', 'value', 'updated')
+    list_display = ('name', 'slug', 'note', 'value', 'updated')
     list_editable = ['value']
 
 
 class ConstantCapAdmin(admin.ModelAdmin):
-    list_display = ('name', 'slug', 'value', 'updated')
+    list_display = ('name', 'slug', 'note', 'value', 'updated')
     list_editable = ['value']
 
 

--- a/paying_for_college/disclosures/scripts/api_utils.py
+++ b/paying_for_college/disclosures/scripts/api_utils.py
@@ -25,11 +25,11 @@ import requests
 from paying_for_college.models import ConstantCap
 
 try:
-    LATEST_YEAR = ConstantCap.objects.get(slug='latestYear').value
+    LATEST_YEAR = ConstantCap.objects.get(slug='apiYear').value
 except:  # pragma: no cover
     LATEST_YEAR = 2013
 try:
-    LATEST_SALARY_YEAR = ConstantCap.objects.get(slug='latestSalaryYear').value
+    LATEST_SALARY_YEAR = ConstantCap.objects.get(slug='salaryYear').value
 except:  # pragma: no cover
     LATEST_SALARY_YEAR = 2011
 

--- a/paying_for_college/fixtures/test_constants.json
+++ b/paying_for_college/fixtures/test_constants.json
@@ -148,9 +148,9 @@
     "fields": {
         "note": "This is the year we base API calls and calculations on. Should be updated when data is advanced.", 
         "updated": "2015-12-19", 
-        "name": "Latest year", 
+        "name": "API year", 
         "value": 2013, 
-        "slug": "latestYear"
+        "slug": "apiYear"
     }
 },
 {
@@ -159,9 +159,20 @@
     "fields": {
         "note": "Salary data apparently is available on a different schedule from school data, so the latest year with data can be different from overall school data.", 
         "updated": "2015-12-19", 
-        "name": "Latest salary year", 
+        "name": "Salary year", 
         "value": 2011, 
-        "slug": "latestSalaryYear"
+        "slug": "salaryYear"
+    }
+},
+{
+    "pk": 17,
+    "model": "paying_for_college.constantcap",
+    "fields": {
+        "note": "IF YOU ARE UPDATING CONSTANTS, update this year value. It will be used as the first year of an academic-year pair on the \"About this tool\" page to indicate which academic year the constants apply to.",
+        "updated": "2016-08-02",
+        "name": "Constants year",
+        "value": 2016,
+        "slug": "constantsYear"
     }
 },
 {

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -288,7 +288,7 @@ class APITests(django.test.TestCase):
         url = reverse('disclosures:constants-json')
         resp = client.get(url)
         self.assertTrue('institutionalLoanRate' in resp.content)
-        self.assertTrue('latestYear' in resp.content)
+        self.assertTrue('apiYear' in resp.content)
 
     # /paying-for-college/understanding-financial-aid-offers/api/constants/
     def test_national_stats_json(self):

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -318,6 +318,8 @@ class ConstantsRepresentation(View):
             constants[ccap.slug] = ccap.value
         for crate in ConstantRate.objects.order_by('slug'):
             constants[crate.slug] = "{0}".format(crate.value)
+        cy = constants['constantsYear']
+        constants['constantsYear'] = "{}-{}".format(cy, str(cy+1)[2:])
         return json.dumps(constants)
 
     def get(self, request):


### PR DESCRIPTION
Our "About this tool" page has a reference to the academic year for
which rates apply. This delivers that academic year, based on when constants were
updated. It requires the person who updates constants to change this value.

This PR also clarifies the naming of year constants to better reflect
their usage. `latestYear` becomes `apiYear` and `latestSalaryYear`
becomes `salaryYear`
## Additions
- new constant `constantsYear`
- related tests and fixtures
## Changes
- 2 constant vars renamed
## Testing
- pull
- run `./manage.py loaddata collegedata` 
- fire up `./manage.py runserver` and then check the [constants API](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/constants/) for the new vars.
## Review
- @marteki @amymok @saintsoup52

This PR shouldn't be merged until @marteki and @saintsoup52 sign off.
## Checklist
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
