### PR TITLE
Reset API to deliver one value for `nationalSalary`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Update national stats to deliver generic stats at /api/national-stats/
 - simplify warnings for ID problems
 - Updated the budget section to better message lack of salary data
+- Changed `/national-stats/` API to deliver a `nationalSalary` value of $34,300 regardless of program length
 
 ## 2.1.5
 - Show recalculation updates on mobile screens

--- a/paying_for_college/disclosures/scripts/nat_stats.py
+++ b/paying_for_college/disclosures/scripts/nat_stats.py
@@ -92,7 +92,7 @@ def get_prepped_stats(program_length=None):
         national_stats_for_page['completionRateMedian'] = full_data[LENGTH_MAP['completion'][program_length]]['median']
         national_stats_for_page['completionRateMedianLow'] = full_data[LENGTH_MAP['completion'][program_length]]['average_range'][0]
         national_stats_for_page['completionRateMedianHigh'] = full_data[LENGTH_MAP['completion'][program_length]]['average_range'][1]
-        national_stats_for_page['nationalSalary'] = full_data[LENGTH_MAP['earnings'][program_length]]['median']
-        national_stats_for_page['nationalSalaryAvgLow'] = full_data[LENGTH_MAP['earnings'][program_length]]['average_range'][0]
-        national_stats_for_page['nationalSalaryAvgHigh'] = full_data[LENGTH_MAP['earnings'][program_length]]['average_range'][1]
+        # national_stats_for_page['nationalSalary'] = full_data[LENGTH_MAP['earnings'][program_length]]['median']
+        # national_stats_for_page['nationalSalaryAvgLow'] = full_data[LENGTH_MAP['earnings'][program_length]]['average_range'][0]
+        # national_stats_for_page['nationalSalaryAvgHigh'] = full_data[LENGTH_MAP['earnings'][program_length]]['average_range'][1]
     return national_stats_for_page


### PR DESCRIPTION
We were delivering `nationalSalary` based on program length or, if no
program info, by school prodominantDegree. This removes the test and
delivers the nationwide salary value for all cases.
## Removals
- script code that parsed program and school data to deliver salary by program length.
## Testing
- All calls to `/national-stats/` should return a `nationalSalary` value of $34,300. Two tests:
- formerly showed 42051: [Yale](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/national-stats/130794/)
- formerly showed 31080: [Brown-Mackie North Canton](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/national-stats/204316/)
## Review
- @marteki @mistergone @saintsoup52
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
