### PR TITLE
Fixes Grad PLUS loan calculations, other errors

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -8,16 +8,20 @@ patch:
   'npm:minimatch:20160620':
     - capital-framework > npmi > npm > glob > minimatch:
         patched: '2016-06-29T16:28:08.447Z'
-      student-debt-calc > istanbul > fileset > minimatch:
-        patched: '2016-08-04T15:51:44.067Z'
+      glob-all > glob > minimatch:
+        patched: '2016-08-09T00:11:35.413Z'
     - capital-framework > npmi > npm > init-package-json > glob > minimatch:
         patched: '2016-06-29T16:28:08.447Z'
-      student-debt-calc > istanbul > fileset > glob > minimatch:
-        patched: '2016-08-04T15:51:44.067Z'
+      browser-sync > resp-modifier > minimatch:
+        patched: '2016-08-09T00:11:35.413Z'
     - capital-framework > npmi > npm > read-package-json > glob > minimatch:
         patched: '2016-06-29T16:28:08.447Z'
+      protractor > jasmine > glob > minimatch:
+        patched: '2016-08-09T00:11:35.413Z'
     - capital-framework > npmi > npm > init-package-json > read-package-json > glob > minimatch:
         patched: '2016-06-29T16:28:08.447Z'
+      jasmine > glob > minimatch:
+        patched: '2016-08-09T00:11:35.413Z'
     - capital-framework > npmi > npm > read-installed > read-package-json > glob > minimatch:
         patched: '2016-06-29T16:28:08.447Z'
     - capital-framework > npmi > npm > minimatch:
@@ -96,12 +100,37 @@ patch:
         patched: '2016-07-25T15:16:02.601Z'
     - student-debt-calc > fileset > minimatch:
         patched: '2016-07-25T15:16:02.601Z'
+    - student-debt-calc > istanbul > fileset > minimatch:
+        patched: '2016-08-04T15:51:44.067Z'
+    - student-debt-calc > istanbul > fileset > glob > minimatch:
+        patched: '2016-08-04T15:51:44.067Z'
   'npm:tough-cookie:20160722':
     - capital-framework > npmi > npm > npm-registry-client > request > tough-cookie:
         patched: '2016-07-25T15:16:02.601Z'
+      browser-sync > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-09T00:11:35.413Z'
     - capital-framework > npmi > npm > request > tough-cookie:
         patched: '2016-07-25T15:16:02.601Z'
+      browser-sync > localtunnel > request > tough-cookie:
+        patched: '2016-08-09T00:11:35.413Z'
     - capital-framework > npmi > npm > node-gyp > request > tough-cookie:
         patched: '2016-07-25T15:16:02.601Z'
     - student-debt-calc > request > tough-cookie:
         patched: '2016-07-25T15:16:02.601Z'
+  'npm:negotiator:20160616':
+    - browser-sync > socket.io > engine.io > accepts > negotiator:
+        patched: '2016-08-09T00:11:35.413Z'
+    - browser-sync > serve-index > accepts > negotiator:
+        patched: '2016-08-09T00:11:35.413Z'
+    - accepts > negotiator:
+        patched: '2016-08-09T00:11:35.413Z'
+  'npm:request:20160119':
+    - browser-sync > localtunnel > request:
+        patched: '2016-08-09T00:11:35.413Z'
+  'npm:ws:20160624':
+    - browser-sync > socket.io > socket.io-client > engine.io-client > ws:
+        patched: '2016-08-09T00:11:35.413Z'
+    - protractor > selenium-webdriver > ws:
+        patched: '2016-08-09T00:11:35.413Z'
+    - browser-sync > socket.io > engine.io > ws:
+        patched: '2016-08-09T00:11:35.413Z'

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -772,9 +772,9 @@
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.1.tgz"
     },
     "connect-history-api-fallback": {
-      "version": "1.2.0",
+      "version": "1.3.0",
       "from": "connect-history-api-fallback@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz"
     },
     "console-browserify": {
       "version": "1.1.0",
@@ -3370,21 +3370,19 @@
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz"
         },
         "qs": {
-          "version": "5.2.0",
+          "version": "5.2.1",
           "from": "qs@>=5.2.0 <5.3.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz"
         },
         "request": {
           "version": "2.65.0",
           "from": "request@2.65.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
-          "dependencies": {
-            "tough-cookie": {
-              "version": "2.2.2",
-              "from": "tough-cookie@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
-            }
-          }
+          "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz"
+        },
+        "tough-cookie": {
+          "version": "2.2.2",
+          "from": "tough-cookie@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
         },
         "yargs": {
           "version": "3.29.0",
@@ -5722,16 +5720,9 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
     },
     "resp-modifier": {
-      "version": "6.0.1",
-      "from": "resp-modifier@6.0.1",
-      "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.1.tgz",
-      "dependencies": {
-        "minimatch": {
-          "version": "2.0.10",
-          "from": "minimatch@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
-        }
-      }
+      "version": "6.0.2",
+      "from": "resp-modifier@6.0.2",
+      "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz"
     },
     "restore-cursor": {
       "version": "1.0.1",
@@ -6253,8 +6244,8 @@
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz"
     },
     "student-debt-calc": {
-      "version": "2.5.11",
-      "from": "student-debt-calc@2.5.11",
+      "version": "2.6.0",
+      "from": "student-debt-calc@2.6.0",
       "dependencies": {
         "abbrev": {
           "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "require-dir": "0.3.0",
     "snyk": "1.18.0",
     "sticky-kit": "1.1.3",
-    "student-debt-calc": "2.5.11"
+    "student-debt-calc": "2.6.0"
   },
   "snyk": true
 }

--- a/src/disclosures/js/index.js
+++ b/src/disclosures/js/index.js
@@ -52,7 +52,6 @@ var app = {
                 publish.financialData( 'totalCost', null );
               }
               financialView.updateViewWithURL( schoolValues, urlValues );
-
               // initialize metric view
               metricView.init();
               financialView.updateView( getFinancial.values() );

--- a/src/disclosures/js/models/financial-model.js
+++ b/src/disclosures/js/models/financial-model.js
@@ -111,12 +111,14 @@ var financialModel = {
   recalcOverborrowing: function() {
     var model = this.values,
         overBorrow = 0;
-    if ( model.yearOneCosts < model.grantsSavingsTotal + model.borrowingTotal ) {
+    if ( model.costOfAttendance < model.grantsSavingsTotal + model.borrowingTotal ) {
       overBorrow = model.borrowingTotal +
                            model.grantsSavingsTotal -
                            model.costOfAttendance;
-      if ( overBorrow > model.borrowingTotal ) {
-        overBorrow = model.borrowingTotal;
+      if ( overBorrow > model.borrowingTotal && model.borrowingTotal > 0 ) {
+        overBorrow = Math.min( overBorrow, model.borrowingTotal );
+      } else {
+        overBorrow = 0;
       }
     }
     return overBorrow;

--- a/src/disclosures/js/models/financial-model.js
+++ b/src/disclosures/js/models/financial-model.js
@@ -115,7 +115,7 @@ var financialModel = {
       overBorrow = model.borrowingTotal +
                            model.grantsSavingsTotal -
                            model.costOfAttendance;
-      if ( overBorrow > model.borrowingTotal && model.borrowingTotal > 0 ) {
+      if ( overBorrow > 0 && model.borrowingTotal > 0 ) {
         overBorrow = Math.min( overBorrow, model.borrowingTotal );
       } else {
         overBorrow = 0;

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -237,14 +237,17 @@ var financialView = {
    * that is based on the remaining cost
    */
   updateRemainingCostContent: function() {
-    var gap = Math.round( getFinancial.values().gap ),
+    var model = getFinancial.values(),
+        gap = Math.round( model.gap ),
+        overborrowing = Math.round( model.overborrowing ),
         positiveRemainingCost = $( '.offer-part_content-positive-cost' ),
         negativeRemainingCost = $( '.offer-part_content-negative-cost' );
     positiveRemainingCost.hide();
     negativeRemainingCost.hide();
+
     if ( gap > 0 ) {
       positiveRemainingCost.show();
-    } else if ( gap < 0 ) {
+    } else if ( overborrowing > 0 ) {
       var $span = negativeRemainingCost.find( '[data-financial="gap"]' );
       $span.text( $span.text().replace( '-', '' ) );
       negativeRemainingCost.show();


### PR DESCRIPTION
This PR updates `student-debt-calc` to version 2.6.0, which fixes Grad PLUS loan limit calculations. It also addresses an odd calculation error caused by inconsistent variable use in `student-debt-calc`.
## Changes
- updates `student-debt-calc` to 2.6.0
- updates `browser-sync` to 2.14.0 (fixes a vulnerability)
## Testing
- Passes unit tests!
## Review
- @marteki @higs4281 - pull it down, `npm install`, `gulp`, and try it out!
- [Here's a (localhost) link where Grad PLUS should be $8,000](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=121983&pid=3845&totl=0&tuit=1000&hous=2000&book=1000&tran=1000&othr=3000&pelg=0&schg=1000&stag=1100&othg=1200&mta=1300&gib=1400&wkst=50&ppl=1300&parl=1200&perl=0&subl=0&unsl=0&gpl=8000&prvl=0&prvi=4.55&prvf=2.1&insl=0&insi=5&inst=36&oid=9e0280139f3238cbc9702c7b0d62e5c238a835d0#info-right)
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
## Animated GIF

![30-rock-bad-ideas](https://cloud.githubusercontent.com/assets/1490703/17501010/cfe1f0b0-5da8-11e6-9a79-0912c27b19d9.gif)
