### PR TITLE
Modified answer events to always fire irregardless of settlement status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## 2.3.6
+- Modified Google Analytics question event to fire independent of settlement status
+
 ## 2.3.5
 - Fixed Google Analytics events on "Yes" and "Not sure" buttons
 

--- a/src/disclosures/js/views/question-view.js
+++ b/src/disclosures/js/views/question-view.js
@@ -95,6 +95,10 @@ var questionView = {
       }, 900, 'swing', function() {
         // Noop function.
       } );
+
+      Analytics.sendEvent( getDataLayerOptions( 'Step Completed',
+        $( this ).text().trim() )
+      );
     } );
   }
 

--- a/src/disclosures/js/views/question-view.js
+++ b/src/disclosures/js/views/question-view.js
@@ -80,11 +80,9 @@ var questionView = {
       } else if ( $( this ).attr( 'id' ) === 'question_answer-yes' ) {
         questionView.$followupYes.show();
         questionView.$followupNoNotSure.hide();
-        Analytics.sendEvent( getDataLayerOptions( 'Step Completed', 'Yes' ) );
       } else {
         questionView.$followupNoNotSure.show();
         questionView.$followupYes.hide();
-        Analytics.sendEvent( getDataLayerOptions( 'Step Completed', 'Not sure' ) );
       }
       // Show the rest of the page
       questionView.$getOptions.show();


### PR DESCRIPTION
Modified answer events to always fire irregardless of settlement status
## Changes

- Modified `src/disclosures/js/views/question-view.js` to always fire the answer event  irregardless of settlement status.

## Testing


- Run 'gulp build`
- Run the acceptance tests -- they should pass. 
- Everything should work as expected.



## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
