### PR TITLE
Fix for Google Analytics events on "Yes" and "Not sure" buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## 2.3.5
+- Fixed Google Analytics events on "Yes" and "Not sure" buttons
+
 ## 2.3.4
 - Add abstract model for Feedback and Notification
 

--- a/src/disclosures/js/views/question-view.js
+++ b/src/disclosures/js/views/question-view.js
@@ -1,7 +1,9 @@
 'use strict';
+var Analytics = require( '../utils/Analytics' );
 var postVerification = require( '../dispatchers/post-verify' );
 var getFinancial = require( '../dispatchers/get-financial-values' );
 var getSchool = require( '../dispatchers/get-school-values' );
+var getDataLayerOptions = Analytics.getDataLayerOptions;
 
 var questionView = {
   $settlementBigQuestion: $( '.step_settlement' ),
@@ -78,9 +80,11 @@ var questionView = {
       } else if ( $( this ).attr( 'id' ) === 'question_answer-yes' ) {
         questionView.$followupYes.show();
         questionView.$followupNoNotSure.hide();
+        Analytics.sendEvent( getDataLayerOptions( 'Step Completed', 'Yes' ) );
       } else {
         questionView.$followupNoNotSure.show();
         questionView.$followupYes.hide();
+        Analytics.sendEvent( getDataLayerOptions( 'Step Completed', 'Not sure' ) );
       }
       // Show the rest of the page
       questionView.$getOptions.show();


### PR DESCRIPTION
Fix for Google Analytics events on "Yes" and "Not sure" buttons

## Changes

- Modified `src/disclosures/js/views/question-view.js` to trigger events when "Not sure" or "Yes" are clicked.

## Testing

- Run 'gulp build`
- Run the acceptance tests -- they should pass. 
- Everything should work as expected.



## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
