### PR TITLE
Update the `load_programs` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## Unreleased
-- 
+## 2.2.9
+- Update `load_programs` to load from specific s3 bucket location
 
 ## 2.2.8
 - Fixed Python unit tests when run as part of cfgov-refresh.

--- a/docs/url-spec.md
+++ b/docs/url-spec.md
@@ -16,9 +16,10 @@ iped=204316&pid=business-1042&oid=a9e280139f3238cbc9702c7b0d62e5c238a835a0
 ```
 
 #### Value details
-- School IDs (iped) must be an integer.
-- Program IDs (pid) must not contain these characters: `; < > { } _`
-- Offer IDs (oid) must contain only hex characters: a-f, 0-9
+- The following three values, in bold, are required. If they are missing, the tool will display an error.
+- School IDs (**iped**) must be an integer.
+- Program IDs (**pid**) must not contain these characters: `; < > { } _`
+- Offer IDs (**oid**) must contain only hex characters: a-f, 0-9
 
 The values below are just examples to show type.   
 Rates can be more precise than two decimal places, but may be rounded for display.  
@@ -26,9 +27,9 @@ Dollar amounts should be in rounded whole numbers.
 
 In URL | Description | Example value | Note
 :----- | :---------  | :------------ | :---
-iped | college ID | 123456 | 6-digit integer: the unit ID from IPEDS
-pid  | program ID | business-981 | string: this would be combined with school ID to get a unique program
-oid  | offer ID | 9e0280139f3238cbc970<br>2c7b0d62e5c238a835d0 | 40-hex-character hashed value: represents one offer to one student. First 7 characters should be given to the student for matching with the disclosure page.
+**iped** | college ID | 123456 | **Required** -- a 6-digit integer, the unit ID from IPEDS
+**pid**  | program ID | business-981 | **Required** -- a string; this would be combined with college ID to get a unique program
+**oid**  | offer ID | 9e0280139f3238cbc970<br>2c7b0d62e5c238a835d0 | **Required** -- a 40-hex-character hashed value that represents one offer to one student. First 7 characters should be given to the student for matching with the disclosure page.
 book | books | 650 | books + supplies
 gib  | gi bill | 3000 |
 gpl  | grad plus loans | 1000 |
@@ -50,15 +51,16 @@ prvi | private loan interest | 0.0455 | coefficient, not percentage point
 schg | school grants and scholarships | 2000 |
 stag | state grants | 2000 |
 subl | subsidized loans | 3500 |
-totl | total direct cost | 40000 | tuition, fees, books, supplies
+totl | total direct cost | 40000 | tuition, fees, books, and supplies for the entire length of a program
 tran | transportation | 200 |
-tuit | tuition | 38976 | annual tuition + fees
+tuit | tuition | 18000 | annual tuition + fees
 unsl | unsubsidized loans | 2000 |
 wkst | work study | 3000 |
 
 #### Change log
 Change | date
 :----- | :---
+Noted three required fields | 2016-11-19
 Added `leng` field for optionally adjusting program length | 2016-11-17
 Added underscore to list of characters not allowed in a program ID | 2016-08-24
 Added note that values should be annual unless otherwise specified | 2016-07-26

--- a/paying_for_college/disclosures/scripts/load_programs.py
+++ b/paying_for_college/disclosures/scripts/load_programs.py
@@ -123,7 +123,6 @@ def read_in_data(filename):
     return data
 
 
-# http://files.consumerfinance.gov.s3.amazonaws.com/pb/paying_for_college/csv/CFPBDATAFILE713%20(2).CSV
 def read_in_s3(url):
     data = [{}]
     response = requests.get(url)
@@ -185,14 +184,21 @@ def clean(data):
     return cleaned_data
 
 
-# 'source' should be a CSV file path or, if s3 is True, an s3 URL
 def load(source, s3=False):
+    """
+    Loads program data from a local or S3 file.
+    For a local file, 'source' should be a CSV file path.
+    For an s3 file, 'source' should be the file name of a CSV
+    in the 'validated_program_data' folder on s3.
+    """
     test_program = False
     new_programs = 0
     updated_programs = 0
     FAILED = []  # failed messages
     if s3:
-        raw_data = read_in_s3(source)
+        s3_url = ('http://files.consumerfinance.gov.s3.amazonaws.com'
+                  '/pb/paying_for_college/csv/validated_program_data/{}')
+        raw_data = read_in_s3(s3_url.format(source))
     else:
         raw_data = read_in_data(source)
     if not raw_data[0]:
@@ -255,7 +261,8 @@ def load(source, s3=False):
             for key, error_list in serializer.errors.iteritems():
 
                 fail_msg = (
-                    'ERROR on row {}: {}: '.format(raw_data.index(row) + 1, key))
+                    'ERROR on row {}: {}: '.format(
+                        raw_data.index(row) + 1, key))
                 for e in error_list:
                     fail_msg = '{} {},'.format(fail_msg, e)
                 FAILED.append(fail_msg)

--- a/paying_for_college/management/commands/load_programs.py
+++ b/paying_for_college/management/commands/load_programs.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from paying_for_college.disclosures.scripts import load_programs
 
 COMMAND_HELP = """update_programs will update program data based on

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read_file(filename):
 
 setup(
     name='college-costs',
-    version='2.2.8',
+    version='2.2.9',
     author='CFPB',
     author_email='tech@cfpb.gov',
     maintainer='cfpb',


### PR DESCRIPTION
The command's s3 loading option will now be pointed at a specific bucket, 
`validated_program_data`, to ensure that raw school submissions aren't 
inadvertently loaded into the cfgov database without being checked.

## Testing

- You should be able to run the command locally with the s3 option to load programs.  

```
python manage.py load_programs edmc.csv --s3 true
``` 

This should return "1522 programs updated."

## Review
@amymok 

* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
