### PR TITLE
don't treat PID as numeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Update national stats to deliver generic stats at /api/national-stats/
 - simplify warnings for ID problems
 - Updated the budget section to better message lack of salary data
+- don't treat PID as numeric in js -- characters are allowed
 
 ## 2.1.5
 - Show recalculation updates on mobile screens

--- a/src/disclosures/js/utils/query-handler.js
+++ b/src/disclosures/js/utils/query-handler.js
@@ -17,7 +17,7 @@ function queryHandler( queryString ) {
   };
   var parameters = {};
   var numericKeys = [
-    'iped', 'pid', 'tuit', 'hous', 'book', 'tran', 'othr',
+    'iped', 'tuit', 'hous', 'book', 'tran', 'othr',
     'pelg', 'schg', 'stag', 'othg', 'mta', 'gib', 'fam', 'wkst', 'parl',
     'perl', 'subl', 'unsl', 'ppl', 'gpl', 'prvl', 'prvi', 'prvf', 'insl',
     'insi', 'sav', 'totl'


### PR DESCRIPTION
PID values are allowed to have characters and should not be stripped.
Sorry I'm tumbling to this so late, but stripping will defeat some program IDs.
## Changes
- Take pid out of the `numercKeys` list
## Testing
- We can't test this with current EDMC programs, because as luck would have it they made all their IDs integers. But here's how you can hack a program locally to test it:
- fire up runserver

```
.manage.py runserver
```
- In another tab, fire up the virtual env and open a shell session

```
./manage.py shell
```

Then in shell, paste all this in:

```
from paying_for_college.models import *
p = Program.objects.get(program_code='1832')
p.program_code = 'a832'
p.save()
exit()
```

Then try [this disclosure](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=449898&pid=a832&oid=fa8283b5b7c939a058889f997949efa566c616a1&book=1500&gib=0&gpl=0&hous=5611&insi=5.0&insl=3000&inst=36&mta=0&othg=100&othr=6079&parl=7000&pelg=1500&perl=5500&ppl=0&prvl=2000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&totl=44700&tran=500&tuit=22322&unsl=2000&wkst=1000)
It should render a disclosure without errors, using a pid with a letter in it.

Then check out master, run `gulp` and refresh the same URL. It should go wonky because the API program call will fail (with a stripped ID) but the back end won't raise a warning because the pid is valid before it hits the page.

if you want to reset your programs to their former pristine state:

```
./manage.py purge programs
./manage.py loaddata collegedata
```
## Review
- @mistergone or @marteki 
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
