### PR TITLE
Turn off the non-settlement disclosure page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 - Turned off auxiliary page URLs and the landing page, except in standalone 
 - Added `s3=True` option to `load_programs` to load CSVs straight from s3
+- Fixed constant values for DLOriginationFee and plusOriginationFee
 
 ## 2.1.5
 - Show recalculation updates on mobile screens

--- a/paying_for_college/disclosures/urls.py
+++ b/paying_for_college/disclosures/urls.py
@@ -2,8 +2,8 @@ from django.conf.urls import url
 from paying_for_college.views import *
 
 urlpatterns = [
-    url(r'^$',
-        BuildComparisonView.as_view(), name='worksheet'),
+    # url(r'^$',
+    #     BuildComparisonView.as_view(), name='worksheet'),
 
     url(r'^offer/$',
         OfferView.as_view(), name='offer'),

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -121,12 +121,12 @@ class TestViews(django.test.TestCase):
         response = client.post(reverse('disclosures:pfc-feedback'))
         self.assertTrue(response.status_code == 400)
 
-    def test_disclosure(self):
-        response = client.get(reverse('disclosures:worksheet'))
-        self.assertTrue('base_template' in response.context.keys())
-        response2 = client.post(reverse('disclosures:worksheet'),
-                                request=self.POST)
-        self.assertTrue('GET' in '%s' % response2)
+    # def test_disclosure(self):
+    #     response = client.get(reverse('disclosures:worksheet'))
+    #     self.assertTrue('base_template' in response.context.keys())
+    #     response2 = client.post(reverse('disclosures:worksheet'),
+    #                             request=self.POST)
+    #     self.assertTrue('GET' in '%s' % response2)
 
     def test_technote(self):
         response = client.get(reverse('disclosures:pfc-technote'))

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -229,14 +229,14 @@ class FeedbackView(TemplateView):
             return HttpResponseBadRequest("Invalid form")
 
 
-class BuildComparisonView(View):
+# class BuildComparisonView(View):
 
-    def get(self, request):
-        return render_to_response('worksheet.html',
-                                  {'data_js': "0",
-                                   'base_template': BASE_TEMPLATE,
-                                   'url_root': URL_ROOT},
-                                  context_instance=RequestContext(request))
+#     def get(self, request):
+#         return render_to_response('worksheet.html',
+#                                   {'data_js': "0",
+#                                    'base_template': BASE_TEMPLATE,
+#                                    'url_root': URL_ROOT},
+#                                   context_instance=RequestContext(request))
 
 
 class SchoolRepresentation(View):


### PR DESCRIPTION
In turning off URLs, I missed the bare /understanding-your-financial-aid-offer/
URL, which would probably be the starting point for nonsettlement.
## Removals
- Nonsettlement URL turned off
## Testing
- Can only be ssen on build.
- Should have no effect in standalone
## Review
- @amymok or @marteki or @mistergone 
