### PR TITLE
Adds option for loading program CSVs right from s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
+- Added `s3=True` option to `load_programs` to load CSVs straight from s3
 
 ## 2.1.5
 - Show recalculation updates on mobile screens

--- a/paying_for_college/tests/test_commands.py
+++ b/paying_for_college/tests/test_commands.py
@@ -60,6 +60,8 @@ class CommandTests(unittest.TestCase):
         mock_load.return_value = (['failure'], 'not OK')
         call_command('load_programs', 'filename')
         self.assertEqual(mock_load.call_count, 2)
+        call_command('load_programs', 'filename', '--s3', 'true')
+        self.assertEqual(mock_load.call_count, 3)
         mock_error = mock.Mock()
         mock_error.side_effect = Exception('Mock Error!')
         mock_load.return_value = mock_error

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,3 +8,4 @@ elasticsearch==2.3.0
 csvkit==0.9.1
 djangorestframework==3.3.3
 six==1.10.0
+boto==2.38.0


### PR DESCRIPTION
Our data pipeline stores incoming school program data in s3; this allows
the load_programs script to load these files directly fro s3 rather than
requiring the moving and handling of files.
## Additions
- `--s3` option for the `load_programs` script and management command
- related tests
## Testing
- In standalone, try running load_programs with an s3 URL:

```
./manage.py load_programs --s3 true \
"http://files.consumerfinance.gov.s3.amazonaws.com/pb/paying_for_college/csv/CFPBDATAFILE713%20(2).CSV"
```

If you run `./manage.py purge programs` first, it should load 1,522 programs.  
If you run it without purging, it should report updating 1,522 programs.
## Review
- @amymok 
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
