### PR TITLE
Add levelCode value to program data

### DIFF
--- a/paying_for_college/disclosures/urls.py
+++ b/paying_for_college/disclosures/urls.py
@@ -8,6 +8,9 @@ urlpatterns = [
     url(r'^offer/$',
         OfferView.as_view(), name='offer'),
 
+    url(r'^offer/test/$',
+        OfferView.as_view(test=True), name='offer_test'),
+
     url(r'^api/email/$', EmailLink.as_view(), name='email'),
 
     url(r'^feedback/$',

--- a/paying_for_college/migrations/0010_program_test.py
+++ b/paying_for_college/migrations/0010_program_test.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('paying_for_college', '0009_auto_20160727_1310'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='program',
+            name='test',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -520,6 +520,7 @@ class Program(models.Model):
                                    help_text="COMPLETERS WHO GET RELATED JOB")
     job_note = models.TextField(blank=True,
                                 help_text="EXPLANATION FROM SCHOOL")
+    test = models.BooleanField(default=False)
 
     def __unicode__(self):
         return u"%s (%s)" % (self.program_name, unicode(self.institution))
@@ -548,6 +549,7 @@ class Program(models.Model):
             'jobNote': self.job_note,
             'jobRate': "{0}".format(self.job_rate),
             'level': self.get_level(),
+            'levelCode': self.level,
             'medianStudentLoanCompleters': self.median_student_loan_completers,
             'meanStudentLoanCompleters': self.mean_student_loan_completers,
             'privateDebt': self.private_debt,

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -228,6 +228,7 @@ class OfferTest(django.test.TestCase):
         """request for offer disclosure."""
 
         url = reverse('disclosures:offer')
+        url_test = ('disclosures:offer_test')
         qstring = ('?iped=408039&pid=981&'
                    'oid=f38283b5b7c939a058889f997949efa566c616c5&'
                    'tuit=38976&hous=3000&book=650&tran=500&othr=500&'
@@ -251,6 +252,8 @@ class OfferTest(django.test.TestCase):
                       '5b7c939a058889f997949efa566c616c5')
         resp = client.get(url+qstring)
         self.assertTrue(resp.status_code == 200)
+        resp_test = client.get(url+qstring)
+        self.assertTrue(resp_test.status_code == 200)
         resp2 = client.get(url+no_oid)
         self.assertTrue(resp2.status_code == 200)
         self.assertTrue("noOffer" in resp2.context['warning'])

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -136,6 +136,7 @@ class BaseTemplateView(TemplateView):
 
 class OfferView(TemplateView):
     """consult values in querystring and deliver school/program data"""
+    test = False
 
     def get(self, request):
         school = None
@@ -164,6 +165,8 @@ class OfferView(TemplateView):
                     if PID:
                         programs = Program.objects.filter(program_code=PID,
                                                           institution=school).order_by('-pk')
+                        if not self.test:
+                            programs = programs.filter(test=False)
                         if programs:
                             program = programs[0]
                             program_data = program.as_json()


### PR DESCRIPTION
Our "level" values are not code-friendly. This adds a new value, `levelCode,` to program API data as a coding option. levelCode is the raw level value that is mapped to degree types based on this mapping: 

```
var levelCodes = {
  '0': "Non-degree-granting",
  '1': 'Certificate',
  '2': "Associate degree",
  '3': "Bachelor's degree",
  '4': "Graduate degree"
};
```

This PR also adds a `test` Boolean value to the Program model to allow for safer testing of fake program data. The live tool will not see test programs.  
Only the `/offer/test/` URL will be able to see test program data.
## Additions
- program values `levelCode` and `test`
- matching URLs and tests
- new data fixture and migration
## Testing

Pull, run `migrate` and `loaddata collegedata`, and the new `levelCode` value should show up for any [program API call](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/program/450526_3353/)

<img width="409" alt="levelcode" src="https://cloud.githubusercontent.com/assets/515885/17459413/8b8936b2-5c04-11e6-8f00-7e2e0e3ffab8.png">
## Review
- @amymok @mistergone @marteki 
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
