### PR TITLE
Catch missing URL values in cost-error model method

### DIFF
--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -400,8 +400,10 @@ class DisclosureBase(models.Model):
     def cost_error(self):
         """Return 1 or 0: Is total-cost less than tuition?"""
         url_data = self.parsed_url
-        if url_data and url_data['totl'] != '' and url_data['tuit'] != '':
-            if int(url_data['totl']) < int(url_data['tuit']):
+        if (url_data
+                and url_data.get('totl') != ''
+                and url_data.get('tuit') != ''):
+            if int(url_data.get('totl', 0)) < int(url_data.get('tuit', 0)):
                 return 1
             else:
                 return 0

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -400,10 +400,10 @@ class DisclosureBase(models.Model):
     def cost_error(self):
         """Return 1 or 0: Is total-cost less than tuition?"""
         url_data = self.parsed_url
-        if (url_data
-                and url_data.get('totl') != ''
-                and url_data.get('tuit') != ''):
-            if int(url_data.get('totl', 0)) < int(url_data.get('tuit', 0)):
+        if url_data:
+            totl = url_data.get('totl') or 0
+            tuit = url_data.get('tuit') or 0
+            if int(totl) < int(tuit):
                 return 1
             else:
                 return 0

--- a/paying_for_college/tests/test_models.py
+++ b/paying_for_college/tests/test_models.py
@@ -289,12 +289,44 @@ class SchoolModelsTest(TestCase):
         feedback.url = feedback.url.replace('offer', 'feedback')
         self.assertIs(feedback.unmet_cost, None)
 
-    def test_feedback_cost_error(self):
+    def test_feedback_cost_error_valid_values(self):
         feedback = self.create_feedback()
         self.assertEqual(feedback.cost_error, 0)
+
+    def test_feedback_cost_error_true(self):
+        feedback = self.create_feedback()
         feedback.url = feedback.url.replace('totl=81467', 'totl=1000')
         self.assertEqual(feedback.cost_error, 1)
-        feedback.url = feedback.url.replace('totl=1000', 'totl=')
+
+    def test_feedback_cost_error_blank_totl(self):
+        feedback = self.create_feedback()
+        feedback.url = feedback.url.replace('totl=81467', 'totl=')
+        self.assertEqual(feedback.cost_error, 1)
+
+    def test_feedback_cost_error_blank_tuition(self):
+        feedback = self.create_feedback()
+        feedback.url = feedback.url.replace('tuit=16107', 'tuit=')
+        self.assertEqual(feedback.cost_error, 0)
+
+    def test_feedback_cost_error_missing_tuit_field(self):
+        feedback = self.create_feedback()
+        feedback.url = feedback.url.replace('&tuit=16107', '')
+        self.assertEqual(feedback.cost_error, 0)
+
+    def test_feedback_cost_error_missing_totl_field(self):
+        feedback = self.create_feedback()
+        feedback.url = feedback.url.replace('&totl=81467', '')
+        self.assertEqual(feedback.cost_error, 1)
+
+    def test_feedback_cost_error_missing_totl_and_tuit_fields(self):
+        feedback = self.create_feedback()
+        feedback.url = feedback.url.replace('&tuit=16107', '')
+        feedback.url = feedback.url.replace('&totl=81467', '')
+        self.assertEqual(feedback.cost_error, 0)
+
+    def test_feedback_cost_error_missing_url(self):
+        feedback = self.create_feedback()
+        feedback.url = ''
         self.assertEqual(feedback.cost_error, 0)
 
     def test_feedback_tuition_plan(self):


### PR DESCRIPTION
We've encountered a few disclosure URLs that were missing some fields.
This uses the dictionary get() method, which should have been used in
the first place, to avoid key errors when running reports.