### PR TITLE
Add manage command to help tear down demo data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
 - Added model function for exporting program as CSV
+- Added management command for purging test programs
 
 ## 2.2.0
 - Release for school review

--- a/paying_for_college/disclosures/scripts/purge_objects.py
+++ b/paying_for_college/disclosures/scripts/purge_objects.py
@@ -1,12 +1,13 @@
 from paying_for_college.models import Notification, Program
 
 error_msg = ("The only purge arguments that can be passed "
-             "are 'notifications' and 'programs.'")
-no_args_msg = ("You must supply an object type to purge, "
-               "either notifications or programs")
+             "are 'notifications', 'programs' and 'test-programs'")
+no_args_msg = ("You must supply an object type to purge: "
+               "notifications, programs or test-programs")
 object_map = {
-    'notifications': Notification,
-    'programs': Program
+    'notifications': Notification.objects.all(),
+    'programs': Program.objects.all(),
+    'test-programs': Program.objects.filter(test=True),
 }
 
 
@@ -17,6 +18,7 @@ def purge(objects):
         return no_args_msg
     if objects not in object_map.keys():
         return error_msg
-    msg = "Purging {} {}".format(object_map[objects].objects.count(), objects)
-    object_map[objects].objects.all().delete()
+    queryset = object_map[objects]
+    msg = "Purging {} {}".format(queryset.count(), objects)
+    queryset.delete()
     return msg

--- a/paying_for_college/management/commands/purge.py
+++ b/paying_for_college/management/commands/purge.py
@@ -3,20 +3,20 @@ import datetime
 from django.core.management.base import BaseCommand, CommandError
 from paying_for_college.disclosures.scripts.purge_objects import purge
 
-COMMAND_HELP = ("Purge will wipe out all notifications or programs "
+COMMAND_HELP = ("Purge will wipe out notifications or programs "
                 "in the local Django database. "
                 "It can't be run against any other models, "
-                "and you must provide an object type to purge. "
-                "Use it by running 'manage.py purge notifications' "
-                "or 'manage.py purge projects'")
+                "and you must provide an object type to purge.\n"
+                "Purge all notifications with 'manage.py purge notifications'\n"
+                "Purge all projects with 'manage.py purge projects'\n"
+                "Purge test projecs with 'manage.py purge test-projects'")
 
 
 class Command(BaseCommand):
     help = COMMAND_HELP
 
     def add_arguments(self, parser):
-        parser.add_argument('objects',
-                            type=str)
+        parser.add_argument('objects', type=str)
 
     def handle(self, *args, **options):
         msg = purge(options['objects'])

--- a/paying_for_college/tests/test_scripts.py
+++ b/paying_for_college/tests/test_scripts.py
@@ -9,7 +9,7 @@ from mock import mock_open, patch
 import requests
 from django.utils import timezone
 
-from paying_for_college.models import School, Notification, Alias
+from paying_for_college.models import School, Notification, Alias, Program
 from paying_for_college.disclosures.scripts import (api_utils, update_colleges,
                                                     nat_stats, notifications,
                                                     update_ipeds,
@@ -35,15 +35,20 @@ class PurgeTests(django.test.TestCase):
     fixtures = ['test_fixture.json', 'test_program.json']
 
     def test_purges(self):
+        self.assertFalse(Program.objects.count() == 0)
+        self.assertFalse(Notification.objects.count() == 0)
         self.assertTrue(purge_objects.purge('schools') ==
                         purge_objects.error_msg)
         self.assertTrue(purge_objects.purge('') ==
                         purge_objects.no_args_msg)
-        self.assertTrue("Purging" in purge_objects.purge('programs'))
+        self.assertTrue("test-programs" in
+                        purge_objects.purge('test-programs'))
+        self.assertFalse(Program.objects.count() == 0)
         self.assertTrue("programs" in purge_objects.purge('programs'))
-        self.assertTrue("Purging" in purge_objects.purge('notifications'))
+        self.assertTrue(Program.objects.count() == 0)
         self.assertTrue("notifications" in
                         purge_objects.purge('notifications'))
+        self.assertTrue(Notification.objects.count() == 0)
 
 
 class TestScripts(django.test.TestCase):

--- a/paying_for_college/tests/test_scripts.py
+++ b/paying_for_college/tests/test_scripts.py
@@ -35,20 +35,18 @@ class PurgeTests(django.test.TestCase):
     fixtures = ['test_fixture.json', 'test_program.json']
 
     def test_purges(self):
-        self.assertFalse(Program.objects.count() == 0)
-        self.assertFalse(Notification.objects.count() == 0)
+        self.assertTrue(Program.objects.exists())
+        self.assertTrue(Notification.objects.exists())
         self.assertTrue(purge_objects.purge('schools') ==
                         purge_objects.error_msg)
         self.assertTrue(purge_objects.purge('') ==
                         purge_objects.no_args_msg)
-        self.assertTrue("test-programs" in
-                        purge_objects.purge('test-programs'))
-        self.assertFalse(Program.objects.count() == 0)
-        self.assertTrue("programs" in purge_objects.purge('programs'))
-        self.assertTrue(Program.objects.count() == 0)
-        self.assertTrue("notifications" in
-                        purge_objects.purge('notifications'))
-        self.assertTrue(Notification.objects.count() == 0)
+        self.assertIn("test-programs", purge_objects.purge('test-programs'))
+        self.assertTrue(Program.objects.exists())
+        self.assertIn("programs", purge_objects.purge('programs'))
+        self.assertFalse(Program.objects.exists())
+        self.assertIn("notifications", purge_objects.purge('notifications'))
+        self.assertFalse(Notification.objects.exists())
 
 
 class TestScripts(django.test.TestCase):


### PR DESCRIPTION
The `purge test-programs` command will wipe out fake programs created
for demo use without destroying real settlement program data and
without requiring a code deployment.
## Additions
- New parameter for the `purge` command, plus related tests
## Testing
- `./manage.py purge test-programs` could be tested against a local db, although you're unlikely to have test programs set up locally. 
  But programs are cheap and easily replaced, so there's no danger in testing. If you wipe out all programs, `./manage.py loaddata collegedata` will restore the real ones.
## Review
- @willbarton
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
