### PR TITLE
Proposal: Use assignees for PR reviews instead of @-mentions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,10 +16,6 @@ Short description explaining the high-level reason for the pull request
 
 -
 
-## Review
-
-- @user
-
 ## Screenshots
 
 
@@ -42,3 +38,4 @@ Short description explaining the high-level reason for the pull request
 * [ ] Placeholder code is flagged
 * [ ] Visually tested in supported browsers and devices
 * [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
+* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:


### PR DESCRIPTION
Currently the PR template suggests that reviewers be requested using @-notifications. This is useful for generating a one-time notification to the intended reviewer, but can easily get lost among other notifications.

This PR removes this suggestion and instead encourages use of the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) to request reviewers. This would have the advantage of letting developers use their [Assigned Issues page](https://github.com/issues/assigned) to see PRs they've been tagged in.

Possible downsides of this change:

1. Assignee lists might get outdated if people forget to reset them when PRs are closed/merged.
2. No longer possible to use cfpb/cfgov-backends or cfpb/cfgov-frontends to notify whole teams.

Any thoughts or feedback on this idea are welcome. 

## Changes

- PR template modified to suggest use of issue Assignees, not @-mentions.

## Review

- @cfpb/cfgov-backends @cfpb/cfgov-frontends 

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)