### PR TITLE
Docs

### DIFF
--- a/docs/notification-spec.md
+++ b/docs/notification-spec.md
@@ -15,13 +15,13 @@ errors: none
 **time** is a UTC timestamp string representing when the disclosure notification was generated.  
 **errors** is a string indicating whether the disclosure was valid. It will have one of two values:  
 
-- "none"  
-This will confirm that the disclosure was completed and is valid.
+  - "none"  
+  This will confirm that the disclosure was completed and is valid.
 
-- "INVALID: student indicated the offer information is wrong"  
-This indicates that the student clicked on the link labeled "No, this is not my information"  
-This option is intended to catch cases where the student was given the wrong URL or a faulty URL.  
-In this case, a new oid will need to be generated in order to complete a valid disclosure; oid values are allowed to generate only one notification.
+  - "INVALID: student indicated the offer information is wrong"  
+  This indicates that the student clicked on the link labeled "No, this is not my information"  
+  This option is intended to catch cases where the student was given the wrong URL or a faulty URL.  
+  In this case, a new oid will need to be generated in order to complete a valid disclosure; oid values are allowed to generate only one notification.
 
 ## Email notification
 Endpoint notifications are preferred because they are more reliable and simpler to automate.  

--- a/docs/offer-ids.md
+++ b/docs/offer-ids.md
@@ -1,0 +1,36 @@
+## Offer IDs
+
+Offer IDs allow a school to provide details of a student's enrollment offer without revealing who the student is. It also allows EDMC to send confirmations to the school that a disclosure was reviewed the student, but without knowing who the student is and without transmitting any personal information.
+
+Only the school will know which student the offer ID applies to.
+
+We chose a 40-hex-character hash as the offer ID because it is safe to accept and transmit, and unique hashes are easy to create in a way that cannot be linked to a student.
+
+The school can decide what values to use to generate the offer ID hashes. 
+An easy method would be to combine a timestamp and another value -- such as a student ID or even a completely random number or numbers -- and generate a hash from those values.
+
+Following is a Python script that would generate such a hash from an input value of the school's choice. It uses the SHA-1 hash algorithm, which generates a 40-character hash string. This is the same algorithm used to generate GitHub commit ID.
+
+```python
+"""script to generate offer IDs"""
+import sys
+import hashlib
+import datetime
+
+
+def create_hash(value):
+    """returns a unique 40-character SHA-1 hash using the value provided."""
+    val = value + datetime.datetime.now().isoformat()
+    return hashlib.sha1(val).hexdigest()
+```
+
+This would return a unique offer ID that could be used as the 'oid' value in the offer URL.  
+If run again with the same value, it will generate a completely new unique value, because a timestamp used.
+
+The school could generate the ID, keep a record of it as the student's offer ID and use it in the schools disclosure URL as spelled out in the [URL specification](https://cfpb.github.io/college-costs/url-spec/).
+
+The Python hashing script is [available for download](http://files.consumerfinance.gov.s3.amazonaws.com/pb/paying_for_college/scripts/create_offer_hash.py) and can be run with this command:
+
+```
+python create_offer_hash.py [VALUE]
+```

--- a/docs/offer-ids.md
+++ b/docs/offer-ids.md
@@ -1,36 +1,48 @@
 ## Offer IDs
 
-Offer IDs allow a school to provide details of a student's enrollment offer without revealing who the student is. It also allows EDMC to send confirmations to the school that a disclosure was reviewed the student, but without knowing who the student is and without transmitting any personal information.
+Offer IDs allow a school to provide a disclosure of a student's enrollment offer without revealing who the student is. They also allow the CFPB to send confirmations to the school that a disclosure was reviewed by a student, but without transmitting any information about the student.
 
 Only the school will know which student the offer ID applies to.
 
-We chose a 40-hex-character hash as the offer ID because it is safe to accept and transmit, and unique hashes are easy to create in a way that cannot be linked to a student.
+We chose a 40-hex-character hash as the form for an offer ID because it has two advantages:  
+
+- The hashes contain only numbers and the letters a-f and are safe to transmit and accept.
+- Unique hash values are easy to create in a way that cannot be traced back to a student.
 
 The school can decide what values to use to generate the offer ID hashes. 
-An easy method would be to combine a timestamp and another value -- such as a student ID or even a completely random number or numbers -- and generate a hash from those values.
+One easy method would be to combine a timestamp and another value -- such as a student ID or even a completely random number or numbers -- and generate a SHA-1 hash from those values.
 
-Following is a Python script that would generate such a hash from an input value of the school's choice. It uses the SHA-1 hash algorithm, which generates a 40-character hash string. This is the same algorithm used to generate GitHub commit ID.
+Following is a short Python script that generates such a hash from an input value of the school's choice. It uses the SHA-1 hash algorithm to create the required 40-character offer ID.
 
 ```python
 """script to generate offer IDs"""
-import sys
 import hashlib
 import datetime
 
 
 def create_hash(value):
-    """returns a unique 40-character SHA-1 hash using the value provided."""
+    """returns a one-time, unique 40-character SHA-1 hash using the value provided."""
     val = value + datetime.datetime.now().isoformat()
     return hashlib.sha1(val).hexdigest()
 ```
 
-This would return a unique offer ID that could be used as the 'oid' value in the offer URL.  
-If run again with the same value, it will generate a completely new unique value, because a timestamp used.
+This would return a unique offer ID that could be used as the 'oid' value in a student's offer URL.  
+If run again with the same value, it will generate a completely new unique ID, because a new timestamp is used in creating each hash.
 
-The school could generate the ID, keep a record of it as the student's offer ID and use it in the schools disclosure URL as spelled out in the [URL specification](https://cfpb.github.io/college-costs/url-spec/).
+The school could generate an ID, using any input value desired, keep a record of it as the student's offer ID and use it in the student's disclosure URL as spelled out in the [URL specification](https://cfpb.github.io/college-costs/url-spec/).
 
-The Python hashing script is [available for download](http://files.consumerfinance.gov.s3.amazonaws.com/pb/paying_for_college/scripts/create_offer_hash.py) and can be run with this command:
+**The first seven characters in the offer ID should be given to the student so that she can confirm on the  disclosure page that the offer is hers.** 
+
+The Python hashing script above is [available for download](http://files.consumerfinance.gov.s3.amazonaws.com/pb/paying_for_college/scripts/create_offer_hash.py) and can be run from a shell command line with this command:
 
 ```
 python create_offer_hash.py [VALUE]
 ```
+Replace '[VALUE]' with a value of your choice, and the script will generate a unique offer ID with each use.  
+Example:
+```
+python create_offer_hash.py student123
+```
+
+Entering that command will produce something like this:  
+`2df92217303700c6165d56a24b89cef419133a89`

--- a/docs/offer-ids.md
+++ b/docs/offer-ids.md
@@ -4,6 +4,13 @@ Offer IDs allow a school to provide a disclosure of a student's enrollment offer
 
 Only the school will know which student the offer ID applies to.
 
+Two important details to note:  
+
+- **The first seven characters in the offer ID should be given to the student so that she can confirm on the  disclosure page that the offer is hers.** 
+- **An offer ID can be used only once.**  
+If an offer ID generates a notification, either successful or with an error, it cannot be used again to validate an offer. If a student needs to re-evaluate an offer, an new offer ID needs to be generated and used in a new offer URL. 
+
+## Technical details
 We chose a 40-hex-character hash as the form for an offer ID because it has two advantages:  
 
 - The hashes contain only numbers and the letters a-f and are safe to transmit and accept.
@@ -30,8 +37,6 @@ This would return a unique offer ID that could be used as the 'oid' value in a s
 If run again with the same value, it will generate a completely new unique ID, because a new timestamp is used in creating each hash.
 
 The school could generate an ID, using any input value desired, keep a record of it as the student's offer ID and use it in the student's disclosure URL as spelled out in the [URL specification](https://cfpb.github.io/college-costs/url-spec/).
-
-**The first seven characters in the offer ID should be given to the student so that she can confirm on the  disclosure page that the offer is hers.** 
 
 The Python hashing script above is [available for download](http://files.consumerfinance.gov.s3.amazonaws.com/pb/paying_for_college/scripts/create_offer_hash.py) and can be run from a shell command line with this command:
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    
+    <title>college-costs documentation</title>
+    
+    
+
+    <link rel="stylesheet" href="./css/normalize.css">
+    <link rel="stylesheet" href="./css/main.css">
+    <link rel="stylesheet" href="./css/syntax.css">
+    
+
+    
+    <style type="text/css">
+        .sidebar-nav a:hover,
+        .sidebar-nav a:focus,
+        .sidebar-nav a:active,
+        .sidebar-nav a.sidebar-nav-active {
+            border-left-color: #2CB34A;
+        }
+        header {
+            border-bottom-color: #2CB34A;
+        }
+    </style>
+    
+
+    <!--[if lt IE 9]>
+      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="./js/respond.min.js"></script>
+    <![endif]--> 
+</head>
+
+<body>
+    
+    <div class="container">
+        <header role="banner">
+            <div class="wrap">
+                
+                <img class="logo" src="https://cfpb.github.io/img/logo_210.png" alt="Consumer Financial Protection Bureau">
+                
+                <h1 class="site-title"><a class="title-link" href="./">college-costs</a></h1>
+            </div>
+        </header>
+    
+        <div class="wrap content">
+            <aside>
+                <nav class="sidebar-nav" role="navigation">
+                    <ul>
+                        
+                        <li>
+                             
+                            <a href="." class="sidebar-nav-active">Introduction</a>
+
+                            
+                        </li>
+                        
+                        <li>
+                            
+                            <span>Specifications</span>
+                            <ul class="secondary-nav">
+                                
+                                <li>
+                                    <a href="csv-spec/" class="">CSV spec for program data</a>
+                                </li>
+                                
+                                <li>
+                                    <a href="url-spec/" class="">URL spec for offer data</a>
+                                </li>
+                                
+                                <li>
+                                    <a href="notification-spec/" class="">Notification spec validating offers</a>
+                                </li>
+                                
+                                <li>
+                                    <a href="offer-ids/" class="">How to create offer IDs</a>
+                                </li>
+                                
+                            </ul>
+                            
+                        </li>
+                        
+                    </ul>
+                </nav>
+            </aside>
+
+            <section id="main" class="main-content" role="main">
+                <h1 id="data-specifications">Data specifications</h1>
+<p>This is specification documentation for the <a href="https://github.com/cfpb/college-costs">college-costs</a> project.</p>
+<p>The project takes in and displays information about the costs and benefits of enrolling in a collegiate program.</p>
+<p>This documentation spells out how information to be used should be formatted and delivered.</p>
+            </section>
+        </div>
+
+        <footer role="contentinfo">
+            <div class="wrap">
+                This project is maintained by <a href="https://cfpb.github.io">The Consumer Financial Protection Bureau.</a>.
+
+                <p>Hosted on <a href="http://pages.github.com/">GitHub Pages</a>.</p>
+            </div>
+        </footer>
+    </div> 
+</body>
+</html>
+
+<!--
+MkDocs version : 0.15.3
+Build Date UTC : 2016-08-24 17:05:39.311577
+-->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ pages:
     - CSV spec for program data: csv-spec.md
     - URL spec for offer data: url-spec.md
     - Notification spec validating offers: notification-spec.md
+    - How to create offer ID hashes: offer-ids.md
 
 theme: mkDOCter
 extra:


### PR DESCRIPTION
This adds documentation explaining how offer IDs work and how to create them.  
New schools will need this information.
## Additions
- Docs page on offer IDs with a downloadable python script for creating them.
## Testing
- Review the new [Offer ID page](https://cfpb.github.io/college-costs/offer-ids/)
## Review
- Any of @amymok @marteki @mistergone @kurzn @saintsoup52
## Checklist
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
