### PR TITLE
Option to deliver generic national stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Updates loan origination fee displays to work with corrected constants
 - Fix alignment issues in debt summary
 - Update our national statistics from scorecard project
+- Update national stats to deliver generic stats at /api/national-stats/
 
 ## 2.1.5
 - Show recalculation updates on mobile screens

--- a/paying_for_college/disclosures/urls.py
+++ b/paying_for_college/disclosures/urls.py
@@ -30,7 +30,11 @@ urlpatterns = [
         ConstantsRepresentation.as_view(),
         name='constants-json'),
 
-    url(r'^api/national-stats/([^/]+)/$',
+    url(r'^api/national-stats/$',
+        StatsRepresentation.as_view(),
+        name='national-stats-generic-json'),
+
+    url(r'^api/national-stats/(?P<id_pair>[^/]+)/$',
         StatsRepresentation.as_view(),
         name='national-stats-json'),
 

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -192,9 +192,9 @@ class SchoolSearchTest(django.test.TestCase):
         test1 = get_program(school, '981')
         self.assertTrue('Occupational' in test1.program_name)
         test2 = get_program(school, 'xxx')
-        self.assertTrue(test2 == '')
+        self.assertTrue(test2 == None)
         test3 = get_program(school, '<program>')
-        self.assertTrue(test3 == '')
+        self.assertTrue(test3 == None)
 
     @mock.patch('paying_for_college.views.SearchQuerySet.autocomplete')
     def test_school_search_api(self, mock_sqs_autocomplete):
@@ -308,10 +308,11 @@ class APITests(django.test.TestCase):
         url = reverse('disclosures:national-stats-json', args=['408039'])
         resp = client.get(url)
         self.assertTrue('retentionRateMedian' in resp.content)
+        self.assertTrue(resp.status_code == 200)
         url2 = reverse('disclosures:national-stats-json', args=['000000'])
         resp2 = client.get(url2)
-        self.assertTrue('No school' in resp2.content)
-        self.assertTrue(resp2.status_code == 400)
+        self.assertTrue('nationalSalary' in resp2.content)
+        self.assertTrue(resp2.status_code == 200)
 
     def test_expense_json(self):
         """api call for BLS expense data"""

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -77,6 +77,8 @@ def validate_oid(oid):
 
 
 def validate_pid(pid):
+    if not pid:
+        return False
     for char in [';', '<', '>', '{', '}']:
         if char in pid:
             return False
@@ -116,13 +118,13 @@ def get_school(schoolID):
 def get_program(school, programCode):
     """Try to get latest program; return either program or empty string"""
     if not validate_pid(programCode):
-        return ''
+        return None
     programs = Program.objects.filter(program_code=programCode,
                                       institution=school).order_by('-pk')
     if programs:
         return programs[0]
     else:
-        return ''
+        return None
 
 
 class BaseTemplateView(TemplateView):
@@ -276,6 +278,7 @@ class ProgramRepresentation(View):
                             content_type='application/json')
 
 
+
 class StatsRepresentation(View):
 
     def get_stats(self, school, programID):
@@ -283,17 +286,17 @@ class StatsRepresentation(View):
         national_stats = nat_stats.get_prepped_stats(program_length=get_program_length(program, school))
         return json.dumps(national_stats)
 
-    def get(self, request, id_pair):
+    def get(self, request, id_pair=''):
         school_id = id_pair.split('_')[0]
         school = get_school(school_id)
-        if not school:
-            error = ("No school could be found "
-                     "for iped ID {0}".format(school_id))
-            return HttpResponseBadRequest(error)
+        # if not school:
+        #     error = ("No school could be found "
+        #              "for iped ID {0}".format(school_id))
+        #     return HttpResponseBadRequest(error)
         try:
             program_id = id_pair.split('_')[1]
         except:
-            program_id = ''
+            program_id = None
         stats = self.get_stats(school, program_id)
         return HttpResponse(stats, content_type='application/json')
 

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -278,7 +278,6 @@ class ProgramRepresentation(View):
                             content_type='application/json')
 
 
-
 class StatsRepresentation(View):
 
     def get_stats(self, school, programID):
@@ -289,10 +288,6 @@ class StatsRepresentation(View):
     def get(self, request, id_pair=''):
         school_id = id_pair.split('_')[0]
         school = get_school(school_id)
-        # if not school:
-        #     error = ("No school could be found "
-        #              "for iped ID {0}".format(school_id))
-        #     return HttpResponseBadRequest(error)
         try:
             program_id = id_pair.split('_')[1]
         except:


### PR DESCRIPTION
In addition to delivering national salary and grad rates tied to program
length, this delivers fall-back generic salary and grad-rate values when
the bare `/api/national-stats/` endpoint is called without providing a school ID 
or program ID. This also provides a fallback in case both school ID and program ID are bad.
## Additions
- new URL option
## Changes
- StatsRepresentation view and related tests and functions
## Testing

A call to the `/api/national-stats/` [bare endpoint](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/national-stats/), with no school or program ID, should return these generic stats, including the $34,300 overall median salary used in college scorecard comparisons:

<img width="345" alt="generic stats" src="https://cloud.githubusercontent.com/assets/515885/17423710/fab031c4-5a8a-11e6-9995-4a6c3bf8a0fb.png">

Calls that provide an extra URL field with a schoolID_programID pair will work as before, delivering salary and grad rate values based on program length.
## Review
- @amymok or @marteki or @mistergone 

FYI: @saintsoup52
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
