### PR TITLE
Add a management command to tag settlement schools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## Unreleased
+- Added a script to tag settlement schools using an S3 csv of school IDs
+
 ## 2.2.2
 - Switch to djangorestframework==2.4.8 to match servers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## Unreleased
+- Added manage command to run update_national_stats_file
+
 ## 2.2.2
 - Switch to djangorestframework==2.4.8 to match servers
 

--- a/docs/csv-spec.md
+++ b/docs/csv-spec.md
@@ -11,7 +11,7 @@ program_code | string | assumed unique within a school; <br>can't contain these 
 program_name | string |
 program_length | integer | number of months in program
 program_level | integer | 0 = Non-degree-granting<br> 1 = Certificate<br> 2 = Associate<br> 3 = Bachelor's<br> 4 = Graduate
-accreditor | string | often will be blank
+accreditor | string | may be blank
 median_salary | integer |
 average_time_to_complete | integer | in months
 books_supplies | integer | annual cost of books and supplies

--- a/docs/offer-ids.md
+++ b/docs/offer-ids.md
@@ -8,7 +8,7 @@ Two important details to note:
 
 - **The first seven characters in the offer ID should be given to the student so that she can confirm on the  disclosure page that the offer is hers.** 
 - **An offer ID can be used only once.**  
-If an offer ID generates a notification, either successful or with an error, it cannot be used again to validate an offer. If a student needs to re-evaluate an offer, an new offer ID needs to be generated and used in a new offer URL. 
+If an offer ID generates a notification, either successful or with an error, it cannot be used again to validate an offer. If a student needs to re-evaluate an offer, a new offer ID needs to be generated and used in a new offer URL. 
 
 ## Technical details
 We chose a 40-hex-character hash as the form for an offer ID because it has two advantages:  

--- a/docs/offer-ids.md
+++ b/docs/offer-ids.md
@@ -1,6 +1,6 @@
 ## Offer IDs
 
-Offer IDs allow a school to provide a disclosure of a student's enrollment offer without revealing who the student is. They also allow the CFPB to send confirmations to the school that a disclosure was reviewed by a student, but without transmitting any information about the student.
+Offer IDs allow a school to provide a disclosure of a student's enrollment offer without revealing who the student is. They also allow the CFPB to send a confirmation to the school after a disclosure is reviewed.
 
 Only the school will know which student the offer ID applies to.
 
@@ -8,46 +8,88 @@ Two important details to note:
 
 - **The first seven characters in the offer ID should be given to the student so that she can confirm on the  disclosure page that the offer is hers.** 
 - **An offer ID can be used only once.**  
-If an offer ID generates a notification, either successful or with an error, it cannot be used again to validate an offer. If a student needs to re-evaluate an offer, an new offer ID needs to be generated and used in a new offer URL. 
+If an offer ID generates a notification, either successful or with an error, it cannot be used again to validate an offer. If a student needs to re-evaluate an offer, a new offer ID needs to be generated and used in a new offer URL. 
 
 ## Technical details
 We chose a 40-hex-character hash as the form for an offer ID because it has two advantages:  
 
-- The hashes contain only numbers and the letters a-f and are safe to transmit and accept.
 - Unique hash values are easy to create in a way that cannot be traced back to a student.
+- The hashes contain only numbers and the letters a-f and are safe to transmit and accept.
 
-The school can decide what values to use to generate the offer ID hashes. 
-One easy method would be to combine a timestamp and another value -- such as a student ID or even a completely random number or numbers -- and generate a SHA-1 hash from those values.
+The school is free decide how to generate the offer IDs, but they need to be unique.   
+One easy method would be to combine a timestamp and another value -- such as a student ID or a random number or phrase -- and generate a SHA-1 hash from the combined values.
 
-Following is a short Python script that generates such a hash from an input value of the school's choice. It uses the SHA-1 hash algorithm to create the required 40-character offer ID.
+Following is an example Python function that does just that.
 
 ```python
-"""script to generate offer IDs"""
 import hashlib
 import datetime
 
 
 def create_hash(value):
-    """returns a one-time, unique 40-character SHA-1 hash using the value provided."""
     val = value + datetime.datetime.now().isoformat()
     return hashlib.sha1(val).hexdigest()
 ```
 
 This would return a unique offer ID that could be used as the 'oid' value in a student's offer URL.  
-If run again with the same value, it will generate a completely new unique ID, because a new timestamp is used in creating each hash.
+If run again, even with the same input value, it would generate a new unique ID, because a new timestamp is used in creating each hash.
 
-The school could generate an ID, using any input value desired, keep a record of it as the student's offer ID and use it in the student's disclosure URL as spelled out in the [URL specification](https://cfpb.github.io/college-costs/url-spec/).
+The school could then keep a record of the ID and the student it is for, and use it in the student's disclosure URL as spelled out in our [URL specification](https://cfpb.github.io/college-costs/url-spec/).
 
-The Python hashing script above is [available for download](http://files.consumerfinance.gov.s3.amazonaws.com/pb/paying_for_college/scripts/create_offer_hash.py) and can be run from a shell command line with this command:
+## A helper script
+
+The hashing function above is part of an offer-generating script that is [available for download](http://files.consumerfinance.gov.s3.amazonaws.com/pb/paying_for_college/scripts/create_offer_ids.py). When run from a shell command line, the script can be used to create a single ID or a whole batch of IDs, and the result can be saved as a spreadsheet.
+
+The command to use the script takes this form:
 
 ```
-python create_offer_hash.py [VALUE]
-```
-Replace '[VALUE]' with a value of your choice, and the script will generate a unique offer ID with each use.  
-Example:
-```
-python create_offer_hash.py student123
+python create_offer_ids.py "VALUE" [--number N] [--csv]
 ```
 
-Entering that command will produce something like this:  
+- VALUE is a word or phrase of your choice, used to increase randomness.
+- The `--number` option allows you to provide a number [N] of IDs you'd like to create.
+- The `--csv` option tells the script to create a spreadsheet containing the new IDs.
+
+Example usages:
+
+```
+python create_offer_ids.py "go tigers"
+```
+
+This will return a single unique offer ID, something like this:  
 `2df92217303700c6165d56a24b89cef419133a89`
+
+
+```
+python create_offer_ids.py "go tigers" --number 2
+```
+
+This will return two unique offer IDs, such as  
+```4e259e04a2265b2d3d1114e3f66cb41a44f5be91```  
+```ee350cdc99747d7b85e3556ef1d99ef2b0d1f8b0```
+
+
+```
+python create_offer_ids.py "go tigers" --number 200 --csv
+```
+
+The program will now return a message like this:  
+```200 offer IDs were output to 'student_offer_ids_2016-10-11.csv'```
+
+The CSV could be opened in a program such as Excel and used to assign IDs to prospective students.
+
+Note:  
+The date tag in the CSV's name depends on the day the script is run.  
+If run with the `--csv` option multiple times on the same day, the new IDs will be appended to the first CSV created that day, if it hasn't been moved to a different directory.
+
+If run on another day, a new CSV would be created with that day's date in the name.
+
+<div>
+<form id="hash-input">
+<input type="text" id="hashValue" name="hash-value" placeholder="Enter word or phrase">
+</input>
+</form>
+</div>
+<div>
+<h3 id="offerId"></h3>
+</div>

--- a/docs/offer-ids.md
+++ b/docs/offer-ids.md
@@ -78,18 +78,7 @@ The program will now return a message like this:
 
 The CSV could be opened in a program such as Excel and used to assign IDs to prospective students.
 
-Note:  
-The date tag in the CSV's name depends on the day the script is run.  
-If run with the `--csv` option multiple times on the same day, the new IDs will be appended to the first CSV created that day, if it hasn't been moved to a different directory.
-
-If run on another day, a new CSV would be created with that day's date in the name.
-
-<div>
-<form id="hash-input">
-<input type="text" id="hashValue" name="hash-value" placeholder="Enter word or phrase">
-</input>
-</form>
-</div>
-<div>
-<h3 id="offerId"></h3>
-</div>
+Notes:  
+- The date tag in the CSV's name depends on the day the script is run.  
+- If run with the `--csv` option multiple times on the same day, the new IDs will be appended to the first CSV created that day, if it hasn't been moved to a different directory.
+- If run on another day, a new CSV would be created with that day's date in the name.

--- a/paying_for_college/disclosures/scripts/tag_settlement_schools.py
+++ b/paying_for_college/disclosures/scripts/tag_settlement_schools.py
@@ -1,0 +1,32 @@
+from .load_programs import read_in_s3
+from paying_for_college.views import get_school
+
+
+def tag_schools(s3_url):
+    """
+    Sets schools' 'settlement_school' value based on a CSV
+
+    Assumes the CSV's headings include fields for 'ipeds_unit_id' and 'flag'
+    """
+    counter = 0
+    csv_data = read_in_s3(s3_url)
+    if not csv_data[0]:
+        return "ERROR: could not read data from {0}".format(s3_url)
+    headings = csv_data[0].keys()
+    for heading in ['ipeds_unit_id', 'flag']:
+        if heading not in headings:
+            return ("ERROR: CSV doesn't have required fields; "
+                    "fields found were {}".format(headings))
+    initial_flag = csv_data[0]['flag']
+    for row in csv_data:
+        school = None
+        if row['ipeds_unit_id']:
+            school = get_school(row['ipeds_unit_id'])
+        if school:
+            school.settlement_school = row['flag']
+            school.save()
+            counter += 1
+    intro = "school was" if counter == 1 else "schools were"
+    return "{} {} tagged as '{}' settlement schools".format(counter,
+                                                            intro,
+                                                            initial_flag)

--- a/paying_for_college/management/commands/tag_schools.py
+++ b/paying_for_college/management/commands/tag_schools.py
@@ -1,0 +1,21 @@
+from django.core.management.base import BaseCommand, CommandError
+from paying_for_college.disclosures.scripts import tag_settlement_schools
+
+COMMAND_HELP = """
+`tag_schools` updates the 'settlement_school' flag, which is used to mark 
+schools that are participating in the disclosure program pursuant 
+to a legal settlement. The command accepts one argument, an S3 URL, which  
+should point to a CSV of schools subject to settlement. The CSV must contain 
+columns for 'ipeds_unit_id' and 'flag'.
+"""
+
+
+class Command(BaseCommand):
+    help = COMMAND_HELP
+
+    def add_arguments(self, parser):
+        parser.add_argument('url', type=str)
+
+    def handle(self, *args, **options):
+        msg = tag_settlement_schools.tag_schools(options['url'])
+        self.stdout.write(msg)

--- a/paying_for_college/management/commands/update_pfc_national_stats.py
+++ b/paying_for_college/management/commands/update_pfc_national_stats.py
@@ -1,8 +1,5 @@
-import datetime
-
 from django.core.management.base import BaseCommand, CommandError
 from paying_for_college.disclosures.scripts import nat_stats
-
 
 COMMAND_HELP = """update_pfc_national_stats gets the latest national statistics
  yaml file from collegescorecard, parses it and updates our local json file at

--- a/paying_for_college/management/commands/update_pfc_national_stats.py
+++ b/paying_for_college/management/commands/update_pfc_national_stats.py
@@ -1,0 +1,18 @@
+import datetime
+
+from django.core.management.base import BaseCommand, CommandError
+from paying_for_college.disclosures.scripts import nat_stats
+
+
+COMMAND_HELP = """update_pfc_national_stats gets the latest national statistics
+ yaml file from collegescorecard, parses it and updates our local json file at
+ paying_for_college/fixtures/national_stats.json.
+"""
+
+
+class Command(BaseCommand):
+    help = COMMAND_HELP
+
+    def handle(self, *args, **options):
+        msg = nat_stats.update_national_stats_file()
+        self.stdout.write(msg)

--- a/paying_for_college/tests/test_commands.py
+++ b/paying_for_college/tests/test_commands.py
@@ -4,15 +4,22 @@ import unittest
 from django.core.management.base import CommandError
 from django.core.management import call_command
 
-from paying_for_college.management.commands import (update_ipeds,
-                                                    update_via_api,
-                                                    load_programs,
-                                                    retry_notifications,
-                                                    send_stale_notifications,
-                                                    purge)
+# from paying_for_college.management.commands import (update_ipeds,
+#                                                     update_via_api,
+#                                                     load_programs,
+#                                                     retry_notifications,
+#                                                     send_stale_notifications,
+#                                                     purge, tag_schools)
 
 
 class CommandTests(unittest.TestCase):
+
+    @mock.patch('paying_for_college.management.commands.'
+                'tag_schools.tag_settlement_schools.tag_schools')
+    def test_tag_schools(self, mock_tag):
+        mock_tag.return_value = 'Aye Aye'
+        call_command('tag_schools', 's3URL')
+        self.assertEqual(mock_tag.call_count, 1)
 
     @mock.patch('paying_for_college.management.commands.'
                 'purge.purge')

--- a/paying_for_college/tests/test_commands.py
+++ b/paying_for_college/tests/test_commands.py
@@ -4,13 +4,6 @@ import unittest
 from django.core.management.base import CommandError
 from django.core.management import call_command
 
-# from paying_for_college.management.commands import (update_ipeds,
-#                                                     update_via_api,
-#                                                     load_programs,
-#                                                     retry_notifications,
-#                                                     send_stale_notifications,
-#                                                     purge, tag_schools)
-
 
 class CommandTests(unittest.TestCase):
 

--- a/paying_for_college/tests/test_commands.py
+++ b/paying_for_college/tests/test_commands.py
@@ -15,6 +15,14 @@ from paying_for_college.management.commands import (update_ipeds,
 class CommandTests(unittest.TestCase):
 
     @mock.patch('paying_for_college.management.commands.'
+                'update_pfc_national_stats.nat_stats.'
+                'update_national_stats_file')
+    def test_update_pfc_national_stats(self, mock_update):
+        mock_update.return_value = 'OK'
+        call_command('update_pfc_national_stats')
+        self.assertEqual(mock_update.call_count, 1)
+
+    @mock.patch('paying_for_college.management.commands.'
                 'purge.purge')
     def test_purges(self, mock_purge):
         mock_purge.return_value = 'Aye Aye'

--- a/paying_for_college/tests/test_scripts.py
+++ b/paying_for_college/tests/test_scripts.py
@@ -32,7 +32,7 @@ completion_rate:\n\
 
 
 class TaggingTests(django.test.TestCase):
-    """Test functions for taggins settlement schools via CSV"""
+    """Test functions for tagging settlement schools via CSV"""
 
     fixtures = ['test_fixture.json']
     mock_csv_data = [{"ipeds_unit_id": "243197",

--- a/paying_for_college/tests/test_scripts.py
+++ b/paying_for_college/tests/test_scripts.py
@@ -13,7 +13,8 @@ from paying_for_college.models import School, Notification, Alias, Program
 from paying_for_college.disclosures.scripts import (api_utils, update_colleges,
                                                     nat_stats, notifications,
                                                     update_ipeds,
-                                                    purge_objects)
+                                                    purge_objects,
+                                                    tag_settlement_schools)
 from paying_for_college.disclosures.scripts.ping_edmc import (notify_edmc,
                                                               EDMC_DEV,
                                                               OID, ERRORS)
@@ -28,6 +29,40 @@ completion_rate:\n\
   median: 0.4379\n\
   average_range: [.3180, .5236]\n
 """
+
+
+class TaggingTests(django.test.TestCase):
+    """Test functions for taggins settlement schools via CSV"""
+
+    fixtures = ['test_fixture.json']
+    mock_csv_data = [{"ipeds_unit_id": "243197",
+                      "flag": "mock_university"}]
+    bad_csv_data = [{"ipeds_unit_id": "243197",
+                     "floog": "mock_university"}]
+
+    @mock.patch('paying_for_college.disclosures.scripts.'
+                'tag_settlement_schools.read_in_s3')
+    def test_tag_schools(self, mock_read_in):
+        mock_read_in.return_value = self.mock_csv_data
+        msg = tag_settlement_schools.tag_schools('mock_s3URL')
+        self.assertIn("mock_university", msg)
+        self.assertIn("tagged as", msg)
+        flagged = School.objects.filter(settlement_school='mock_university')
+        self.assertTrue(flagged.count() == 1)
+
+    @mock.patch('paying_for_college.disclosures.scripts.'
+                'tag_settlement_schools.read_in_s3')
+    def test_tag_schools_no_data(self, mock_read_in):
+        mock_read_in.return_value = [{}]
+        msg = tag_settlement_schools.tag_schools('mock_s3URL')
+        self.assertIn("ERROR", msg)
+
+    @mock.patch('paying_for_college.disclosures.scripts.'
+                'tag_settlement_schools.read_in_s3')
+    def test_tag_schools_bad_heading(self, mock_read_in):
+        mock_read_in.return_value = self.bad_csv_data
+        msg = tag_settlement_schools.tag_schools('mock_s3URL')
+        self.assertIn("ERROR", msg)
 
 
 class PurgeTests(django.test.TestCase):


### PR DESCRIPTION
We need a way to tag new groups of settlement schools as they come in,
and this provides a way to do it via CSV, without having to deploy code.
It also affords a way to _untag_ schools that had been marked as
settlement schools for demo purposes. Schools in this state have a
settlement_school value of `demo`, and by setting up a CSV with all the
demo schools and providing a blank tag value, we can de-tag all the demo
schools in one go.
## Additions
- Script, associated management command and tests
## Testing
- Try tagging some test schools locally with  

```
./manage.py tag_schools "http://files.consumerfinance.gov.s3.amazonaws.com/pb/paying_for_college/csv/tag_test.csv"
```

You should get a message saying two schools were tagged.
## Review
- @amymok @willbarton
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
