### PR TITLE
Change search script include from HTTP to HTTPS

### DIFF
--- a/paying_for_college/templates/standalone/base_update.html
+++ b/paying_for_college/templates/standalone/base_update.html
@@ -152,7 +152,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     var script = document.createElement( 'script' );
     script.type = 'text/javascript';
-    script.src = 'http://search.usa.gov/javascripts/remote.loader.js';
+    script.src = 'https://search.usa.gov/javascripts/remote.loader.js';
     document.getElementsByTagName( 'head' )[0].appendChild( script );
 //]]>
 </script>


### PR DESCRIPTION
This PR changes a script include from HTTP to HTTPS.

See also [cfgov-refresh#2474](https://github.com/cfpb/cfgov-refresh/pull/2474).
## Changes
- Changed references from http://search.usa.gov to https://search.usa.gov.
## Testing
- When running this app as part of the larger cfgov-refresh project, browse to the Paying for College section and note the lack of mixed-content warnings in the browser dev console.
## Review
- @higs4281 @cfpb/cfgov-frontends  
## Checklist
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [ ] New functions include new tests
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged
- [ ] Visually tested in supported browsers and devices
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
