### PR TITLE
Bom handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## 2.3.3
+- Improved error handling for program CSVs to catch BOM and bad ope_id values
+
 ## 2.3.2
 - Bumped snyk dependency to 1.24.6
 

--- a/docs/csv-spec.md
+++ b/docs/csv-spec.md
@@ -29,12 +29,13 @@ job_placement_note | string | optional note on job rate
 mean_student_loan_completers | integer | average of amounts grads owe
 median_salary | integer |
 median_student_loan_completers | integer | median of amounts grads owe
-ope_id | string | alternate Dept. of Ed school ID as backup
+ope_id | string | max of 8 characters; alternate Dept. of Ed school ID as backup
 soc_codes | string | pipe-separated list of related career/fields
 
 #### Change log
 Change | date
 :----- | :---
+Added 8-character max for ope_id | 2017-03-27
 Added note on sFTP delivery | 2017-01-09
 Added boldface to required fields | 2016-10-21
 Noted ipeds_unit_id is an integer | 2016-08-24

--- a/docs/notification-spec.md
+++ b/docs/notification-spec.md
@@ -21,10 +21,13 @@ errors: none
   - "INVALID: student indicated the offer information is wrong"  
   This indicates that the student clicked on the link labeled "No, this is not my information"  
   This option is intended to catch cases where the student was given the wrong URL or a faulty URL.  
-  In this case, a new oid will need to be generated in order to complete a valid disclosure; oid values are allowed to generate only one notification.
+  In this case, a new `oid` will need to be generated in order to complete a valid disclosure; `oid` values are allowed to generate only one notification.
 
 Schools may use `oid` values of up to 128 hex characters.
 
-## Email notification
+## Email notification option
 Endpoint notifications are preferred because they are more reliable and simpler to automate.  
 Schools that can't set up endpoints can get notifications via email.
+
+## Notification failures
+If a technological problem prevents notifications from being transmitted to the school for more than a day, an email will be sent to the school's contacts with details about the unsent notifications and any attempts to transmit them. The email serves two purposes – to assist in troubleshooting, and to clarify the status of any unsent notifications while the issue is being resolved.

--- a/docs/url-spec.md
+++ b/docs/url-spec.md
@@ -6,7 +6,7 @@ Values should be annual unless otherwise specified.
 This scheme results in URLs about 400 characters long, well below browser/server character limits.  
 Here's what a full URL would look like (using fictional school, program and offer values):  
 ```
-http://www.consumerfinance.gov/paying-for-college2/
+https://www.consumerfinance.gov/paying-for-college2/
 understanding-your-financial-aid-offer/offer/?
 iped=123456&pid=business-123&oid=a9e280139f3238cbc9702c7b0d62e5c238a835a0
 &book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36
@@ -60,6 +60,7 @@ wkst | work study | 3000 |
 #### Change log
 Change | date
 :----- | :---
+Changed URL to https | 2017-02-10
 Noted three required fields | 2016-11-19
 Added `leng` field for optionally adjusting program length | 2016-11-17
 Added underscore to list of characters not allowed in a program ID | 2016-08-24

--- a/docs/url-spec.md
+++ b/docs/url-spec.md
@@ -60,6 +60,7 @@ wkst | work study | 3000 |
 #### Change log
 Change | date
 :----- | :---
+Noted three fields are expressed as percentage points: `insi`, `prvf`, and `prvi` | 2017-03-31
 Changed URL to https | 2017-02-10
 Noted three required fields | 2016-11-19
 Added `leng` field for optionally adjusting program length | 2016-11-17

--- a/docs/url-spec.md
+++ b/docs/url-spec.md
@@ -34,7 +34,7 @@ book | books | 650 | books + supplies
 gib  | gi bill | 3000 |
 gpl  | grad plus loans | 1000 |
 hous | housing | 3000 | room + board
-insi | institutional (school) loan interest rate | 0.0455 | rates should be expressed as coefficients, so 4.55% is 0.0455
+insi | institutional (school) loan interest rate | 4.55 | rate should be expressed as percentage points
 insl | institutional loans (all) | 3000 | including tuition payment plans
 inst | institutional loan term | 48 | in months
 leng | program length | 48 | optional field for providing an adjusted program length, in months
@@ -46,8 +46,8 @@ pelg | pell_grant | 1500 |
 perl | perkins loans | 3000 |
 ppl  | parent plus loans | 1000 |
 prvl | private loans | 3000 |
-prvf | private loan origination fee | 0.021 | coefficient, not percentage point
-prvi | private loan interest | 0.0455 | coefficient, not percentage point
+prvf | private loan origination fee | 2.1 | expressed as percentage points
+prvi | private loan interest | 4.55 | expressed as percentage points
 schg | school grants and scholarships | 2000 |
 stag | state grants | 2000 |
 subl | subsidized loans | 3500 |

--- a/paying_for_college/disclosures/scripts/load_programs.py
+++ b/paying_for_college/disclosures/scripts/load_programs.py
@@ -18,7 +18,7 @@ It takes in a csv file with column labels as described in ProgramSerializer.
 To run the script, use this manage.py command:
 
 ```
-./manage.py load_programs [PATH TO CSV]
+./manage.py load_programs [PATH TO CSV or s3 filename]
 ```
 """
 
@@ -37,7 +37,7 @@ class ProgramSerializer(serializers.Serializer):
     tuition_fees = serializers.IntegerField()
     books_supplies = serializers.IntegerField()
     # allowed to be missing or blank
-    ope_id = serializers.CharField(  # '747000'
+    ope_id = serializers.CharField(  # '02117100'
         max_length=8,
         allow_blank=True,
         required=False)
@@ -102,7 +102,7 @@ def read_in_encoding(filename, encoding='windows-1252'):
         with open(filename, 'r') as f:
             reader = cdr(f, encoding=encoding)
             data = [row for row in reader]
-    except:
+    except Exception:
         data = [{}]
     return data
 
@@ -112,7 +112,7 @@ def read_in_data(filename):
     try_encoding = False
     with open(filename, 'r') as f:
         try:
-            reader = cdr(f)
+            reader = cdr(f, encoding='utf-8-sig')
             data = [row for row in reader]
         except UnicodeDecodeError:
             try_encoding = True
@@ -128,7 +128,7 @@ def read_in_s3(url):
     response = requests.get(url)
     try:
         f = StringIO.StringIO(response.content)
-        reader = cdr(f, encoding='utf-8')
+        reader = cdr(f, encoding='utf-8-sig')
         data = [row for row in reader]
     except UnicodeDecodeError:
         f = StringIO.StringIO(response.content)
@@ -177,9 +177,11 @@ def clean(data):
     cleaned_data = dict(map(lambda (k, v):
                         (k, clean_number_as_string(v) if k in number_fields
                          else clean_string_as_string(v)), data.iteritems()))
-
     for rate in rate_fields:
         cleaned_data[rate] = standardize_rate(cleaned_data[rate])
+    cleaned_data['ope_id'] = cleaned_data['ope_id'].replace(
+        '-', '').replace(
+        ' ', '')
 
     return cleaned_data
 


### PR DESCRIPTION
Adds encoding directives to handle utf-8 CSV files carrying a BOM.

## Changes

- Also handles bad ope_ids
- updates docs

## Testing

- You could run this locally, which processes a bad CSV provided by EDMC:
```
python manage.py load_programs --s3 true CFPB_2017-03-24.csv
```
* [x] Passes all existing automated tests
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
