### PR TITLE
Fix script to handle longer ZIP code values

### DIFF
--- a/paying_for_college/disclosures/scripts/update_colleges.py
+++ b/paying_for_college/disclosures/scripts/update_colleges.py
@@ -32,7 +32,7 @@ def fix_zip5(zip5):
     if len(zip5) == 3:
         return "00{0}".format(zip5)
     else:
-        return zip5
+        return zip5[:5]
 
 
 def update(exclude_ids=[], single_school=None):


### PR DESCRIPTION
The College Scorecard API started using longer ZIP code forms, so we
need to truncate them because our app uses 5-digit codes.
