### PR TITLE
Remove snyk from prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "scripts": {
     "test": "snyk test && mocha test/js-unit/",
     "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect"
   },
   "devDependencies": {
     "browser-sync": "2.14.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "test": "snyk test && mocha test/js-unit/",
-    "snyk-protect": "snyk protect",
+    "snyk-protect": "snyk protect"
   },
   "devDependencies": {
     "browser-sync": "2.14.0",


### PR DESCRIPTION
This PR removes snyk from the prepublish script in package.json. This should allow wheel building to happen again.

@chosak @higs4281 @ascott1 