### PR TITLE
Use hyphenated name for cfgov-setup import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,6 @@ setup(
     ],
     long_description=read_file('README.md'),
     zip_safe=False,
-    setup_requires=['cfgov_setup==1.2', 'setuptools-git-version==1.0.3'],
+    setup_requires=['cfgov-setup==1.2', 'setuptools-git-version==1.0.3'],
     frontend_build_script='setup.sh'
 )


### PR DESCRIPTION
This uses the standard name as specified in the [cfgov-django-setup repo](https://github.com/cfpb/cfgov-django-setup#installation) for the setup.py config.

This does not need to be deployed and can wait for the next substantive change for a release.
The current config will work thanks to permissive pypi name-handling, but we should use the proper name for our own package.
