### PR TITLE
Update PFC to use djangorestframework 3.1.3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,7 @@
 [run]
+source = 
+    .
+
 omit = 
     *config/wsgi.py
     *admin*

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_script:
   - python manage.py migrate
   - python manage.py loaddata test_fixture.json
 script: 
-  # - nosetests --with-coverage --config=.coveragerc --cover-package disclosures
-  - coverage run --source='.' manage.py test
+  - coverage run manage.py test > /dev/null
 after_success:
   - coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
+-
+
+## 2.2.5
+- Updated the `load_programs` script to be compatible with djangorestframework 3.1.3
 - Updated the URL for national statistics to follow moving of Dept. of Education repo.
 - Updates to the 'collegedata.json' fixture were backported from production, based on 2014-2015 values.
 - The console message for the update-via-api management command was changed to note the Salary year being used.

--- a/docs/csv-spec.md
+++ b/docs/csv-spec.md
@@ -4,6 +4,8 @@ The CSV should be UTF-8 encoded.
 #### Column names and types for college program data
 The eight boldface fields are required. Data submissions will be rejected if these fields are missing or blank, or if a program code contains illegal characters.
 
+A sample CSV in the correct format can be [downloaded here](http://files.consumerfinance.gov.s3.amazonaws.com/pb/paying_for_college/csv/sample-program.csv).
+
 name | type | note
 :--- | :--- | :---
 **ipeds_unit_id** | integer | will be used as the canonical 6-digit school ID

--- a/docs/csv-spec.md
+++ b/docs/csv-spec.md
@@ -1,37 +1,39 @@
 ## CSV specifications for program data
 The CSV should be UTF-8 encoded.  
 
-#### Column names and types for incoming college program data
+#### Column names and types for college program data
+The eight boldface fields are required. Data submissions will be rejected if these fields are missing or blank, or if a program code contains illegal characters.
 
 name | type | note
 :--- | :--- | :---
-ipeds_unit_id | integer | will be used as the canonical 6-digit school ID
-ope_id | string | alternate Dept. of Ed school ID as backup
-program_code | string | assumed unique within a school; <br>can't contain these characters: ; < > { } _
-program_name | string |
-program_length | integer | number of months in program
-program_level | integer | 0 = Non-degree-granting<br> 1 = Certificate<br> 2 = Associate<br> 3 = Bachelor's<br> 4 = Graduate
-accreditor | string | may be blank
-median_salary | integer |
+**ipeds_unit_id** | integer | will be used as the canonical 6-digit school ID
+**program_code** | string | assumed unique within a school; <br>can't contain these characters: ; < > { } _
+**program_name** | string |
+**program_length** | integer | standard number of months to complete program
+**program_level** | integer | 0 = Non-degree-granting<br> 1 = Certificate<br> 2 = Associate<br> 3 = Bachelor's<br> 4 = Graduate
+**books_supplies** | integer | annual cost of books and supplies
+**total_cost** | integer | total attendance cost for completing an entire program
+**tuition_fees** | integer | annual cost of tuition and fees
+accreditor | string | 
 average_time_to_complete | integer | in months
-books_supplies | integer | annual cost of books and supplies
 campus_name | string
 cip_code | string | used to look up related career/field
+completers | integer | number in cohort who completed the program
 completion_rate | float | 0.41 (would signify 41%)
 completion_cohort | integer | number of students who enrolled in the program
-completers | integer | number in cohort who completed the program
 default_rate | float |0.25
 job_placement_rate | float | 0.33
 job_placement_note | string | optional note on job rate
 mean_student_loan_completers | integer | average of amounts grads owe
+median_salary | integer |
 median_student_loan_completers | integer | median of amounts grads owe
+ope_id | string | alternate Dept. of Ed school ID as backup
 soc_codes | string | pipe-separated list of related career/fields
-total_cost | integer | total attendance cost
-tuition_fees | integer | annual cost of tuition and fees
 
 #### Change log
 Change | date
 :----- | :---
+Added boldface to required fields | 2016-10-21
 Noted ipeds_unit_id is an integer | 2016-08-24
 Added underscore to list of characters not allowed in a program code | 2016-08-24
 Added notes indicating that books_supplies and tutiion_fees should be annual values | 2016-07-26

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "college-costs",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Tools to help students make informed financial decisions about college.",
   "homepage": "http://www.github.com/cfpb/college-costs/",
   "author": {

--- a/paying_for_college/tests/test_load_programs.py
+++ b/paying_for_college/tests/test_load_programs.py
@@ -1,23 +1,93 @@
-from decimal import *
-
+# from decimal import *
 import django
 import mock
 from mock import mock_open, patch
 
 from paying_for_college.models import Program, School
-from paying_for_college.disclosures.scripts.load_programs import (get_school,
-                                                                  read_in_data,
-                                                                  read_in_encoding,
-                                                                  read_in_s3,
-                                                                  clean_number_as_string,
-                                                                  clean_string_as_string,
-                                                                  clean, load,
-                                                                  standardize_rate,
-                                                                  strip_control_chars)
+from paying_for_college.disclosures.scripts.load_programs import (
+    get_school,
+    read_in_data,
+    read_in_encoding,
+    read_in_s3,
+    clean_number_as_string,
+    clean_string_as_string,
+    clean, load,
+    standardize_rate,
+    # strip_control_chars
+)
 
 
 class TestLoadPrograms(django.test.TestCase):
     fixtures = ['test_program.json']
+    read_out = [
+       {u'accreditor': u'',
+        u'average_time_to_complete': u'',
+        u'books_supplies': u'0',
+        u'campus_name': u'Argosy University, San Francisco Bay Area',
+        u'cip_code': u'11.0103',
+        u'completers': u'',
+        u'completion_cohort': u'',
+        u'completion_rate': u'None',
+        u'default_rate': u'None',
+        u'ipeds_unit_id': u'121983',
+        u'job_placement_note': u'',
+        u'job_placement_rate': u'None',
+        u'mean_student_loan_completers': u'',
+        u'median_salary': u'',
+        u'median_student_loan_completers': u'17681',
+        u'ope_id': u'',
+        u'program_code': u'TEST1',
+        u'program_length': u'20',
+        u'program_level': u'2',
+        u'program_name': u'Information Technology',
+        u'soc_codes': u'',
+        u'test': u'True',
+        u'total_cost': u'33859',
+        u'tuition_fees': u'33859'}]
+    to_cleanup = {u'job_placement_rate': u'80',
+                  u'default_rate': u'0.29',
+                  u'job_placement_note': '',
+                  u'mean_student_loan_completers': 'Blank',
+                  u'average_time_to_complete': '',
+                  u'accreditor': '',
+                  u'total_cost': u'44565',
+                  u'ipeds_unit_id': u'139579',
+                  u'median_salary': u'45586',
+                  u'program_code': u'1509',
+                  u'books_supplies': 'No Data',
+                  u'campus_name': u'SU Savannah',
+                  u'cip_code': u'11.0401',
+                  u'ope_id': u'1303900',
+                  u'completion_rate': u'0.23',
+                  u'program_level': u'2',
+                  u'tuition_fees': u'44565',
+                  u'program_name': u'Information Technology',
+                  u'median_student_loan_completers': u'28852',
+                  u'program_length': u'24',
+                  u'completers': u'0',
+                  u'completion_cohort': u'0'}
+    cleaned = {u'job_placement_rate': 'NUMBER',
+               u'default_rate': 'NUMBER',
+               u'job_placement_note': 'STRING',
+               u'mean_student_loan_completers': 'NUMBER',
+               u'average_time_to_complete': 'NUMBER',
+               u'accreditor': 'STRING',
+               u'total_cost': 'NUMBER',
+               u'ipeds_unit_id': 'STRING',
+               u'median_salary': 'NUMBER',
+               u'program_code': 'STRING',
+               u'books_supplies': 'NUMBER',
+               u'campus_name': 'STRING',
+               u'cip_code': 'STRING',
+               u'ope_id': 'STRING',
+               u'completion_rate': 'NUMBER',
+               u'program_level': 'NUMBER',
+               u'tuition_fees': 'NUMBER',
+               u'program_name': 'STRING',
+               u'median_student_loan_completers': 'NUMBER',
+               u'program_length': 'NUMBER',
+               u'completers': 'NUMBER',
+               u'completion_cohort': 'NUMBER'}
 
     def test_standardize_rate(self):
         self.assertTrue(standardize_rate(u'1.7') == u'0.017')
@@ -93,27 +163,38 @@ class TestLoadPrograms(django.test.TestCase):
     @mock.patch('paying_for_college.disclosures.scripts.load_programs.'
                 'requests.get')
     def test_read_in_s3(self, mock_requests):
-        mock_requests.return_value.content = u'a,b,c\nd,e,\u201c'.encode('utf-8')
+        mock_requests.return_value.content = (
+            u'a,b,c\nd,e,\u201c'.encode('utf-8')
+        )
         data = read_in_s3('fake-s3-url.com')
-        self.assertTrue(mock_requests.call_count == 1)
-        self.assertTrue(data == [{u'a': u'd', u'b': u'e', u'c': u'\u201c'}])
-        mock_requests.return_value.content = u'a,b,c\nd,e,\u201c'.encode('windows-1252')
+        self.assertEqual(
+            mock_requests.call_count,
+            1
+        )
+        self.assertEqual(
+            data,
+            [{u'a': u'd', u'b': u'e', u'c': u'\u201c'}]
+        )
+        mock_requests.return_value.content = (
+            u'a,b,c\nd,e,\u201c'.encode('windows-1252')
+        )
         data = read_in_s3('fake-s3-url.com')
         self.assertTrue(mock_requests.call_count == 2)
         self.assertTrue(data == [{u'a': u'd', u'b': u'e', u'c': u'\u201c'}])
-
 
     @mock.patch('paying_for_college.disclosures.scripts.load_programs.'
                 'requests.get')
     @mock.patch('paying_for_college.disclosures.scripts.load_programs.'
                 'cdr')
     def test_read_in_s3_error(self, mock_cdr, mock_requests):
-        mock_requests.return_value.content = u'a,b,c\nd,e,\u201c'.encode('utf-8')
+        mock_requests.return_value.content = (
+            u'a,b,c\nd,e,\u201c'.encode('utf-8')
+        )
         mock_cdr.side_effect = TypeError
         data = read_in_s3('fake-s3-url.com')
-        self.assertTrue(mock_requests.call_count == 1)
-        self.assertTrue(mock_cdr.call_count == 1)
-        self.assertTrue(data == [{}])
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertEqual(mock_cdr.call_count, 1)
+        self.assertEqual(data, [{}])
 
     @mock.patch('paying_for_college.disclosures.scripts.load_programs.'
                 'read_in_encoding')
@@ -147,96 +228,122 @@ class TestLoadPrograms(django.test.TestCase):
         self.assertTrue(m.call_count == 2)
         self.assertTrue(data == [{}])
 
-    @mock.patch('paying_for_college.disclosures.scripts.load_programs.clean_number_as_string')
-    @mock.patch('paying_for_college.disclosures.scripts.load_programs.clean_string_as_string')
-    @mock.patch('paying_for_college.disclosures.scripts.load_programs.standardize_rate')
+    @mock.patch('paying_for_college.disclosures.scripts.'
+                'load_programs.clean_number_as_string')
+    @mock.patch('paying_for_college.disclosures.scripts.'
+                'load_programs.clean_string_as_string')
+    @mock.patch('paying_for_college.disclosures.scripts.'
+                'load_programs.standardize_rate')
     def test_clean(self, mock_standardize, mock_string, mock_number):
         mock_number.return_value = 'NUMBER'
         mock_string.return_value = 'STRING'
         mock_standardize.return_value = 'NUMBER'
-        input_dict = {u'job_placement_rate': u'80', u'default_rate': u'0.29',
-        u'job_placement_note': '', u'mean_student_loan_completers': 'Blank',
-        u'average_time_to_complete': '', u'accreditor': '',
-        u'total_cost': u'44565', u'ipeds_unit_id': u'139579', u'median_salary': u'45586',
-        u'program_code': u'1509', u'books_supplies': 'No Data', u'campus_name': u'SU Savannah',
-        u'cip_code': u'11.0401', u'ope_id': u'1303900', u'completion_rate': u'0.23',
-        u'program_level': u'2', u'tuition_fees': u'44565', u'program_name': u'Information Technology',
-        u'median_student_loan_completers': u'28852', u'program_length': u'24',
-        u'completers': u'0', u'completion_cohort': u'0'}
-
-        expected_dict = {u'job_placement_rate': 'NUMBER', u'default_rate': 'NUMBER',
-        u'job_placement_note': 'STRING', u'mean_student_loan_completers': 'NUMBER',
-        u'average_time_to_complete': 'NUMBER', u'accreditor': 'STRING',
-        u'total_cost': 'NUMBER', u'ipeds_unit_id': 'STRING', u'median_salary': 'NUMBER',
-        u'program_code': 'STRING', u'books_supplies': 'NUMBER', u'campus_name': 'STRING',
-        u'cip_code': 'STRING', u'ope_id': 'STRING', u'completion_rate': 'NUMBER',
-        u'program_level': 'NUMBER', u'tuition_fees': 'NUMBER', u'program_name': 'STRING',
-        u'median_student_loan_completers': 'NUMBER', u'program_length': 'NUMBER',
-        u'completers': 'NUMBER', u'completion_cohort': 'NUMBER'}
-        result = clean(input_dict)
+        result = clean(self.to_cleanup)
         self.assertEqual(mock_number.call_count, 14)
         self.assertEqual(mock_string.call_count, 8)
-        # print(result)
-        # print(expected_dict)
-        self.assertDictEqual(result, expected_dict)
+        self.assertDictEqual(result, self.cleaned)
 
     @mock.patch('paying_for_college.disclosures.scripts.load_programs.'
                 'read_in_s3')
     def test_load_s3(self, mock_read_in_s3):
+        mock_read_in_s3.return_value = self.read_out
+        (FAILED, msg) = load('mockurl', s3=True)
+        self.assertTrue(mock_read_in_s3.call_count == 1)
+        self.assertEqual(FAILED, [])
+        self.assertIn('0 programs created', msg)
+
+    @mock.patch('paying_for_college.disclosures.scripts.load_programs.'
+                'read_in_s3')
+    def test_load_s3_failure(self, mock_read_in_s3):
         mock_read_in_s3.return_value = [{}]
         (FAILED, msg) = load('mockurl', s3=True)
         self.assertTrue(mock_read_in_s3.call_count == 1)
         self.assertTrue('ERROR' in FAILED[0])
 
-    @mock.patch('paying_for_college.disclosures.scripts.load_programs.read_in_data')
-    @mock.patch('paying_for_college.disclosures.scripts.load_programs.clean')
-    @mock.patch('paying_for_college.disclosures.scripts.load_programs.Program.objects.get_or_create')
-    def test_load(self, mock_program, mock_clean, mock_read_in):
+    @mock.patch('paying_for_college.disclosures.scripts.'
+                'load_programs.read_in_data')
+    @mock.patch('paying_for_college.disclosures.scripts.'
+                'load_programs.clean')
+    @mock.patch('paying_for_college.disclosures.scripts.'
+                'load_programs.Program.objects.get_or_create')
+    def test_load(self, mock_get_or_create_program, mock_clean, mock_read_in):
+        accreditor = ("Accrediting Council for Independent Colleges "
+                      "and Schools (ACICS) - Test")
+        jpr_note = ("The rate reflects employment status "
+                    "as of November 1, 2014 - Test")
+        program_name = "Occupational Therapy Assistant - 981 - Test"
         mock_read_in.return_value = [
-            {"ipeds_unit_id": "408039", "ope_id": "", "campus_name": "Ft Wayne - Test", 
-                "program_code": "981 - Test", "program_name": "Occupational Therapy Assistant - 981 - Test", 
-                "program_level": "4", "program_length": "25", 
-                "accreditor": "Accrediting Council for Independent Colleges and Schools (ACICS) - Test", 
-                "median_salary": "24000", "average_time_to_complete": "35", "books_supplies": "1000", 
-                "completion_rate": "13", "default_rate": "50", "job_placement_rate": "0.20", 
-                "job_placement_note": "The rate reflects employment status as of November 1, 2014 - Test", 
-                "mean_student_loan_completers": "30000", "median_student_loan_completers": "30500", 
-                "total_cost": "50000", "tuition_fees": "40000", "cip_code": "51.0803 - Test", 
-                "completers": "0", "completion_cohort": "0"}
+            {"ipeds_unit_id": "408039",
+             "ope_id": "",
+             "campus_name": "Ft Wayne - Test",
+             "program_code": "981 - Test",
+             "program_name": program_name,
+             "program_level": "4",
+             "program_length": "25",
+             "accreditor": accreditor,
+             "median_salary": "24000",
+             "average_time_to_complete": "35",
+             "books_supplies": "1000",
+             "completion_rate": "13",
+             "default_rate": "50",
+             "job_placement_rate": "0.20",
+             "job_placement_note": jpr_note,
+             "mean_student_loan_completers": "30000",
+             "median_student_loan_completers": "30500",
+             "total_cost": "50000",
+             "tuition_fees": "40000",
+             "cip_code": "51.0803 - Test",
+             "completers": "0",
+             "completion_cohort": "0"}
         ]
-        mock_clean.return_value = {"ipeds_unit_id": "408039", "ope_id": "", "campus_name": "Ft Wayne - Test", 
-                "program_code": "981 - Test", "program_name": "Occupational Therapy Assistant - 981 - Test", 
-                "program_level": 4, "program_length": 25, 
-                "accreditor": "Accrediting Council for Independent Colleges and Schools (ACICS) - Test", 
-                "median_salary": 24000, "average_time_to_complete": 35, "books_supplies": 1000, 
-                "completion_rate": 13, "default_rate": 50, "job_placement_rate": 0.20, 
-                "job_placement_note": "The rate reflects employment status as of November 1, 2014 - Test", 
-                "mean_student_loan_completers": 30000, "median_student_loan_completers": 30500, 
-                "total_cost": 50000, "tuition_fees": 40000, "cip_code": "51.0803 - Test", 
-                "completers": 0, "completion_cohort": 0}
+        mock_clean.return_value = {"ipeds_unit_id": "408039",
+                                   "ope_id": "",
+                                   "campus_name": "Ft Wayne - Test",
+                                   "program_code": "981 - Test",
+                                   "program_name": program_name,
+                                   "program_level": 4,
+                                   "program_length": 25,
+                                   "accreditor": accreditor,
+                                   "median_salary": 24000,
+                                   "average_time_to_complete": 35,
+                                   "books_supplies": 1000,
+                                   "completion_rate": 13,
+                                   "default_rate": 50,
+                                   "job_placement_rate": 0.20,
+                                   "job_placement_note": jpr_note,
+                                   "mean_student_loan_completers": 30000,
+                                   "median_student_loan_completers": 30500,
+                                   "total_cost": 50000,
+                                   "tuition_fees": 40000,
+                                   "cip_code": "51.0803 - Test",
+                                   "completers": 0,
+                                   "completion_cohort": 0}
         program = Program.objects.first()
-        mock_program.return_value = (program, False)
+        mock_get_or_create_program.return_value = (program, False)
 
         load("filename")
         self.assertEqual(mock_read_in.call_count, 1)
         self.assertEqual(mock_clean.call_count, 1)
-        self.assertEqual(mock_program.call_count, 1)
-        self.assertEqual(program.accreditor, "Accrediting Council for Independent Colleges and Schools (ACICS) - Test")
+        self.assertEqual(mock_get_or_create_program.call_count, 1)
+        self.assertEqual(program.accreditor, accreditor)
         self.assertEqual(program.cip_code, "51.0803 - Test")
-        self.assertEqual(program.completion_rate, 13.00) # This is converted to unicode probably bc how decimialfield was handled
-        self.assertEqual(program.default_rate, 50.00) # This is converted to unicode probably bc how decimialfield was handled
+        self.assertEqual(program.completion_rate, 13.00)
+        self.assertEqual(program.default_rate, 50.00)
         self.assertEqual(program.mean_student_loan_completers, 30000)
         self.assertEqual(program.median_student_loan_completers, 30500)
         self.assertEqual(program.program_code, "981 - Test")
-        self.assertEqual(program.program_name, "Occupational Therapy Assistant - 981 - Test")
+        self.assertEqual(
+            program.program_name,
+            "Occupational Therapy Assistant - 981 - Test"
+        )
         self.assertEqual(program.program_length, 25)
         self.assertEqual(program.total_cost, 50000)
         self.assertEqual(program.campus, "Ft Wayne - Test")
         self.assertEqual(program.level, 4)
         self.assertEqual(program.time_to_complete, 35)
         self.assertEqual(program.salary, 24000)
-        self.assertEqual(program.job_rate, 0.20) # This is converted to unicode probably bc how decimialfield was handled
-        self.assertEqual(program.job_note, "The rate reflects employment status as of November 1, 2014 - Test")
+        self.assertEqual(program.job_rate, 0.20)
+        self.assertEqual(program.job_note, jpr_note)
         self.assertEqual(program.tuition, 40000)
         self.assertEqual(program.books, 1000)
         self.assertEqual(program.completers, 0)
@@ -244,14 +351,16 @@ class TestLoadPrograms(django.test.TestCase):
         mock_clean.return_value['ipeds_unit_id'] = '9'
         load('filename')
         self.assertEqual(mock_read_in.call_count, 2)
-        self.assertEqual(mock_program.call_count, 1)
+        self.assertEqual(mock_get_or_create_program.call_count, 1)
         mock_clean.return_value['program_code'] = '<904>'
         load('filename')
         self.assertEqual(mock_read_in.call_count, 3)
-        self.assertEqual(mock_program.call_count, 1)  # loader bails before creating program
+        self.assertEqual(
+            mock_get_or_create_program.call_count,
+            1)  # loader bails before creating program
         mock_clean.return_value['ipeds_unit_id'] = "408039"
         mock_clean.return_value['program_code'] = "99982"
-        mock_program.return_value = (program, True)
+        mock_get_or_create_program.return_value = (program, True)
         load('filename')
         self.assertEqual(mock_read_in.call_count, 4)
         mock_read_in.return_value[0]['test'] = "True"

--- a/pytest.sh
+++ b/pytest.sh
@@ -1,6 +1,5 @@
 #! /bin/bash
 # run python unittests
 
-# coverage run --source='.' manage.py test > /dev/null
 coverage run manage.py test > /dev/null
 coverage report -m

--- a/pytest.sh
+++ b/pytest.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 # run python unittests
+set -e
 
 coverage run manage.py test > /dev/null
 coverage report -m

--- a/pytest.sh
+++ b/pytest.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 # run python unittests
 
-export DJANGO_SETTINGS_MODULE=paying_for_college.config.settings.standalone
-coverage run --rcfile=.coveragerc --source='.' manage.py test
+# coverage run --source='.' manage.py test > /dev/null
+coverage run manage.py test > /dev/null
 coverage report -m

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,11 +1,9 @@
-Django==1.8.13
+Django==1.8.15
 Unipath==1.1
 requests==2.7.0
 django-haystack==2.4.1
 python-dateutil==2.2
 PyYAML==3.11
-elasticsearch==2.3.0
-csvkit==0.9.1
-djangorestframework==2.4.8
-six==1.10.0
+elasticsearch==1.6.0
+djangorestframework==3.1.3
 boto==2.38.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read_file(filename):
 
 setup(
     name='college-costs',
-    version='2.2.4',
+    version='2.2.5',
     author='CFPB',
     author_email='tech@cfpb.gov',
     maintainer='cfpb',


### PR DESCRIPTION
This PR supports cfgov-refresh [PR 2456](https://github.com/cfpb/cfgov-refresh/pull/2456)
## Changes
- The load_programs script and related tests were adjusted for DRF's breaking changes.
- Our [public CSV specification](https://cfpb.github.io/college-costs/csv-spec/) is updated to be more explicit about required fields and to provide a sample CSV.
## Testing
- Run unit tests with `./pytest.sh`
- You can give the program loader a spin locally to prove validation is working now; first load collegedata so the script has data to check against:

```
python manage.py loaddata collegedata
python manage.py load_programs --s3 true http://files.consumerfinance.gov.s3.amazonaws.com/pb/paying_for_college/csv/argosySF_test_program.csv
```

This loads a test program row in your local db. The first time you run it, you should get back:

```
1 programs created. 0 programs updated.
```
## Review
- @chosak @willbarton @amymok 
- [x] Project documentation and CHANGELOG updated.
