### PR TITLE
Improve message posted when updating colleges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 - Updated the URL for national statistics to follow moving of Dept. of Education repo.
 - Updates to the 'collegedata.json' fixture were backported from production, based on 2014-2015 values.
+- The console message for the update-via-api management command was changed to note the Salary year being used.
 
 ## 2.2.4
 - Prevented creation of notifications if a school has no contact info

--- a/paying_for_college/disclosures/scripts/update_colleges.py
+++ b/paying_for_college/disclosures/scripts/update_colleges.py
@@ -13,7 +13,8 @@ import requests
 
 from paying_for_college.disclosures.scripts import api_utils
 from paying_for_college.disclosures.scripts.api_utils import (MODEL_MAP,
-                                                              LATEST_YEAR)
+                                                              LATEST_YEAR,
+                                                              LATEST_SALARY_YEAR)
 from paying_for_college.models import School, CONTROL_MAP
 
 DATESTAMP = datetime.datetime.now().strftime("%Y-%m-%d")
@@ -43,9 +44,9 @@ def update(exclude_ids=[], single_school=None):
     FAILED = []  # failed to get a good API response
     NO_DATA = []  # API responded, but with no data
     CLOSED = 0  # schools that have closed since our last scrape
-    START_MSG = "Requesting school data from {0}."
+    START_MSG = "Requesting school data from {0} and salary data from {1}."
     JOB_MSG = "The job is paced for the Ed API, so it can take an hour to run."
-    print(START_MSG.format(LATEST_YEAR))
+    print(START_MSG.format(LATEST_YEAR, LATEST_SALARY_YEAR))
     if not single_school:
         print(JOB_MSG)
     UPDATED = False


### PR DESCRIPTION
This only affects a message a developer would seen when updating the
colleges database. It notes an important constant that needs to be
checked -- **Salary year** --  which is stored in the Django database. 
Salary year differs from the 'Latest year' constant, because salary data 
is always a couple years behind the rest of the data.
## Changes
- the update_colleges script, which is invoked by the `update_via_api` management command.
- the collegedata fixture includes backported updates made in production
## Review
- @amymok 
- [x] Project documentation and CHANGELOG updated.
