### PR TITLE
No notification creation if school has no contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## 2.2.4
+- Prevented creation of notifications if a school has no contact info
+- Allowed offer IDs of up to 128 characters, up from 40
+
 ## 2.2.3
 - Added a script to tag settlement schools using an S3 csv of school IDs
 - Added manage command to run update_national_stats_file

--- a/docs/notification-spec.md
+++ b/docs/notification-spec.md
@@ -23,8 +23,8 @@ errors: none
   This option is intended to catch cases where the student was given the wrong URL or a faulty URL.  
   In this case, a new oid will need to be generated in order to complete a valid disclosure; oid values are allowed to generate only one notification.
 
+Schools may use `oid` values of up to 128 characters.
+
 ## Email notification
 Endpoint notifications are preferred because they are more reliable and simpler to automate.  
 Schools that can't set up endpoints can get notifications via email.
-
-

--- a/docs/offer-ids.md
+++ b/docs/offer-ids.md
@@ -11,12 +11,12 @@ Two important details to note:
 If an offer ID generates a notification, either successful or with an error, it cannot be used again to validate an offer. If a student needs to re-evaluate an offer, a new offer ID needs to be generated and used in a new offer URL. 
 
 ## Technical details
-We chose a 40-hex-character hash as the form for an offer ID because it has two advantages:  
+We chose a 40-hex-character hash as the standard form for an offer ID because it has two advantages:  
 
 - Unique hash values are easy to create in a way that cannot be traced back to a student.
 - The hashes contain only numbers and the letters a-f and are safe to transmit and accept.
 
-The school is free decide how to generate the offer IDs, but they need to be unique.   
+The school is free decide how to generate the offer IDs, and we will allow up to 128 hex characters so other hashing algorithms can be used, but the IDs need to be unique.   
 One easy method would be to combine a timestamp and another value -- such as a student ID or a random number or phrase -- and generate a SHA-1 hash from the combined values.
 
 Following is an example Python function that does just that.

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -1,6 +1,7 @@
 import datetime
 import unittest
 import json
+import copy
 
 import mock
 import django
@@ -364,7 +365,7 @@ class VerifyViewTest(django.test.TestCase):
 
     fixtures = ['test_fixture.json']
     post_data = {'oid': 'f38283b5b7c939a058889f997949efa566c616c5',
-                 'iped': '408039',
+                 'iped': '243197',
                  'errors': 'none'}
     url = reverse('disclosures:verify')
 
@@ -376,13 +377,22 @@ class VerifyViewTest(django.test.TestCase):
         self.assertTrue(resp2.status_code == 400)
         self.assertTrue('already' in resp2.content)
 
+    def test_verify_view_school_has_no_contact(self):
+        post_data = copy.copy(self.post_data)
+        post_data['iped'] = '408039'
+        post_data['oid'] = 'f38283b5b7c939a058889f997949efa566c616c4'
+        print("\n\n\n***SCHOOL is {}\nSCHOOL CONTACT IS {}\n".format(School.objects.get(pk=408039), School.objects.get(pk=408039).contact))
+        resp = client.post(self.url, data=post_data)
+        print("RESPONSE is {}\n***\n\n\n".format(resp.content))
+        self.assertTrue(resp.status_code == 400)
+
     def test_verify_view_bad_id(self):
         self.post_data['iped'] = ''
         resp = client.post(self.url, data=self.post_data)
         self.assertTrue(resp.status_code == 400)
 
     def test_verify_view_bad_oid(self):
-        self.post_data['iped'] = '408039'
+        self.post_data['iped'] = '243197'
         self.post_data['oid'] = 'f38283b5b7c939a058889f997949efa566script'
         resp = client.post(self.url, data=self.post_data)
         self.assertTrue(resp.status_code == 400)

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -36,6 +36,7 @@ def setup_view(view, request, *args, **kwargs):
 
 class Validators(unittest.TestCase):
     """check the oid validator"""
+    max_oid = '6ca1a60a72b3d4640b20a683d63a40297b7c45c4df479cd93cd57d9c44820069eb71d168eedd531bb488cd2e58d3dbbce8ee80c02ef6fc9623479510adedf704'
     good_oid = '9e0280139f3238cbc9702c7b0d62e5c238a835d0'
     bad_oid = '9e0<script>console.log("hi")</script>5d0'
     short_oid = '9e45a3e7'
@@ -44,6 +45,7 @@ class Validators(unittest.TestCase):
         self.assertFalse(validate_oid(self.bad_oid))
         self.assertFalse(validate_oid(self.short_oid))
         self.assertTrue(validate_oid(self.good_oid))
+        self.assertTrue(validate_oid(self.max_oid))
 
     def test_validate_pid(self):
         # bad_chars = [';', '<', '>', '{', '}']

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -68,7 +68,7 @@ def validate_oid(oid):
     if find_illegal:
         return False
     else:
-        if len(oid) == 40:
+        if len(oid) >= 40 and len(oid) <= 128:
             return True
         else:
             return False
@@ -380,6 +380,9 @@ class VerifyView(View):
             return HttpResponseBadRequest('Error: No valid OID provided')
         if 'iped' in data and data['iped'] and get_school(data['iped']):
             school = get_school(data['iped'])
+            if not school.contact:
+                errmsg = "Error: School has no contact."
+                return HttpResponseBadRequest(errmsg)
             if Notification.objects.filter(institution=school, oid=OID):
                 errmsg = "Error: OfferID has already generated a notification."
                 return HttpResponseBadRequest(errmsg)


### PR DESCRIPTION
The introduction of demo program data made it possible to generate a notification object for a school that has no contact info. 
This PR prevents the creation of notifications in such cases.
We're also expanding the allowed offer ID length to 128 to allow for more robust hashes.
Addresses GHE # 218 and 219.
## Additions
- Test for cases where school has no contact info.
## Changes
- VerifyView
- offer ID verification expanded to allow up to 128 characters
## Review
- @amymok 
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
