### PR TITLE
Remove hero wrapper on <h1>s

### DIFF
--- a/paying_for_college/templates/choose_a_loan.html
+++ b/paying_for_college/templates/choose_a_loan.html
@@ -41,7 +41,7 @@
     
     <div id='guide-content' class='guide-content'>
         <!-- HEADER -->
-<div class='hero'><h1>Student Loans: Choosing a loan that's right for you</h1></div><!-- SECTION -->
+<h1>Student Loans: Choosing a loan that's right for you</h1><!-- SECTION -->
 <section class='major-sect'>
     <div class="border-overlay-spacing">
 	   <h5 class='guide-sect-header black vspace2 tb border-overlay'>Why Is it important?</h5>

--- a/paying_for_college/templates/manage_your_money.html
+++ b/paying_for_college/templates/manage_your_money.html
@@ -42,7 +42,7 @@
     
     <div id='guide-content' class='guide-content'>
         <!-- HEADER -->
-<div class='hero'><h1>Student Banking: Managing your college money</h1></div><!-- SECTION -->
+<h1>Student Banking: Managing your college money</h1><!-- SECTION -->
 <section class='major-sect'>
     <div class="border-overlay-spacing">
 	   <h5 class='guide-sect-header black vspace2 tb border-overlay'>Why Is it important?</h5>


### PR DESCRIPTION
The `.hero` wrapper class, combined with the `h1` styles in `footer.nonresponsive.css`, causes the header text to be very large
## Removals
- `.hero` wrapper div on `choose_a_loan` and `manage_your_money` pages
## Testing
- Check out branch
- Navigate to `choose-a-student-loan` and `manage-your-college-money` pages and check that header is expected size
## Review
- @sebworks
## Screenshots

Before:

<img width="1022" alt="screen shot 2016-10-07 at 8 27 16 am" src="https://cloud.githubusercontent.com/assets/778171/19195856/1becdc7a-8c68-11e6-9752-42ad50cae4cb.png">

After:

<img width="961" alt="screen shot 2016-10-07 at 12 57 40 am" src="https://cloud.githubusercontent.com/assets/778171/19195865/24bc5d30-8c68-11e6-9208-c7808c42291b.png">
## Checklist
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [ ] New functions include new tests
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged
- [ ] Visually tested in supported browsers and devices
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
