### PR TITLE
Fix test when using locale middleware

### DIFF
--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -116,13 +116,12 @@ class TestViews(django.test.TestCase):
         self.assertTrue(sorted(response.context_data.keys()) ==
                         ['base_template', 'form', 'url_root'])
 
-    @mock.patch('paying_for_college.views.Feedback')
-    def test_feedback_post(self, mock_feedback):
-        response = client.post(
+    def test_feedback_post_creates_feedback(self):
+        self.assertFalse(Feedback.objects.exists())
+        client.post(
             reverse('disclosures:pfc-feedback'),
             data=self.feedback_post_data)
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(mock_feedback.call_count == 1)
+        self.assertTrue(Feedback.objects.exists())
 
     def test_feedback_post_invalid(self):
         response = client.post(reverse('disclosures:pfc-feedback'))

--- a/paying_for_college/tests/test_views.py
+++ b/paying_for_college/tests/test_views.py
@@ -116,12 +116,13 @@ class TestViews(django.test.TestCase):
         self.assertTrue(sorted(response.context_data.keys()) ==
                         ['base_template', 'form', 'url_root'])
 
-    @mock.patch('paying_for_college.views.render_to_response')
-    def test_feedback_post(self, mock_render):
-        client.post(
+    @mock.patch('paying_for_college.views.Feedback')
+    def test_feedback_post(self, mock_feedback):
+        response = client.post(
             reverse('disclosures:pfc-feedback'),
             data=self.feedback_post_data)
-        self.assertTrue(mock_render.call_count == 1)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(mock_feedback.call_count == 1)
 
     def test_feedback_post_invalid(self):
         response = client.post(reverse('disclosures:pfc-feedback'))


### PR DESCRIPTION
When running the college-costs tests with https://github.com/cfpb/cfgov-refresh/, the django locale middleware is loaded. That middleware chokes trying to modify the headers of the original MagicMock it got instead of a Response object. This PR removes the mocking of `render_to_response` and mocks the feedback object creation instead.

Part of GHE/CFGOV/platform/issues/798

## Changes

- Fix a test that was failing when run as part of https://github.com/cfpb/cfgov-refresh/

## Testing

- Checkout https://github.com/cfpb/cfgov-refresh/
- `pip install git+https://https://github.com/cfpb/college-costs.git@holistic-tests`
- `tox -e optional`

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
