### PR TITLE
Support optional testing of other databases

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,6 +12,7 @@ omit =
     *setup.py
     */data_sources/*
     */csvkit/*
+    *settings/*
 
 [report]
 exclude_lines = 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
 - '2.7'
-nodejs: 6
+before_install:
+- nvm use 6
 install:
 - pip install -r requirements/testing.txt
 - pip install coveralls

--- a/paying_for_college/config/settings/dev.py
+++ b/paying_for_college/config/settings/dev.py
@@ -1,4 +1,8 @@
 from __future__ import absolute_import
+import os
+
+import dj_database_url
+
 from .base import *
 
 DEBUG = True
@@ -9,3 +13,6 @@ DATABASES = {
         'NAME': PROJECT_ROOT.child('db.sqlite3'),
     }
 }
+
+if 'DATABASE_URL' in os.environ:
+    DATABASES['default'] = dj_database_url.config()

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,4 +1,5 @@
 -r base.txt
 
 coverage==4.0
+dj-database-url==0.4.2
 mock==1.3.0


### PR DESCRIPTION
This change adds support for using the `DATABASE_URL` environment variable to specify Django's dev/test database, based on the [dj-database-url](https://github.com/kennethreitz/dj-database-url) package.

It lets you run tests against e.g. Postgres:

```sh
$ DATABASE_URL=postgres://user@localhost/db ./pytest.sh
```

(Note that this will require first creating a local database and `pip install`ing `psycopg2==2.7.3.2`.)

It adds `dj-database-url==0.4.2` to the dev/test requirements as that matches the current version in cfgov-refresh.

It also excludes the Django settings files from coverage because otherwise the new logic would reduce the coverage of this repo.

## Notes

- @richaagarwal and I paired on this. This is part of the work being done on platform#2567 to add Postgres compatibility to all cf.gov code. We're hoping to use this pattern with all satellite apps to make database testing easier everywhere.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
