### PR TITLE
Data update for tool demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
 - Added model function for exporting program as CSV
+- Marked all non-settlement schools with the `settlement_school` tag of "demo"
 
 ## 2.2.0
 - Release for school review


### PR DESCRIPTION
This PR, which is data-only (no code) introduces some technical debt by marking all current
non-settlement schools as settlement schools, in the service of enabling
demo use of the tool. The schools so tagged will carry a
"settlement_school" value of "demo," which can be identified and removed
when the false tag is no longer needed.
## Review
- Who shall give me a thumbs-up for technical debt? Show yourselves!
- @willbarton ?
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
