### PR TITLE
Fix the About This Tool page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Update national stats to deliver generic stats at /api/national-stats/
 - simplify warnings for ID problems
 - Updated the budget section to better message lack of salary data
+- Fixed how data flows into the About This Tool page
 
 ## 2.1.5
 - Show recalculation updates on mobile screens

--- a/src/disclosures/js/index.js
+++ b/src/disclosures/js/index.js
@@ -24,10 +24,12 @@ var app = {
       .done( function( constants, expenses ) {
         financialModel.init( constants[0] );
         financialView.init();
-        expensesModel.init( expenses[0] );
-        expensesView.init();
-        // Check for URL offer data
+        if ( location.href.indexOf( 'about-this-tool' ) === -1 ) {
+          expensesModel.init( expenses[0] );
+          expensesView.init();
+        }
         if ( getUrlValues.urlOfferExists() ) {
+          // Check for URL offer data
           var urlValues = getUrlValues.urlValues();
           $.when( fetch.schoolData( urlValues.collegeID, urlValues.programID ) )
             .done( function( schoolData, programData, nationalData ) {
@@ -59,7 +61,6 @@ var app = {
               // Update expenses model bases on region and salary
               region = schoolValues.BLSAverage.substr( 0, 2 );
               $( '#bls-region-select' ).val( region ).change();
-
             } );
         }
         // set financial caps based on data


### PR DESCRIPTION
This removes a call to the expenses model when on the About This Tool page.
## Changes
- Fixed how data flows into the About This Tool page by not calling the expenses model when we're on it
## Testing

Pull down the branch.
Check any sample offer to make sure that all offer figures and expenses data is properly populated.
Check the About This Tool page. All numeric figures should be properly populated.
## Review
- Any one of @mistergone @higs4281 @amymok 
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
