### PR TITLE
Add handling for test programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## Unreleased
+- Added model function for exporting program as CSV
+
 ## 2.2.0
-- release for school review
-- fix wording in costs section after BLS review
+- Release for school review
+- Fixed wording in costs section after BLS review
 
 ## 2.1.8
-- fixed GradPlus and over-borrowing calculations
-- student-debt-calc bumped to v. 2.6.0
+- Fixed GradPlus and over-borrowing calculations
+- Student-debt-calc bumped to v. 2.6.0
 
 ## 2.1.7
 - Added security updates

--- a/paying_for_college/disclosures/scripts/load_programs.py
+++ b/paying_for_college/disclosures/scripts/load_programs.py
@@ -150,6 +150,7 @@ def clean(data):
 
 # 'source' should be a CSV file path or, if s3 is True, an s3 URL
 def load(source, s3=False):
+    test_program = False
     new_programs = 0
     updated_programs = 0
     FAILED = []  # failed messages
@@ -161,6 +162,8 @@ def load(source, s3=False):
         return (["ERROR: could not read data from {0}".format(source)], "")
 
     for row in raw_data:
+        if 'test' in row.keys() and row['test'].lower() == 'true':
+            test_program = True
         fixed_data = clean(row)
         serializer = ProgramSerializer(data=fixed_data)
 
@@ -204,6 +207,7 @@ def load(source, s3=False):
             program.books = data['books_supplies']
             program.completers = data['completers']
             program.completion_cohort = data['completion_cohort']
+            program.test = test_program
             program.save()
 
         else:  # There is error

--- a/paying_for_college/disclosures/urls.py
+++ b/paying_for_college/disclosures/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
         OfferView.as_view(), name='offer'),
 
     url(r'^offer/test/$',
-        OfferView.as_view(test=True), name='offer_test'),
+        OfferView.as_view(), {'test': True}, name='offer_test'),
 
     url(r'^api/email/$', EmailLink.as_view(), name='email'),
 

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -572,7 +572,7 @@ class Program(models.Model):
 
         return json.dumps(ordered_out)
 
-    def as_csv(self, csvpath, test=True):
+    def as_csv(self, csvpath):
         """Output a CSV representation of a program"""
         headings = [
             'ipeds_unit_id',

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -10,6 +10,8 @@ from string import Template
 import smtplib
 
 import requests
+
+from paying_for_college.csvkit.csvkit import Writer as cdw
 from django.core.mail import send_mail
 
 REGION_MAP = {'MW': ['IL', 'IN', 'IA', 'KS', 'MI', 'MN',
@@ -550,8 +552,8 @@ class Program(models.Model):
             'jobRate': "{0}".format(self.job_rate),
             'level': self.get_level(),
             'levelCode': self.level,
-            'medianStudentLoanCompleters': self.median_student_loan_completers,
             'meanStudentLoanCompleters': self.mean_student_loan_completers,
+            'medianStudentLoanCompleters': self.median_student_loan_completers,
             'privateDebt': self.private_debt,
             'programCode': self.program_code,
             'programLength': make_divisible_by_6(self.program_length),
@@ -569,6 +571,64 @@ class Program(models.Model):
             ordered_out[key] = dict_out[key]
 
         return json.dumps(ordered_out)
+
+    def as_csv(self, csvpath, test=True):
+        """Output a CSV representation of a program"""
+        headings = [
+            'ipeds_unit_id',
+            'ope_id',
+            'program_code',
+            'program_name',
+            'program_length',
+            'program_level',
+            'accreditor',
+            'median_salary',
+            'average_time_to_complete',
+            'books_supplies',
+            'campus_name',
+            'cip_code',
+            'completion_rate',
+            'completion_cohort',
+            'completers',
+            'default_rate',
+            'job_placement_rate',
+            'job_placement_note',
+            'mean_student_loan_completers',
+            'median_student_loan_completers',
+            'soc_codes',
+            'total_cost',
+            'tuition_fees',
+            'test'
+        ]
+        with open(csvpath, 'w') as f:
+            writer = cdw(f)
+            writer.writerow(headings)
+            writer.writerow([
+                self.institution.school_id,
+                '',
+                self.program_code,
+                self.program_name,
+                self.program_length,
+                self.level,
+                self.accreditor,
+                self.salary,
+                self.time_to_complete,
+                self.books,
+                self.campus,
+                self.cip_code,
+                "{}".format(self.completion_rate),
+                self.completion_cohort,
+                self.completers,
+                "{0}".format(self.default_rate),
+                "{0}".format(self.job_rate),
+                self.job_note,
+                self.mean_student_loan_completers,
+                self.median_student_loan_completers,
+                self.soc_codes,
+                self.total_cost,
+                self.tuition,
+                self.test
+            ])
 
 # class Offer(models.Model):
 #     """

--- a/paying_for_college/tests/test_load_programs.py
+++ b/paying_for_college/tests/test_load_programs.py
@@ -254,6 +254,9 @@ class TestLoadPrograms(django.test.TestCase):
         mock_program.return_value = (program, True)
         load('filename')
         self.assertEqual(mock_read_in.call_count, 4)
+        mock_read_in.return_value[0]['test'] = "True"
+        load('filename')
+        self.assertEqual(mock_read_in.call_count, 5)
 
     @mock.patch('paying_for_college.disclosures.scripts.load_programs.'
                 'clean')

--- a/paying_for_college/tests/test_models.py
+++ b/paying_for_college/tests/test_models.py
@@ -5,6 +5,7 @@ import dateutil.parser
 import smtplib
 
 import mock
+from mock import mock_open, patch
 import requests
 
 from django.test import TestCase
@@ -233,3 +234,14 @@ class NonSettlementNotificaion(TestCase):
         notification = self.create_notification(skul)
         non_msg = notification.notify_school()
         self.assertTrue('No notification required' in non_msg)
+
+
+class ProgramExport(TestCase):
+    fixtures = ['test_program.json']
+
+    def test_program_as_csv(self):
+        p = Program.objects.get(pk=1)
+        m = mock_open()
+        with patch("__builtin__.open", m, create=True):
+            p.as_csv('/tmp.csv')
+        self.assertTrue(m.call_count == 1)

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -136,9 +136,8 @@ class BaseTemplateView(TemplateView):
 
 class OfferView(TemplateView):
     """consult values in querystring and deliver school/program data"""
-    test = False
 
-    def get(self, request):
+    def get(self, request, test=False):
         school = None
         program = None
         program_data = 'null'
@@ -176,9 +175,8 @@ class OfferView(TemplateView):
                         PID = ''
                     if PID:
                         programs = Program.objects.filter(program_code=PID,
-                                                          institution=school).order_by('-pk')
-                        if not self.test:
-                            programs = programs.filter(test=False)
+                                                          institution=school,
+                                                          test=test).order_by('-pk')
                         if programs:
                             program = programs[0]
                             program_data = program.as_json()


### PR DESCRIPTION
This adds an "as_csv" model function to programs to make it easy to
create test programs for demo purposes. It also adjusts the load_program
script to handle an optional "test" column so the programs can be loaded
by a management command via file or s3.

We also tweak the `/offer/test/` option so that it displays _only_ test
programs.
## Additions
- new program model function and related tests
## Changes
- load_programs now handles "test" field
## Testing
- try out loading a test program in your local db:

```
./manage.py load_programs --s3 true http://files.consumerfinance.gov.s3.amazonaws.com/pb/paying_for_college/csv/argosySF_test_program.csv
```

Then fire up runserver and check the test program using an [offer/test/](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/test/?iped=121983&pid=TEST1&oid=fa8283b5b7c939a058889f997949efa566c616a1&book=1500&gib=0&gpl=0&hous=5611&insi=5.0&insl=3000&inst=36&mta=0&othg=100&othr=6079&parl=7000&pelg=1500&perl=5500&ppl=0&prvl=2000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&totl=44700&tran=500&tuit=22322&unsl=2000&wkst=1000) URL
## Review
- @amymok @mistergone @marteki 
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
