### PR TITLE
Add rel noopener noreferrer to target _blank links

### DIFF
--- a/paying_for_college/local_static/paying_for_college/disclosures/worksheet-dev.html
+++ b/paying_for_college/local_static/paying_for_college/disclosures/worksheet-dev.html
@@ -193,7 +193,7 @@ var restoredata = 0;
 				<p><label for="cb_books">Books &amp; Supplies</label><input tabindex="9994" type="text" value="" name="cb_books"></p>
 				<p><label for="cb_transportation">Transportation</label><input tabindex="9995" type="text" value="" name="cb_transportation"></p>
 				<p><label for="cb_otherexpenses">Other Expenses</label><input tabindex="9995" type="text" value="" name="cb_otherexpenses"></p>
-				<p class="navigatorlink"><a href="http://nces.ed.gov/collegenavigator/" target="_blank">Look up school information using College Navigator.</a></p>
+				<p class="navigatorlink"><a href="http://nces.ed.gov/collegenavigator/" target="_blank" rel="noopener noreferrer">Look up school information using College Navigator.</a></p>
 				<button class="button add_to_comparison start_comparing">Start Visualization</button>
 				<br>
 				<button class="add_average_public button preset">Set values to Average Public 4-Year University</button><br>
@@ -299,7 +299,7 @@ var restoredata = 0;
 												<p>You'll pay approx.</p>
 												<h3 class="colorize-red" name="loanmonthly">$0</h3>
 												<p>per month for 10 years to cover your Total Borrowing</p>
-												<p class="padtop"><a tabindex="10000" target="_blank" href="{% url pfc-learnmore %}#estimated_debt">Learn more</a></p>
+												<p class="padtop"><a tabindex="10000" href="{% url pfc-learnmore %}#estimated_debt" target="_blank" rel="noopener noreferrer">Learn more</a></p>
 											</div>
 											<div class="thisequals colright school-colorize">
 												<p>This equals</p>
@@ -331,7 +331,7 @@ var restoredata = 0;
 							<div class="school-drawer-left">
 								<div class="data-financial">
 									<header class="data-header">
-										<h3 class="tooltip-info" tooltip="Financial Aid Award Offer: An offer from a college or career school that states the type and amount of financial aid, including federal grants and loans, that you will receive if you accept admission and register to take classes at that school.">First-Year Financial Aid Offer <a tabindex="10001" class="etip" target="_blank" href="{% url pfc-learnmore %}#financial_aid">Learn more</a></h3>
+										<h3 class="tooltip-info" tooltip="Financial Aid Award Offer: An offer from a college or career school that states the type and amount of financial aid, including federal grants and loans, that you will receive if you accept admission and register to take classes at that school.">First-Year Financial Aid Offer <a tabindex="10001" class="etip" href="{% url pfc-learnmore %}#financial_aid" target="_blank" rel="noopener noreferrer">Learn more</a></h3>
 									</header>
 
 									<div class="data-discount data group">
@@ -497,7 +497,7 @@ var restoredata = 0;
 							<div class="school-drawer-right">
 								<div class="data-first-year data group">
 									<header class="data-header">
-										<h3>First-Year Costs <a tabindex="10015" class="etip" target="_blank" href="{% url pfc-learnmore %}#first_year">Learn more</a></h3>
+										<h3>First-Year Costs <a tabindex="10015" class="etip" href="{% url pfc-learnmore %}#first_year" target="_blank" rel="noopener noreferrer">Learn more</a></h3>
 									</header>
 									<h2><span name="firstyrcostattend">$0</span> total</h2>
 									<table cellpadding="0" cellspacing="0" border="0">
@@ -534,7 +534,7 @@ var restoredata = 0;
 								</div><!-- end .data-first-year -->
 								<div class="data-school-risk data group">
 									<header class="data-header">
-										<h3>School Indicators <a tabindex="10020" class="etip" target="_blank" href="{% url pfc-learnmore %}#school_indicators">Learn more</a></h3>
+										<h3>School Indicators <a tabindex="10020" class="etip" href="{% url pfc-learnmore %}#school_indicators" target="_blank" rel="noopener noreferrer">Learn more</a></h3>
 									</header>
 									<table cellpadding="0" cellspacing="0" width="100%" border="0">
 										<tr>
@@ -634,7 +634,7 @@ var restoredata = 0;
 			<p><label for="cb_books" style="display:inline-block; text-align: right; font-size: 15px; width:200px; padding: 0px 10px;">Books &amp; Supplies</label><input tabindex="9994" type="text" value="" name="cb_books"></p>
 			<p><label for="cb_transportation" style="display:inline-block; text-align: right; font-size: 15px; width:200px; padding: 0px 10px;">Transportation</label><input tabindex="9995" type="text" value="" name="cb_transportation"></p>
 			<p><label for="cb_otherexpenses" style="display:inline-block; text-align: right; font-size: 15px; width:200px; padding: 0px 10px;">Other Expensses</label><input tabindex="9995" type="text" value="" name="cb_otherexpenses"></p>
-			<p class="navigatorlink"><a href="http://nces.ed.gov/collegenavigator/" target="_blank">Look up school information using College Navigator.</a></p>
+			<p class="navigatorlink"><a href="http://nces.ed.gov/collegenavigator/" target="_blank" rel="noopener noreferrer">Look up school information using College Navigator.</a></p>
 			<button class="add_to_comparison button" style="left: 25%; width: 50%;">Add to Comparison View</button>
 			<br>
 			<button class="add_average_public button" style="left: 25%; width: 50%; background-color: #999;">Set values to Average Public University</button><br>

--- a/paying_for_college/templates/choose_a_loan.html
+++ b/paying_for_college/templates/choose_a_loan.html
@@ -47,7 +47,7 @@
 {% include "nav_wrapper.html" %}
 </header><!-- end #repay-debt-header -->
     <div class="cfpb-logo" alt="Consumer Financial Protection Bureau"></div>
-    
+
     <div id='guide-content' class='guide-content'>
         <!-- HEADER -->
 <h1>Student Loans: Choosing a loan that's right for you</h1><!-- SECTION -->
@@ -67,7 +67,7 @@
 	</div>
 	<div class="bubble" _id='o2' id='_o2' rel="answer2">
 		<div class="bubble-text key-dollar">
-			What if my grants and federal loans don't cover the cost of attendance? 
+			What if my grants and federal loans don't cover the cost of attendance?
 		</div>
         <img alt="" src="{% static "paying_for_college/pb/payingforcollege/key_questions/negbubble.png" %}">
 	</div>
@@ -77,8 +77,8 @@
 		</div>
         <img alt="" src="{% static "paying_for_college/pb/payingforcollege/key_questions/negbubble.png" %}">
 	</div>
-	
-	<div style='clear:both;'></div>		
+
+	<div style="clear:both;"></div>
 
 	<div class="answer-box">
 		<div class='answer-entry' id="answer1">
@@ -94,15 +94,15 @@
 		<div class='answer-entry' id="answer2">
 			<p>If your grants and federal loans are not enough to cover the cost of your education, you should consider the following options:</p>
 
-<li>Search for scholarships. Look for <a class="exit-link" href="http://wdcrobcolp01.ed.gov/Programs/EROD/org_list.cfm?category_cd=SGT" target="_blank">state and local grants</a> and <a class="exit-link" href="http://www.careerinfonet.org/scholarshipsearch/ScholarshipCategory.asp?searchtype=category&amp;nodeid=22" target="_blank">scholarships</a> using one of the many free scholarship search options available. Servicemembers, veterans, and their families may be eligible for <a class="exit-link" href="http://gibill.va.gov/" target="_blank">GI Bill benefits</a> and/or military tuition assistance.</li>
+<li>Search for scholarships. Look for <a class="exit-link" href="http://wdcrobcolp01.ed.gov/Programs/EROD/org_list.cfm?category_cd=SGT" target="_blank" rel="noopener noreferrer">state and local grants</a> and <a class="exit-link" href="http://www.careerinfonet.org/scholarshipsearch/ScholarshipCategory.asp?searchtype=category&amp;nodeid=22" target="_blank" rel="noopener noreferrer">scholarships</a> using one of the many free scholarship search options available. Servicemembers, veterans, and their families may be eligible for <a class="exit-link" href="http://gibill.va.gov/" target="_blank" rel="noopener noreferrer">GI Bill benefits</a> and/or military tuition assistance.</li>
 
-<li>Cut costs. Consider getting one or more roommates or a part-time job, possibly through <a class="exit-link" href="http://studentaid.ed.gov/types/work-study" target="_blank">Federal Work-Study.</a></li>
+<li>Cut costs. Consider getting one or more roommates or a part-time job, possibly through <a class="exit-link" href="http://studentaid.ed.gov/types/work-study" target="_blank" rel="noopener noreferrer">Federal Work-Study.</a></li>
 
 <li> See what your family can contribute. Your parents may be able to get tax credits for their contributions. Parents can also explore the federal Direct PLUS Loan program.</li>
 
 <li>Shop around for a private loan. Remember that these loans generally have higher interest rates and less repayment flexibility compared to federal student loans. You generally should turn to private loans only after you have explored all other grant, scholarship, and federal loan options. If you can show you have a very high credit rating, you may find an affordable private student loan, though you will likely need a co-signer, who will be legally obligated to repay the loan if you can't or don't. Look for the one with the lowest interest rate and flexible repayment options.</li>
-		</div>			
-		
+		</div>
+
 		<div class='answer-entry' id="answer3">
 			<p>First, make sure you need a private student loan. These loans generally are not as affordable as federal student loans and offer little repayment flexibility. </p>
 
@@ -131,9 +131,9 @@
 	<h2 class="font-xxl nc">What if my grants and federal loans don't cover the cost of attendance? </h2>
     <p><p>If your grants and federal loans are not enough to cover the cost of your education, you should consider the following options:</p>
 
-<li>Search for scholarships. Look for <a class="exit-link" href="http://wdcrobcolp01.ed.gov/Programs/EROD/org_list.cfm?category_cd=SGT" target="_blank">state and local grants</a> and <a class="exit-link" href="http://www.careerinfonet.org/scholarshipsearch/ScholarshipCategory.asp?searchtype=category&amp;nodeid=22" target="_blank">scholarships</a> using one of the many free scholarship search options available. Servicemembers, veterans, and their families may be eligible for <a class="exit-link" href="http://gibill.va.gov/" target="_blank">GI Bill benefits</a> and/or military tuition assistance.</li>
+<li>Search for scholarships. Look for <a class="exit-link" href="http://wdcrobcolp01.ed.gov/Programs/EROD/org_list.cfm?category_cd=SGT" target="_blank" rel="noopener noreferrer">state and local grants</a> and <a class="exit-link" href="http://www.careerinfonet.org/scholarshipsearch/ScholarshipCategory.asp?searchtype=category&amp;nodeid=22" target="_blank" rel="noopener noreferrer">scholarships</a> using one of the many free scholarship search options available. Servicemembers, veterans, and their families may be eligible for <a class="exit-link" href="http://gibill.va.gov/" target="_blank" rel="noopener noreferrer">GI Bill benefits</a> and/or military tuition assistance.</li>
 
-<li>Cut costs. Consider getting one or more roommates or a part-time job, possibly through <a class="exit-link" href="http://studentaid.ed.gov/types/work-study" target="_blank">Federal Work-Study.</a></li>
+<li>Cut costs. Consider getting one or more roommates or a part-time job, possibly through <a class="exit-link" href="http://studentaid.ed.gov/types/work-study" target="_blank" rel="noopener noreferrer">Federal Work-Study.</a></li>
 
 <li> See what your family can contribute. Your parents may be able to get tax credits for their contributions. Parents can also explore the federal Direct PLUS Loan program.</li>
 
@@ -155,74 +155,74 @@
 			<div>
     <h2 class="guide-sect-header black" id="action-steps">Take action</h2>
 	<ol class='action-steps'>
-		<li class="li-1"><a class="exit-link" href="http://www.fafsa.ed.gov/" target="_blank">Fill out the FAFSA.</a> Complete the form and submit it early.</li>
+		<li class="li-1"><a class="exit-link" href="http://www.fafsa.ed.gov/" target="_blank" rel="noopener noreferrer">Fill out the FAFSA.</a> Complete the form and submit it early.</li>
 		<li class="li-2">Explore all your federal loan options first.</li>
 		<li class="li-3">Shop around if your aid package doesn't cover the full cost of college.</li>
-	</ol>						
-	<a class="btn btn-document" target='_blank' href="/f/loan.pdf">Download <br/>action guide</a>
+	</ol>
+	<a class="btn btn-document" target="_blank" rel="noopener noreferrer" href="/f/loan.pdf">Download <br/>action guide</a>
 </div>
 		</div>
 	</div>
 </section><!-- SECTION -->
-<section class='major-sect'>
+<section class="major-sect">
     <div class="border-overlay-spacing">
-	   <h5 class='guide-sect-header black vspace2 tb border-overlay'>what are the options?</h5>
+	   <h5 class="guide-sect-header black vspace2 tb border-overlay">what are the options?</h5>
     </div>
-	<div class='row'>
-		<div class='span9'>
+	<div class="row">
+		<div class="span9">
 			<!--WHAT ARE THE OPTIONS-->
 <table class="lbtable loans-table vspace2">
     <thead class="">
-        <tr>      
-            <th>&nbsp;</th>	
+        <tr>
+            <th>&nbsp;</th>
             <a name="loans-table"></a>
         	<th class="font-xxxl">Federal Loans</th>
         	<th class="font-xxxl">Private Loans</th>
         </tr>
-    </thead> 
-    <tbody class="">  
-        <tr>  	
+    </thead>
+    <tbody class="">
+        <tr>
         	<td class="rh font-m uc ico-repayment no-pad">
                 <div class="icon-positioning-fix">
                     <div class="icon ico-bullet_check"></div>
                 </div>
         		What you need to know
-        	</td>	
+        	</td>
             <td class="thick-line">
-            Take advantage of your federal loan options before seeking private loans. Federal student loans almost always cost less and are easier to repay. 
+            Take advantage of your federal loan options before seeking private loans. Federal student loans almost always cost less and are easier to repay.
             </td>
         	<td class="thick-line">
-        	Private loans are generally more costly than federal loans and offer little flexibility if you are having trouble making your payments. 
+        	Private loans are generally more costly than federal loans and offer little flexibility if you are having trouble making your payments.
         	</td>
-        </tr>			
-        <tr>  		
+        </tr>
+        <tr>
         	<td class="rh font-m uc ico-interest no-pad">
                 <div class="icon-positioning-fix">
             	    <div class="icon ico-bullet_plus"></div>
                 </div>
         		Benefits
-        	</td>	
-        	<td class="line"> 
+        	</td>
+        	<td class="line">
         	Many federal student loans are subsidized and have fixed interest rates. Most students are eligible, and repayment terms are flexible.
         	</td>
         	<td class="line">
         	You can borrow larger amounts. If you shop around and can show ability to repay, you may be able to find low interest rates.
         	</td>
         </tr>
-        <tr>  		
+        <tr>
         	<td class="rh font-m uc ico-eligibility no-pad">
                 <div class="icon-positioning-fix">
         		    <div class="icon ico-bullet_minus"></div>
                 </div>
         		Risks
         	</td>
-        	<td class="line">					
+        	<td class="line">
         	The amount of money you can borrow is limited, and a portion of your wages and tax refunds could be taken by the government if you neglect repayment responsibilities.
         	</td>
         	<td class="line">
-        	Your interest rate and monthly payment could change with little warning, and you have fewer options for when and how much you repay. 
+        	Your interest rate and monthly payment could change with little warning, and you have fewer options for when and how much you repay.
         	</td>
-        </tr>  		
+        </tr>
     </tbody>
 </table><div class="accordion vspace1">
     <div class="accordion-heading offset pacific-lightest-bg">
@@ -231,15 +231,15 @@
 
     <!--this breaks in print -->
     <table class="pacific-lightest-bg stretch loans-table accordion-item lbtable compare-table">
-        <thead class="">  
+        <thead class="">
         <tr>
             <th>&nbsp;</th>
             <th class="dark-grey">Federal Loans</th>
             <th class="dark-grey">Private Loans</th>
-        </tr>  
-        </thead>  
-        <tbody>  
-       
+        </tr>
+        </thead>
+        <tbody>
+
         <tr>
 
             <td class="rh slate-blue-light font-s uc ico-interest ico-pad">
@@ -247,7 +247,7 @@
                     <div class="icon ico-criteria_repayment"></div>
                 </div>
                 How to repay
-            </td>       
+            </td>
             <td class="thick-line">
                 <p>6-month grace period for undergraduates </p>
 
@@ -259,17 +259,17 @@
 <p>Very limited flexibility for those with financial need or hardship</p>
 
             </td>
-        </tr>  
+        </tr>
 
-                 
-        <tr>    
+
+        <tr>
             <td class="rh slate-blue-light font-s uc ico-interest ico-pad">
                 <div class="icon-positioning-fix">
                     <div class="icon ico-criteria_interest"></div>
                 </div>
                 Interest Rates
-            </td>    
-            <td class="line"> 
+            </td>
+            <td class="line">
                 <p>Rates are fixed</p>
 
 <p>The Subsidized Direct and Perkins Loans have no interest while you're in school</p>
@@ -288,21 +288,21 @@
 May charge various fees, like an origination fee.
             </td>
         </tr>
-        <tr>    
+        <tr>
             <td class="rh slate-blue-light font-s uc ico-eligibility ico-pad">
                 <div class="icon-positioning-fix">
                     <div class="icon ico-criteria_eligibility"></div>
                 </div>
                 Who is eligible
             </td>
-            <td class="line">                    
+            <td class="line">
                 Almost everyone is eligible for federal loans; those with financial need will qualify for lower rates
             </td>
             <td class="line">
                 Lenders decide eligibility based on your credit and other factors, and you will likely need a co-signer
             </td>
-        </tr>    
-        <tr>    
+        </tr>
+        <tr>
             <td class="rh slate-blue-light font-s uc ico-limits ico-pad">
                 <div class="icon-positioning-fix">
                     <div class="icon ico-criteria_limits"></div>
@@ -314,12 +314,12 @@ May charge various fees, like an origination fee.
 
 <p>Generally, undergraduates can max out at $5,500-12,000 per year, and graduate students at $8,000-20,500 per year</p>
 
-<p>More info at <a class="exit-link" href="http://www.studentaid.ed.gov" target="_blank">studentaid.ed.gov </a></p>
+<p>More info at <a class="exit-link" href="http://www.studentaid.ed.gov" target="_blank" rel="noopener noreferrer">studentaid.ed.gov </a></p>
             </td>
             <td class="line">
                 Varies, depending on your credit and other factors, but generally, you should not borrow more than your college costs
             </td>
-        </tr>    
+        </tr>
         </tbody>
 
     </table>
@@ -336,46 +336,46 @@ May charge various fees, like an origination fee.
             </div>
         </div>
     </div>
-    
+
     <div class="smlr-text accordion-body offset pacific-lightest-bg accordion-item" id="FederalLoanOptions">
-        <p class="vspace2 no-marg">Federal student loans almost always cost less and are easier to repay than private loans. You must complete the <a class="exit-link" href="http://www.fafsa.ed.gov/" target="_blank">Free Application for Federal Student Aid (FAFSA) </a> to be eligible for federal student loans.</p>
-        
-        <table style='margin:0 0 0 -18px;'>
+        <p class="vspace2 no-marg">Federal student loans almost always cost less and are easier to repay than private loans. You must complete the <a class="exit-link" href="http://www.fafsa.ed.gov/" target="_blank" rel="noopener noreferrer">Free Application for Federal Student Aid (FAFSA) </a> to be eligible for federal student loans.</p>
+
+        <table style="margin:0 0 0 -18px;">
             <tr>
-                <td class='td2'>
+                <td class="td2">
                     <h2 class"nc vspace1">Perkins Loans</h2>
                     <p><p>Subsidized with a fixed 5% interest rate, administered through your school, and awarded based on financial need</p>
 
 <p>If you are eligible, you should take this loan first</p></p>
                 </td>
-                <td class='td2'>
+                <td class="td2">
                     <h2 class="nc vspace1">Direct Loans</h2>
                     <p><p>Either subsidized or unsubsidized</p>
 
 <p>Everyone is eligible for the Unsubsidized Direct Loan, and Subsidized Direct Loans are awarded based on financial need</p></p>
                 </td>
-                <td class='td2'>
+                <td class="td2">
                     <h2 class="nc vspace1">Parent or Grad PLUS Loans</h2>
                     <p><p>Available to graduate students and parents</p>
 
 <p>Parents with PLUS loans are responsible for repaying those loans</p></p>
                 </td>
             </tr>
-            <tr style='display:none;'>
-                <td class='td2'>
+            <tr style="display:none;">
+                <td class="td2">
                     <a href="<br>" class="font-s fix2bottom">More info</a>
                 </td>
-                <td class='td2'>
+                <td class="td2">
                     <a href="<br>" class="font-s fix2bottom">More info</a>
                 </td>
-                <td class='td2'>
-                    <a href="<br>" class="font-s fix2bottom">Usually your best option if your other federal aid does not cover your expense. Parents are responsible for 
-				repaying this loan.</a>    
+                <td class="td2">
+                    <a href="<br>" class="font-s fix2bottom">Usually your best option if your other federal aid does not cover your expense. Parents are responsible for
+				repaying this loan.</a>
                 </td>
             </tr>
         </table>
     </div><!--Accordion Body 1 End-->
-    
+
     <div class="smlr-text accordion-body offset pacific-lightest-bg accordion-item" id="PrivateLoanOptions">
         <div class="vspace2 no-marg no-marg-top-childs"><p>There are many different private loan options, with different interest rates and costs. Generally, private student loans have higher costs than federal student loans and require a co-signer.</p>
 
@@ -383,25 +383,25 @@ May charge various fees, like an origination fee.
 
 <p>However if you need a private student loan, you should know that there are some unexpected places to look for deals. It's important to shop around and compare different loan offers.</p></div>
 
-        <table style='margin:0 0 0 -18px;'>
+        <table style="margin:0 0 0 -18px;">
             <tr>
-                <td class='td2'>
+                <td class="td2">
                     <h2 class="nc vspace1">State Agency Loans</h2>
                     <p><p>Loans offered by states to residents, or for students attending school in the state</p>
 <p>Ask your school's financial aid office for more information about "state sponsored alternative loans"</p></p>
                 </td>
-                <td class='td2'>
+                <td class="td2">
                     <h2 class="nc vspace1">Traditional Bank Loans</h2>
                     <p><p>These loans come from commercial banks. You may be more familiar with their checking or savings accounts</p>
 <p>Talk to your parent or someone you trust about this option because you will likely need a co-signer</p></p>
                 </td>
-                <td class='td2'>
+                <td class="td2">
                     <h2 class="nc vspace1">School Loans</h2>
                     <p><p>Some schools have their own loan program for students, which tend to have fixed rates</p>
 <p>Ask your school's financial aid office for more information</p></p>
                 </td>
             </tr>
-            <tr style='display:none;'>
+            <tr style="display:none;">
                 <td>
                     <a href="" class="font-s fix2bottom">More info</a>
                 </td>
@@ -409,7 +409,7 @@ May charge various fees, like an origination fee.
                     <a href="" class="font-s fix2bottom">More info</a>
                 </td>
                 <td>
-                    <a href="" class="font-s fix2bottom">More info</a>    
+                    <a href="" class="font-s fix2bottom">More info</a>
                 </td>
             </tr>
         </table>
@@ -418,8 +418,8 @@ May charge various fees, like an origination fee.
 
 <div class="screen-hide" id="two-column-comparison-print">
     <h3>Federal Loan Options</h3>
-    <p>Federal student loans almost always cost less and are easier to repay than private loans. You must complete the <a class="exit-link" href="http://www.fafsa.ed.gov/" target="_blank">Free Application for Federal Student Aid (FAFSA) </a> to be eligible for federal student loans.</p>
-    
+    <p>Federal student loans almost always cost less and are easier to repay than private loans. You must complete the <a class="exit-link" href="http://www.fafsa.ed.gov/" target="_blank" rel="noopener noreferrer">Free Application for Federal Student Aid (FAFSA) </a> to be eligible for federal student loans.</p>
+
     <h4>Perkins Loans</h4>
     <p>
         <p>Subsidized with a fixed 5% interest rate, administered through your school, and awarded based on financial need</p>
@@ -441,7 +441,7 @@ May charge various fees, like an origination fee.
         <p>Available to graduate students and parents</p>
 
 <p>Parents with PLUS loans are responsible for repaying those loans</p>
-        <!--<a href='<br>{"hidden":true,"alt_view":"hidden"}'>Usually your best option if your other federal aid does not cover your expense. Parents are responsible for 
+        <!--<a href='<br>{"hidden":true,"alt_view":"hidden"}'>Usually your best option if your other federal aid does not cover your expense. Parents are responsible for
 				repaying this loan.</a>-->
     </p>
 
@@ -452,7 +452,7 @@ May charge various fees, like an origination fee.
 <p>Borrowing beyond your federal loans could mean high levels of debt. Make sure you have explored all other options including applying for additional scholarships, cutting costs, or getting a part-time job before taking out a private loan. If you are still deciding where to go to school, consider all your options, including finding a low-cost school.</p>
 
 <p>However if you need a private student loan, you should know that there are some unexpected places to look for deals. It's important to shop around and compare different loan offers.</p></p>
-    
+
     <h4>State Agency Loans</h4>
     <p>
         <p>Loans offered by states to residents, or for students attending school in the state</p>
@@ -474,32 +474,32 @@ May charge various fees, like an origination fee.
         <!--<a href='{"hidden":true,"alt_view":"hidden"}'>More info</a>-->
     </p>
 
-</div> 
+</div>
 <section class="major-sect" id="ask-cfpb-print">
 <h5 class"guide-sect-header black vspace2 tb" style="font-size:1em; color:#d83d00; font-weight:500; padding-top:.1em; text-transform:uppercase; margin-top:1.5em;">Ask CFPB!</h5></section>
 
 		</div>
-		<div class='span3'>
-			
-<div class='bubble-space'>
+		<div class="span3">
+
+<div class="bubble-space">
     <div class="bubble-transparent font-m vspace1">
-        <div class='bubble-top-text'>What's the difference between subsidized and unsubsidized student loans?</div>
+        <div class="bubble-top-text">What's the difference between subsidized and unsubsidized student loans?</div>
     </div>
     <div class="bubble-transparent-answer font-s">
         <span class="btn-close">&times;</span>
         <p>The government pays the interest on subsidized loans while you are in school. You pay the interest on unsubsidized loans. Subsidized loans are awarded to students based on financial need.</p>
     </div>
 </div>
-<div class='bubble-space'>
+<div class="bubble-space">
     <div class="bubble-transparent font-m vspace1">
-        <div class='bubble-top-text'>What happened to Stafford Loans? </div>
+        <div class="bubble-top-text">What happened to Stafford Loans? </div>
     </div>
     <div class="bubble-transparent-answer font-s">
         <span class="btn-close">&times;</span>
         <p>These are now called Federal Direct Loans.</p>
     </div>
 </div>
-<div class='bubble-space'>
+<div class="bubble-space">
     <div class="bubble-transparent font-m vspace1">
         <div class='bubble-top-text'>How often do student loan rates change?</div>
     </div>
@@ -510,18 +510,18 @@ May charge various fees, like an origination fee.
 <p>Interest rates on private student loans are set by the lender that makes the loan and depend on the lender's evaluation of your creditworthiness. Some private loans have variable interest rates, which mean your payment amount could change over time.</p>
     </div>
 </div>
-<div class='bubble-space'>
+<div class="bubble-space">
     <div class="bubble-transparent font-m vspace1">
-        <div class='bubble-top-text'>Should I use a credit card to cover my education costs? </div>
+        <div class="bubble-top-text">Should I use a credit card to cover my education costs? </div>
     </div>
     <div class="bubble-transparent-answer font-s">
         <span class="btn-close">&times;</span>
         <p>Don't replace student loan debt with credit card debt - it can be a much more expensive way to finance your education. Credit cards do not provide the flexible repayment terms or borrower protections offered by federal student loans.</p>
     </div>
 </div>
-<div class='bubble-space'>
+<div class="bubble-space">
     <div class="bubble-transparent font-m vspace1">
-        <div class='bubble-top-text'>What if I can't repay my private student loan?</div>
+        <div class="bubble-top-text">What if I can't repay my private student loan?</div>
     </div>
     <div class="bubble-transparent-answer font-s">
         <span class="btn-close">&times;</span>
@@ -531,25 +531,25 @@ May charge various fees, like an origination fee.
 		</div>
 	</div>
 </section><!-- SECTION -->
-<section class='major-sect'>
+<section class="major-sect">
     <div class="border-overlay-spacing">
-	   <h5 class='guide-sect-header black vspace2 tb border-overlay'>Take action</h5>
+	   <h5 class="guide-sect-header black vspace2 tb border-overlay">Take action</h5>
     </div>
-	<div class='row'>
-		<div class='span9'>
+	<div class="row">
+		<div class="span9">
 			<div class="row cf pad-top" id="take-action">
     <div class="span3">
 		<div class="bullet green-bg vspace1">1</div>
-		<p class="font-xl">Fill out the <a class="exit-link" href="http://www.fafsa.ed.gov/" target="_blank">FAFSA</a></p>
+		<p class="font-xl">Fill out the <a class="exit-link" href="http://www.fafsa.ed.gov/" target="_blank" rel="noopener noreferrer">FAFSA</a></p>
 		<div class="font-s">You must complete this form to be eligible for any federal
-student loans or grants. Submit the FAFSA as early as possible. <a class="exit-link" href="http://www.fafsa.ed.gov/deadlines.htm" target="_blank">Find your FAFSA deadlines online.</a><div><br> 
+student loans or grants. Submit the FAFSA as early as possible. <a class="exit-link" href="http://www.fafsa.ed.gov/deadlines.htm" target="_blank" rel="noopener noreferrer">Find your FAFSA deadlines online.</a><div><br>
 Even if you are not sure you'll be eligible for any federal aid, you still need the FAFSA - schools often award scholarships and other grant aid using FAFSA information.&nbsp;</div><div><br>
-If you are having trouble filling out the form, <a class="exit-link" href="http://www.fafsa.ed.gov/help.htm" target="_blank">contact the Department of Education.</a></div></div>
+If you are having trouble filling out the form, <a class="exit-link" href="http://www.fafsa.ed.gov/help.htm" target="_blank" rel="noopener noreferrer">contact the Department of Education.</a></div></div>
 	</div>
 	<div class="span3">
 		<div class="bullet green-bg vspace1">2</div>
 		<p class="font-xl">Explore all your federal loan options first</p>
-		<div class="font-s">If you need to borrow to pay for school, federal student loans almost always cost less than private student loans and have more protections when it's time for repayment. <a href="/paying-for-college/compare-financial-aid-and-college-cost" target="_blank">If you are choosing between schools, compare each school's aid offer.</a></div>
+		<div class="font-s">If you need to borrow to pay for school, federal student loans almost always cost less than private student loans and have more protections when it's time for repayment. <a href="/paying-for-college/compare-financial-aid-and-college-cost" target="_blank" rel="noopener noreferrer">If you are choosing between schools, compare each school's aid offer.</a></div>
 	</div>
 	<div class="span3">
 		<div class="bullet green-bg vspace1">3</div>
@@ -558,8 +558,8 @@ If you are having trouble filling out the form, <a class="exit-link" href="http:
 	</div>
 </div>
 		</div>
-		<div class='span3'>
-			<a class="btn btn-document" href='/f/loan.pdf' target='_blank'>
+		<div class="span3">
+			<a class="btn btn-document" href="/f/loan.pdf" target="_blank" rel="noopener noreferrer">
     Download <br>action guide
 </a>
 		</div>

--- a/paying_for_college/templates/landing.html
+++ b/paying_for_college/templates/landing.html
@@ -67,7 +67,7 @@
                     <h3>Student loans</h3>
                     <p>If you’re considering student loans to help you pay for school, you’re not alone – many students need loans to cover their full cost of attendance. If you have to take out student loans, comparing your options can help you find the student loan best suited for your needs. <a href="/{{url_root}}/choose-a-student-loan/">More about student loans</a>.</p>
 
-                    <p>Still need to apply for financial aid? <br><a href="https://fafsa.gov/" target="_blank">Visit fafsa.gov&nbsp;<i class="icon-external-link"></i></a> 
+                    <p>Still need to apply for financial aid? <br><a href="https://fafsa.gov/" target="_blank" rel="noopener noreferrer">Visit fafsa.gov&nbsp;<i class="icon-external-link"></i></a> 
                 </p>
                 </div>
                 <div class="col last col6">
@@ -84,7 +84,7 @@
             <div class="col last col8">
                 <p>As part of our <a href="http://www.consumerfinance.gov/students/knowbeforeyouowe/">Know Before You Owe project</a>, we worked with the Department of Education to create a <a class="pdf exit-link" href="http://collegecost.ed.gov/shopping_sheet.pdf">Financial Aid Shopping Sheet</a>. Now that thousands of colleges are adopting this clear and comparable form, we’ve built a tool that complements the shopping sheet to help students make comparisons tailored to their individual circumstances.</p>
                 <p><a class="button" href="/{{url_root}}/compare-financial-aid-and-college-cost/">Compare costs</a></p>
-                <p>Still researching schools? <br><a class="exit-link" href="http://collegecost.ed.gov/scorecard/index.aspx" target="_blank">Check out College Scorecard&nbsp;<i class="icon-external-link"></i></a> 
+                <p>Still researching schools? <br><a class="exit-link" href="http://collegecost.ed.gov/scorecard/index.aspx" target="_blank" rel="noopener noreferrer">Check out College Scorecard&nbsp;<i class="icon-external-link"></i></a> 
                 </p>
             </div>
         </section>

--- a/paying_for_college/templates/manage_your_money.html
+++ b/paying_for_college/templates/manage_your_money.html
@@ -45,7 +45,7 @@
 {% include "nav_wrapper.html" %}
 </header><!-- end #repay-debt-header -->
     <div class="cfpb-logo" alt="Consumer Financial Protection Bureau"></div>
-    
+
     <div id='guide-content' class='guide-content'>
         <!-- HEADER -->
 <h1>Student Banking: Managing your college money</h1><!-- SECTION -->
@@ -59,7 +59,7 @@
 <div class="bubbles">
     <div class="bubble" _id='o1' id='_o1' rel="answer1">
         <div class="bubble-text key-clock">
-			When should I get a bank account? 
+			When should I get a bank account?
 		</div>
         <img alt="" src="{% static "paying_for_college/pb/payingforcollege/key_questions/negbubble.png" %}">
 	</div>
@@ -71,12 +71,12 @@
 	</div>
 	<div class="bubble" _id='o3' id='_o3' rel="answer3">
 		<div class="bubble-text key-bank">
-			Do I have to get an account with the bank at my school? 
+			Do I have to get an account with the bank at my school?
 		</div>
         <img alt="" src="{% static "paying_for_college/pb/payingforcollege/key_questions/negbubble.png" %}">
 	</div>
-	
-	<div style='clear:both;'></div>		
+
+	<div style='clear:both;'></div>
 
 	<div class="answer-box">
 		<div class='answer-entry' id="answer1">
@@ -89,10 +89,10 @@
 
 <p>Does your bank charge monthly fees? Many require minimum balances or regular direct deposit to avoid monthly fees. What about out-of-network ATM fees, overdraft fees, fees to use your debit card, and fees for services like online bill-pay? </p>
 
-<p>Knowing if and when fees will be charged could save you hundreds of dollars in fees each year. <a href="http://www.fdic.gov/bank/analytical/overdraft/FDIC138_Report_FinalTOC.pdf" target="_blank">While half of young Americans never overdraft, the other half average approximately seven overdrafts a year.</a> Overdrafts can cost more than $30 each; that's potentially a lot of money taken out of your pocket. </p>
-		</div>			
-		
-		<div class='answer-entry' id="answer3">
+<p>Knowing if and when fees will be charged could save you hundreds of dollars in fees each year. <a href="http://www.fdic.gov/bank/analytical/overdraft/FDIC138_Report_FinalTOC.pdf" target="_blank" rel="noopener noreferrer">While half of young Americans never overdraft, the other half average approximately seven overdrafts a year.</a> Overdrafts can cost more than $30 each; that's potentially a lot of money taken out of your pocket. </p>
+		</div>
+
+		<div class="answer-entry" id="answer3">
 			<p>No. Schools cannot require you to use their bank, so shop around.
 </p><ul><li>Don't feel limited to only the banks or credit unions that have ATMs on or near campus; some will automatically reimburse fees for using any ATM. </li>
 <li>Consider accounts that offer services like remote check deposits, mobile apps, and online bill-pay. Signing up for a bank account now can save you headaches later, and researching accounts with the lowest fees can save you money. </li></ul>
@@ -101,7 +101,7 @@
 </div>
 
 
-<div id='print-questions'>
+<div id="print-questions">
     <h2 class="font-xxl nc">When should I get a bank account? </h2>
     <p><p>Choose an account as soon as possible - you should try to find one before you start school.</p>
 <p>Once you have a bank account, sign up for direct deposit with your school before classes start. If you are expecting money from your financial aid office, you'll often get it faster this way - it can be weeks before the school gets to writing you a paper check.</p></p><br>
@@ -110,22 +110,22 @@
 
 <p>Does your bank charge monthly fees? Many require minimum balances or regular direct deposit to avoid monthly fees. What about out-of-network ATM fees, overdraft fees, fees to use your debit card, and fees for services like online bill-pay? </p>
 
-<p>Knowing if and when fees will be charged could save you hundreds of dollars in fees each year. <a href="http://www.fdic.gov/bank/analytical/overdraft/FDIC138_Report_FinalTOC.pdf" target="_blank">While half of young Americans never overdraft, the other half average approximately seven overdrafts a year.</a> Overdrafts can cost more than $30 each; that's potentially a lot of money taken out of your pocket. </p></p><br>
+<p>Knowing if and when fees will be charged could save you hundreds of dollars in fees each year. <a href="http://www.fdic.gov/bank/analytical/overdraft/FDIC138_Report_FinalTOC.pdf" target="_blank" rel="noopener noreferrer">While half of young Americans never overdraft, the other half average approximately seven overdrafts a year.</a> Overdrafts can cost more than $30 each; that's potentially a lot of money taken out of your pocket. </p></p><br>
 	<h2 class="font-xxl nc">Do I have to get an account with the bank at my school? </h2>
     <p><p>No. Schools cannot require you to use their bank, so shop around.
 </p><ul><li>Don't feel limited to only the banks or credit unions that have ATMs on or near campus; some will automatically reimburse fees for using any ATM. </li>
 <li>Consider accounts that offer services like remote check deposits, mobile apps, and online bill-pay. Signing up for a bank account now can save you headaches later, and researching accounts with the lowest fees can save you money. </li></ul></p><br>
 </div>
 		</div>
-		<div class='span3'>
+		<div class="span3">
 			<div>
     <h2 class="guide-sect-header black" id="action-steps">Action Steps</h2>
-	<ol class='action-steps'>
+	<ol class="action-steps">
 		<li class="li-1">Choose an account as soon as possible.</li>
 		<li class="li-2">Avoid paying unexpected fees. </li>
 		<li class="li-3">Sign up for direct deposit as soon as possible. </li>
-	</ol>						
-	<a class="btn btn-document" target='_blank' href="/f/Money.pdf">Download <br/>action guide</a>
+	</ol>
+	<a class="btn btn-document" href="/f/Money.pdf" target="_blank" rel="noopener noreferrer">Download <br/>action guide</a>
 </div>
 		</div>
 	</div>
@@ -145,38 +145,38 @@
 	</div>
 	<div class="rel-ico-span relative">
 		<div class="icon ico-bullet_check"></div>
-		<h4 class="vspace1 offset-s">Keep in mind</h4>					
+		<h4 class="vspace1 offset-s">Keep in mind</h4>
 		<p class="offset-s" style='color:#444;'><p>Dig deeper when accounts are marketed as "free" or "easy" - very few accounts charge no fees at all.</p>
 <p>Signing up for a bank account now can save you headaches later, and researching accounts with the lowest fees can save you money.</p></p>
 	</div>
 </div>
 
-<!--BANKING OPTIONS -->	
+<!--BANKING OPTIONS -->
 <div class="accordion vspace2 print-show">
 	<div class="accordion-heading sky-lightest-bg">
 		<span class="ec uc">View Banking Options</span>
 	</div>
 	<div class="accordion-item">
-		<div class="accordion-body sky-lightest-bg" style='padding-top:0px;'>
+		<div class="accordion-body sky-lightest-bg" style="padding-top:0px;">
 			<div>You have many bank accounts options. Here are three possibilities and key factors to compare when making your decision.</div>
 		</div>
 		<table class="pacific-lightest-bg stretch loans-table lbtable compare-table">
-			<thead class="">  
-			<tr>  	
+			<thead class="">
+			<tr>
 				<th>&nbsp;</th>
 				<th class="font-xxl">Virtual checking account</th>
 				<th class="font-xxl">Student checking account</th>
 				<th class="font-xxl">School-affiliated banking services </th>
-			</tr>  
-			</thead>  
+			</tr>
+			</thead>
 			<tbody class="">
-			<tr>  	
+			<tr>
 				<td class="rh font-m uc">
                     <div class="icon-positioning-fix">
 					    <div class="icon ico-bullet_check"></div>
                     </div>
 				    How it works
-				</td>	
+				</td>
 			    <td class="thick-line">
 			    Some financial institutions provide exclusively online banking services that are comparable to a traditional checking account
 			    </td>
@@ -185,16 +185,16 @@
 				</td>
 				<td class="thick-line">
 				Many colleges have a bank they partner with to offer students campus affiliated checking accounts or prepaid debit cards
-				</td>				
-			</tr>			
-			<tr>  		
+				</td>
+			</tr>
+			<tr>
 				<td class="rh font-m uc ico-interest">
                     <div class="icon-positioning-fix">
     					<div class="icon ico-bullet_plus"></div>
                     </div>
 					Benefits
-				</td>	
-				<td class="line"> 
+				</td>
+				<td class="line">
 				<p>May waive or reimburse ATM fees, even those for out-of-network ATMs</p>
 
 <p>Often include online banking and bill-pay</p>
@@ -217,7 +217,7 @@ May include online banking and bill-pay</p>
 <p>May offer discounts at local or campus businesses</p>
 
 <p>Sometimes your student ID card can be used to access your money</p>
-				</td>	
+				</td>
 			</tr>
 			<tr>
 				<td class="rh font-m uc ico-eligibility">
@@ -226,15 +226,15 @@ May include online banking and bill-pay</p>
                     </div>
 					Risks
 				</td>
-				<td class="line">					
+				<td class="line">
 				Generally do not have in-person customer service options
 				</td>
 				<td class="line">
 			    <p>Possibly charge monthly maintenance fees - up to $12 a month in some cases - if you don't meet the minimum balance or the bank's other enrollment criteria, like maintaining a full-time enrollment status at school</p>
 
-<p>May charge more than $30 per overdraft, which can add up quickly, especially if you opt in to coverage for ATM and debit card overdrafts</p> 
+<p>May charge more than $30 per overdraft, which can add up quickly, especially if you opt in to coverage for ATM and debit card overdrafts</p>
 				</td>
-				<td class="line">				
+				<td class="line">
 				<p>Could charge fees every time you use your debit card</p>
 
 <p>Don't always provide the ability to write checks</p>
@@ -245,10 +245,10 @@ May include online banking and bill-pay</p>
 
 <p>May charge more than $30 per overdraft, which can add up quickly especially if you opt in to coverage for ATM and debit card overdrafts</p>
 				</td>
-			</tr>  		
-			</tbody>			
+			</tr>
+			</tbody>
 		</table>
-	</div><!--Accordion Item End-->			
+	</div><!--Accordion Item End-->
 </div><!--Accordion End-->
 
 <h2 class='comparison-h2'>Financial aid disbursement</h2>
@@ -260,12 +260,12 @@ May include online banking and bill-pay</p>
 	</div>
 	<div class="rel-ico-span relative">
 		<div class="icon ico-bullet_check"></div>
-		<h4 class="vspace1 offset-s">Keep in mind</h4>					
+		<h4 class="vspace1 offset-s">Keep in mind</h4>
 		<p class="offset-s" style='color:#444;'>You normally have several options for how you get that money, including direct deposit to a bank account, to a card that might also double as your student ID, by check, or cash.</p>
 	</div>
 </div>
 
-<!--BANKING OPTIONS -->	
+<!--BANKING OPTIONS -->
 <div class="accordion vspace2 print-show">
 	<div class="accordion-heading sky-lightest-bg">
 		<span class="ec uc">View aid disbursement options</span>
@@ -275,22 +275,22 @@ May include online banking and bill-pay</p>
 			<div>We encourage you to choose your disbursement option wisely. They all have benefits and risks, so the most important thing is that you understand your needs and what potential fees you will be charged to use each option.</div>
 		</div>
 		<table class="pacific-lightest-bg stretch loans-table lbtable compare-table">
-			<thead class="">  
-			<tr>  	
+			<thead class="">
+			<tr>
 				<th>&nbsp;</th>
 				<th class="font-xxl">Direct deposit to personal account</th>
 				<th class="font-xxl">Paper check</th>
 				<th class="font-xxl">Financial aid disbursement account </th>
-			</tr>  
-			</thead>  
+			</tr>
+			</thead>
 			<tbody class="">
-			<tr>  	
+			<tr>
 				<td class="rh font-m uc">
                     <div class="icon-positioning-fix">
 					    <div class="icon ico-bullet_check"></div>
                     </div>
 				    How it works
-				</td>	
+				</td>
 			    <td class="thick-line">
 			    Once you choose the best bank account for you, share that information with your school, and they will deposit additional aid funds directly to that account
 			    </td>
@@ -303,16 +303,16 @@ May include online banking and bill-pay</p>
 <p>The most common option is a debit card attached to bank account that has your financial aid deposited in it</p>
 
 <p>You are not required to use the bank chosen by your school</p>
-				</td>				
-			</tr>			
-			<tr>  		
+				</td>
+			</tr>
+			<tr>
 				<td class="rh font-m uc ico-interest">
                     <div class="icon-positioning-fix">
     					<div class="icon ico-bullet_plus"></div>
                     </div>
 					Benefits
-				</td>	
-				<td class="line"> 
+				</td>
+				<td class="line">
 				<p>You can pick an account that offers what you need and charges few or no fees</p>
 
 <p>You can access the disbursement quickly with direct deposit</p>
@@ -322,7 +322,7 @@ May include online banking and bill-pay</p>
 				</td>
 				<td class="line">
 				Often the quickest way to access to your disbursement if you haven't already provided your school with direct deposit information
-				</td>	
+				</td>
 			</tr>
 			<tr>
 				<td class="rh font-m uc ico-eligibility">
@@ -331,29 +331,29 @@ May include online banking and bill-pay</p>
                     </div>
 					Risks
 				</td>
-				<td class="line">					
+				<td class="line">
 				No significant risks
 				</td>
 				<td class="line">
 			    <p>If you use a check casher, they may charge as much as 4% of the check amount</p>
 
-<p>You may not be able to access your funds immediately after making a deposit</p> 
+<p>You may not be able to access your funds immediately after making a deposit</p>
 				</td>
-				<td class="line">				
+				<td class="line">
 				<p>The school makes the agreement with the bank, not you</p>
 
 <p>You won't be able to shop for a low-cost product, and these cards and accounts may come with fees you could avoid by shopping</p>
 				</td>
-			</tr>  		
-			</tbody>			
+			</tr>
+			</tbody>
 		</table>
-	</div><!--Accordion Item End-->			
+	</div><!--Accordion Item End-->
 </div><!--Accordion End-->
 
 
 		</div>
 		<div class='span3'>
-			
+
 <div class='bubble-space'>
     <div class="bubble-transparent font-m vspace1">
         <div class='bubble-top-text'><h5 class="guide-sect-header orange vspace2 tb" id="ask-cfpb-print">Ask CFPB!</h5>
@@ -383,12 +383,12 @@ What is a financial aid disbursement? </div>
 		</div>
 	</div>
 </section><!-- SECTION -->
-<section class='major-sect'>
+<section class="major-sect">
     <div class="border-overlay-spacing">
-	   <h5 class='guide-sect-header black vspace2 tb border-overlay'>Take action</h5>
+	   <h5 class="guide-sect-header black vspace2 tb border-overlay">Take action</h5>
     </div>
-	<div class='row'>
-		<div class='span9'>
+	<div class="row">
+		<div class="span9">
 			<div class="row cf pad-top" id="take-action">
     <div class="span3">
 		<div class="bullet green-bg vspace1">1</div>
@@ -407,8 +407,8 @@ What is a financial aid disbursement? </div>
 	</div>
 </div>
 		</div>
-		<div class='span3'>
-			<a class="btn btn-document" href='/f/Money.pdf' target='_blank'>
+		<div class="span3">
+			<a class="btn btn-document" href="/f/Money.pdf" target="_blank" rel="noopener noreferrer">
     Download <br>action guide
 </a>
 		</div>

--- a/paying_for_college/templates/repay_student_debt.html
+++ b/paying_for_college/templates/repay_student_debt.html
@@ -1110,7 +1110,7 @@
         <div class="content-l_col content-l_col-1-4 tip-section">
           <div class="tip_bar"></div><div class="tip_line"></div>
           <h3>TIP</h3>
-          <p>Remember, if you’re having a problem with a student loan , you can submit a complaint <a href="http://www.consumerfinance.gov/complaint/" class="internal-link" target="_blank" rel="noopener noreferrer">online</a> or call us at (855) 411-2372.</p>
+          <p>Remember, if you’re having a problem with a student loan, you can submit a complaint <a href="http://www.consumerfinance.gov/complaint/" class="internal-link" target="_blank" rel="noopener noreferrer">online</a> or call us at (855) 411-2372.</p>
         </div>
       </div>
     </section>

--- a/paying_for_college/templates/repay_student_debt.html
+++ b/paying_for_college/templates/repay_student_debt.html
@@ -121,7 +121,7 @@
                 <p>In order to use this tool, it will be helpful to have a list of your loans and required monthly payment amounts. If you don’t have this information, don’t worry.</p>
                 <div class="read-more read-more_is-closed">
                   <div class="read-more_content">
-                    <p>You can get a list of all federal loans made to you by visiting the <a href="https://www.nslds.ed.gov/nslds_SA/" class="external-link" target="_blank">National Student Loan Data System</a> and selecting “Financial Aid Review.” Click each individual loan to see who the servicer is for that loan (this is also the company that sends you a bill each month). </p>
+                    <p>You can get a list of all federal loans made to you by visiting the <a href="https://www.nslds.ed.gov/nslds_SA/" class="external-link" target="_blank" rel="noopener noreferrer">National Student Loan Data System</a> and selecting “Financial Aid Review.” Click each individual loan to see who the servicer is for that loan (this is also the company that sends you a bill each month). </p>
                     <p>To learn more about your private student loans, take a look at your credit report or contact your school’s financial aid office.</p>
                   </div>
                   <button class="read-more_target">
@@ -353,7 +353,7 @@
       <p>If you leave the military but plan to pursue another qualifying public service profession, like teaching or serving in government, you may still be eligible for PSLF.</p>
 
       <div class='act'>
-        <p>Get started by <a href="https://studentloans.gov/myDirectLoan/index.action" class="external-link" target="_blank">enrolling online at StudentLoans.gov</a>. Once you sign in, select “Income-Driven Repayment Plan Request.” These plans are always available for free to federal student loan borrowers with eligible loans.</p>
+        <p>Get started by <a href="https://studentloans.gov/myDirectLoan/index.action" class="external-link" target="_blank" rel="noopener noreferrer">enrolling online at StudentLoans.gov</a>. Once you sign in, select “Income-Driven Repayment Plan Request.” These plans are always available for free to federal student loan borrowers with eligible loans.</p>
 
         <p>You can also contact your servicer (the company that sends you a bill each month) about enrolling. They will likely ask for proof of your income, such as a tax return or pay stub, to determine your payment.</p>
 
@@ -634,7 +634,7 @@
               <img class="image-left" src="{% static "paying_for_college/repaystudentdebt/images/Icon_1_35x35.png" %}">
               <h3>Pay As You Earn</h3>
 
-              <p>If you are a recent grad, <a href="http://www.consumerfinance.gov/askcfpb/1555/what-pay-you-earn-paye-how-do-i-know-if-i-qualify.html" target="_blank" class="internal-link">Pay As You Earn (PAYE)</a> is a newer repayment plan that is likely available for your federal student loans. The plan caps your monthly federal student loan payment at 10 percent of your discretionary income. If you think you might be eligible, learn more about <a href="http://www.consumerfinance.gov/askcfpb/1555/what-pay-you-earn-paye-how-do-i-know-if-i-qualify.html" target="_blank" class="internal-link">who qualifies for PAYE here</a>.</p>
+              <p>If you are a recent grad, <a href="http://www.consumerfinance.gov/askcfpb/1555/what-pay-you-earn-paye-how-do-i-know-if-i-qualify.html" class="internal-link" target="_blank" rel="noopener noreferrer">Pay As You Earn (PAYE)</a> is a newer repayment plan that is likely available for your federal student loans. The plan caps your monthly federal student loan payment at 10 percent of your discretionary income. If you think you might be eligible, learn more about <a href="http://www.consumerfinance.gov/askcfpb/1555/what-pay-you-earn-paye-how-do-i-know-if-i-qualify.html" class="internal-link" target="_blank" rel="noopener noreferrer">who qualifies for PAYE here</a>.</p>
             </div>
             <div class="content-l_col content-l_col-1-2">
               <img class="image-left" src="{% static "paying_for_college/repaystudentdebt/images/Icon_2_35x35.png" %}">
@@ -646,7 +646,7 @@
 
           <div class="highlighted get-started">
               <h3>Get started</h3>
-              <p>Get started by <a href="https://studentloans.gov/myDirectLoan/index.action" class="external-link" target="_blank">enrolling online at StudentLoans.gov</a>. Once you sign in, select “Income-Driven Repayment Plan Request.” These plans are always available for free to federal student loan borrowers with eligible loans.</p>
+              <p>Get started by <a href="https://studentloans.gov/myDirectLoan/index.action" class="external-link" target="_blank" rel="noopener noreferrer">enrolling online at StudentLoans.gov</a>. Once you sign in, select “Income-Driven Repayment Plan Request.” These plans are always available for free to federal student loan borrowers with eligible loans.</p>
 
               <p>You can also contact your servicer (the company that sends you a bill each month) about enrolling. They will likely ask for proof of your income, such as a tax return or pay stub, to determine your payment.</p>
 
@@ -849,7 +849,7 @@
             <p>If you're not eligible for these plans, or if your payment is already lower than the chart says it would be, you may be able to find a different plan that reduces your payment.</p>
             <div class="read-more read-more_is-closed">
               <div class="read-more_content" style="display: none;">
-                <p>Visit <a href="http://www.studentloans.gov/" target="_blank" class="external-link">www.studentloans.gov</a> to use the Department of Education’s Repayment Estimator, which can show you an estimate of your monthly payment for every option that you qualify for.  You’ll need to sign in in order to get personalized information about your loans and monthly payments.</p>
+                <p>Visit <a href="http://www.studentloans.gov/" class="external-link" target="_blank" rel="noopener noreferrer">www.studentloans.gov</a> to use the Department of Education’s Repayment Estimator, which can show you an estimate of your monthly payment for every option that you qualify for.  You’ll need to sign in in order to get personalized information about your loans and monthly payments.</p>
                 <p>Remember, you might also have other options, like deferment and forbearance. The best way to learn about all of them is to contact your servicer.</p>
               </div>
               <button class="read-more_target">
@@ -1110,7 +1110,7 @@
         <div class="content-l_col content-l_col-1-4 tip-section">
           <div class="tip_bar"></div><div class="tip_line"></div>
           <h3>TIP</h3>
-          <p>Remember, if you’re having a problem with a student loan , you can submit a complaint <a href="http://www.consumerfinance.gov/complaint/" class="internal-link" target="_blank">online</a> or call us at (855) 411-2372.</p>
+          <p>Remember, if you’re having a problem with a student loan , you can submit a complaint <a href="http://www.consumerfinance.gov/complaint/" class="internal-link" target="_blank" rel="noopener noreferrer">online</a> or call us at (855) 411-2372.</p>
         </div>
       </div>
     </section>
@@ -1167,9 +1167,9 @@
                 <h3>Helpful advice</h3>
 
                 <ul>
-                  <li><strong>Consider downloading our</strong> <a href="http://www.consumerfinance.gov/f/201410_cfpb_students_sample-financial-worksheet.doc" class="internal-link" target="_blank">sample financial worksheet</a> to help you determine the maximum amount of money you can put toward student loans.</li>
+                  <li><strong>Consider downloading our</strong> <a href="http://www.consumerfinance.gov/f/201410_cfpb_students_sample-financial-worksheet.doc" class="internal-link" target="_blank" rel="noopener noreferrer">sample financial worksheet</a> to help you determine the maximum amount of money you can put toward student loans.</li>
 
-                  <li><strong>Be wary of options that postpone your monthly payment.</strong> When you put off making payments by signing up for <a href="/askcfpb/631/what-forbearance.html" class="internal-link" target="_blank">forbearance</a> or <a href="/askcfpb/629/what-deferment.html" class="internal-link" target="_blank">deferment</a>, interest will still continue to accrue. This means that once you begin to pay back your loan again, you’ll discover that your student loan balance has grown (you will owe more money than before). You should also watch out for fees when enrolling in forbearance programs.</li>
+                  <li><strong>Be wary of options that postpone your monthly payment.</strong> When you put off making payments by signing up for <a href="/askcfpb/631/what-forbearance.html" class="internal-link" target="_blank" rel="noopener noreferrer">forbearance</a> or <a href="/askcfpb/629/what-deferment.html" class="internal-link" target="_blank" rel="noopener noreferrer">deferment</a>, interest will still continue to accrue. This means that once you begin to pay back your loan again, you’ll discover that your student loan balance has grown (you will owe more money than before). You should also watch out for fees when enrolling in forbearance programs.</li>
 
                   <li><strong>Consider using these sample instructions.</strong> You can use the sample letter text below in a letter, email, or message sent via the “Send a Message” or “Contact Us” feature when you log into your account on the servicer’s website. These instructions may help you get valuable information on repayment options to reduce your monthly payment or to temporarily postpone making payments. </li>
                 </ul>
@@ -1248,7 +1248,7 @@
         <div class="content-l_col content-l_col-1-4 tip-section">
           <div class="tip_bar"></div><div class="tip_line"></div>
           <h3>TIP</h3>
-          <p>Remember, if you’re having a problem with a student loan, you can submit a complaint <a href="/complaint/" class="internal-link" target="_blank">online</a> or call us at (855) 411-2372.</p>
+          <p>Remember, if you’re having a problem with a student loan, you can submit a complaint <a href="/complaint/" class="internal-link" target="_blank" rel="noopener noreferrer">online</a> or call us at (855) 411-2372.</p>
         </div>
       </div>
     </section>
@@ -1516,7 +1516,7 @@
               <hr>
             </ul>
             <p>Remember, if you think that a debt collector has lied to you, harassed you or otherwise broken the law, you may want to see a lawyer.  If you have a problem with debt collection, you can also submit a complaint online or call us at (855) 411-2372.</p>
-            <p>To download these letters as individual documents, visit <a href="/blog/debtcollection/" class="internal-link" target="_blank">our blog post on this topic</a>.</p>
+            <p>To download these letters as individual documents, visit <a href="/blog/debtcollection/" class="internal-link" target="_blank" rel="noopener noreferrer">our blog post on this topic</a>.</p>
           </div><!-- end .communicating -->
         </div><!-- end .col-3-4 -->
         <div class="content-l_col content-l_col-1-4 tip-section">
@@ -1540,11 +1540,11 @@
             <div class="tip_bar"></div><div class="tip_line"></div>
             <h3>TIP</h3>
 
-            <p>Unlike federal student loans, there is a <a href="/askcfpb/1389/what-statute-limitations-on-debt.html" class="internal-link" target="_blank">statute of limitations</a> on the collection of private student debt.</p>
+            <p>Unlike federal student loans, there is a <a href="/askcfpb/1389/what-statute-limitations-on-debt.html" class="internal-link" target="_blank" rel="noopener noreferrer">statute of limitations</a> on the collection of private student debt.</p>
 
             <div class="read-more read-more_is-closed">
               <div class="read-more_content">
-                <p>For borrowers contacted by a debt collector about very old debt (generally debt you have not made any payments toward for two years or longer, depending on your state), you may be able to challenge a lawsuit from a debt collector on these grounds.  In some states, a partial payment on an old account may restart the time period during which you can be sued. Learn more about your rights <a href="/askcfpb/1423/my-debt-several-years-old-can-debt-collectors-still-collect.html" class="internal-link" target="_blank">here</a>.</p>
+                <p>For borrowers contacted by a debt collector about very old debt (generally debt you have not made any payments toward for two years or longer, depending on your state), you may be able to challenge a lawsuit from a debt collector on these grounds.  In some states, a partial payment on an old account may restart the time period during which you can be sued. Learn more about your rights <a href="/askcfpb/1423/my-debt-several-years-old-can-debt-collectors-still-collect.html" class="internal-link" target="_blank" rel="noopener noreferrer">here</a>.</p>
               </div>
               <button class="read-more_target">
                 <span class="read-more_open">Read more <span class="cf-icon cf-icon-down"></span></span>

--- a/paying_for_college/templates/technote.html
+++ b/paying_for_college/templates/technote.html
@@ -217,8 +217,8 @@
                     </p>
                     <p>
                         <strong><a
-                            href="https://studentaid.ed.gov/sa/types/grants-scholarships/pell" target="_blank"
-                            rel="noopener">Federal Pell Grant.</a></strong> This
+                            href="https://studentaid.ed.gov/sa/types/grants-scholarships/pell"
+                            target="_blank" rel="noopener noreferrer">Federal Pell Grant.</a></strong> This
                             does not have to be repaid (unless, for example, you
                             withdraw from school and owe a refund).
                     </p>
@@ -237,7 +237,7 @@
                     </ul>
                     <p>
                         <strong><a href="https://www.dodmou.com/TADECIDE/"
-                            target="_blank" rel="noopener">Military tuition
+                            target="_blank" rel="noopener noreferrer">Military tuition
                             assistance.</a></strong> This does not have to be
                             repaid (unless, for example, you withdraw from
                             school and owe a refund).
@@ -256,7 +256,7 @@
                     <p>
                         <strong><a
                             href="https://www.vets.gov/gi-bill-comparison-tool"
-                            target="_blank" rel="noopener">GI Bill&reg;
+                            target="_blank" rel="noopener noreferrer">GI Bill&reg;
                             Benefits.</a></strong> This does not have to be
                             repaid (unless, for example, you withdraw from
                             school and owe a refund).
@@ -292,7 +292,7 @@
                         should be entered in &ldquo;Cash you will pay,&rdquo; unless it is
                         earned from an approved <a
                         href="https://studentaid.ed.gov/sa/types/work-study"
-                        target="_blank" rel="noopener">Federal Work-Study</a>
+                        target="_blank" rel="noopener noreferrer">Federal Work-Study</a>
                         program.
                     </p>
                     <p>
@@ -300,7 +300,7 @@
                         receive a Parent PLUS loan, which is very similar to a
                         Grad PLUS loan. If your parents take out a <a
                         href="http://www.consumerfinance.gov/askcfpb/553/what-plus-loan.html"
-                        target="_blank" rel="noopener">Parent PLUS</a>
+                        target="_blank" rel="noopener noreferrer">Parent PLUS</a>
                         loan to help pay for college costs, enter it in this
                         section. Since these loans are ones that someone else
                         repays, they are not included in any summaries of your
@@ -755,7 +755,7 @@
                     <p>
                         The <a
                         href="http://www.consumerfinance.gov/askcfpb/547/what-should-i-consider-when-deciding-how-much-borrow.html"
-                        target="_blank" rel="noopener">general rule of thumb</a>
+                        target="_blank" rel="noopener noreferrer">general rule of thumb</a>
                         for undergraduates is that your &ldquo;debt when
                         repayment begins&rdquo; should not exceed your
                         anticipated annual salary the first year out of school.
@@ -772,10 +772,10 @@
                     <p>
                         If you are considering a career in public service, you
                         should explore the U.S. Department of Education’s <a
-                        href="https://studentaid.ed.gov/sa/repay-loans/understand/plans/income-driven" target="_blank"
-                        rel="noopener">income-driven repayment plans</a> and <a
-                        href="https://studentaid.ed.gov/sa/repay-loans/forgiveness-cancellation/public-service" target="_blank"
-                        rel="noopener">Public Service Loan Forgiveness
+                        href="https://studentaid.ed.gov/sa/repay-loans/understand/plans/income-driven"
+                        target="_blank" rel="noopener noreferrer">income-driven repayment plans</a> and <a
+                        href="https://studentaid.ed.gov/sa/repay-loans/forgiveness-cancellation/public-service"
+                        target="_blank" rel="noopener noreferrer">Public Service Loan Forgiveness
                         (PSLF)</a> program, which could result in lower monthly
                         payments and eventual forgiveness of some federal
                         student loan debt. Whatever the case, the rule of thumb
@@ -818,7 +818,8 @@
                         options before your grace period ends.  Also, you have
                         the right to switch to another available repayment plan
                         at any time during the repayment of your loans. <a
-                        href="https://studentaid.ed.gov/sa/repay-loans/understand/plans" target="_blank" rel="noopener">Learn about
+                        href="https://studentaid.ed.gov/sa/repay-loans/understand/plans"
+                        target="_blank" rel="noopener noreferrer">Learn about
                         other repayment options.</a>
                     </p>
                     <h3>
@@ -843,7 +844,7 @@
                         large categories of typical expenses once you leave
                         school. They are prepopulated with data from the Bureau
                         of Labor Statistics’ <a href="http://www.bls.gov/cex/"
-                        target="_blank" rel="noopener">Consumer Expenditure (BLS
+                        target="_blank" rel="noopener noreferrer">Consumer Expenditure (BLS
                         CE) Survey</a>, based on the average expenses for
                         someone earning your projected yearly salary and living
                         in one of four broadly defined geographical regions in
@@ -933,8 +934,8 @@
                     </p>
                     <p>
                         There are also <a
-                        href="https://studentaid.ed.gov/sa/repay-loans/understand/plans" target="_blank"
-                        rel="noopener">alternative repayment plans</a> based on
+                        href="https://studentaid.ed.gov/sa/repay-loans/understand/plans"
+                        target="_blank" rel="noopener noreferrer">alternative repayment plans</a> based on
                         income and family size that we do not feature on our
                         tool. These repayment plans have lower student loan
                         payments when you have a lower salary. For instance, if
@@ -983,13 +984,13 @@
                         school’s default rate is drawn from the Department of
                         Education’s <a
                         href="https://www.nslds.ed.gov/nslds/nslds_SA/"
-                        target="_blank" rel="noopener">National Student Loan
+                        target="_blank" rel="noopener noreferrer">National Student Loan
                         Data System (NSLDS)</a>.
                     </p>
                     <p>
                         You can see other school-level data at the <a
                         href="http://nces.ed.gov/collegenavigator/"
-                        target="_blank" rel="noopener">Department of Education’s
+                        target="_blank" rel="noopener noreferrer">Department of Education’s
                         College Navigator</a>.
                     </p>
                 </section>
@@ -1035,7 +1036,7 @@
                         school. More guidance on preparing for college is
                         available at the <a
                         href="https://studentaid.ed.gov/sa/prepare-for-college"
-                        target="_blank" rel="noopener">Department of
+                        target="_blank" rel="noopener noreferrer">Department of
                         Education</a>.
                     </p>
                 </section>
@@ -1049,23 +1050,23 @@
                     </h2>
                     <div>
                         <a href="https://collegescorecard.ed.gov"
-                        target="_blank" rel="noopener">College Scorecard</a>
+                        target="_blank" rel="noopener noreferrer">College Scorecard</a>
                         <p>
                             Compare <a class="scorecard-school"
                             href="https://collegescorecard.ed.gov"
-                            target="_blank" rel="noopener">your school</a>’s
+                            target="_blank" rel="noopener noreferrer">your school</a>’s
                             annual costs, graduation rates, and post-college
                             earnings.
                         </p>
                     </div>
                     <p>
                         <a
-                         href="https://www.consumer.ftc.gov/articles/0395-choosing-college-questions-ask" target="_blank"
-                         rel="noopener">Questions to ask your college</a>
+                         href="https://www.consumer.ftc.gov/articles/0395-choosing-college-questions-ask"
+                         target="_blank" rel="noopener noreferrer">Questions to ask your college</a>
                     </p>
                     <div>
-                        <a href="https://fafsa.ed.gov/" target="_blank"
-                        rel="noopener">FAFSA&reg;</a>
+                        <a href="https://fafsa.ed.gov/"
+                        target="_blank" rel="noopener noreferrer">FAFSA&reg;</a>
                         <p>
                             Apply for federal, state, and school financial
                             aid.
@@ -1074,14 +1075,14 @@
                     <div>
                         <a
                         href="http://www.consumerfinance.gov/paying-for-college/choose-a-student-loan/"
-                        target="_blank" rel="noopener">Student loan guide</a>
+                        target="_blank" rel="noopener noreferrer">Student loan guide</a>
                         <p>
                             Choose a student loan that’s right for you.
                         </p>
                     </div>
                     <div>
                         <a href="http://www.consumerfinance.gov/paying-for-college/manage-your-college-money/"
-                        target="_blank" rel="noopener">Student banking guide</a>
+                        target="_blank" rel="noopener noreferrer">Student banking guide</a>
                         <p>
                             Manage your college money.
                         </p>

--- a/paying_for_college/templates/worksheet-old.html
+++ b/paying_for_college/templates/worksheet-old.html
@@ -1,4 +1,4 @@
-{% extends base_template %} 
+{% extends base_template %}
 {% load static from staticfiles %}
 {% block title %}Check the financial risks and rewards of a college program{% endblock %}
 
@@ -15,7 +15,7 @@
     content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-student-loans.original.png">
 {% endblock %}
 
-{% block page_viewport %}	
+{% block page_viewport %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 {% endblock %}
 
@@ -100,7 +100,7 @@ var restoredata = {{ data_js|safe }};
 		    			<p><i class="icon-left"></i><a href="/{{url_root}}/">Paying for College</a></p>
 		    		</div>
 		    		<h1 class="sub-page">Compare financial aid</h1>
-		    		<p>Compare college costs and financial aid offers to see how they might impact you down the road. Just researching schools? Check out <a class="exit-link" href="http://collegecost.ed.gov/scorecard/index.aspx" target="_blank">College Scorecard</a>.</p>
+		    		<p>Compare college costs and financial aid offers to see how they might impact you down the road. Just researching schools? Check out <a class="exit-link" href="http://collegecost.ed.gov/scorecard/index.aspx" target="_blank" rel="noopener noreferrer">College Scorecard</a>.</p>
 		    	</div>
 		    	<div class="pfc-hero-image">
 		    		<img alt="" src="{% static "paying_for_college/disclosures/images/hero_compare.png" %}">
@@ -115,7 +115,7 @@ var restoredata = {{ data_js|safe }};
 				<p></p>
 			</div>
 			<h2 class="h3 vert-pad bottom-border bold">Compare Schools</h2>
-			<span class="about-link"><a class="school-link" href="/paying-for-college/compare-financial-aid-and-college-cost/technote/" target="_blank">About this tool</a></span>
+			<span class="about-link"><a class="school-link" href="/paying-for-college/compare-financial-aid-and-college-cost/technote/" target="_blank" rel="noopener noreferrer">About this tool</a></span>
 			<div id="step-one" class="get-started step-one clearfix">
 				<div class="step-left">
 					<div class="pfc-container-left">
@@ -165,7 +165,7 @@ var restoredata = {{ data_js|safe }};
 											</label>
 										</div><!-- /get-started-radio-group -->
 										<div class="get-started-radio-group">
-											<input id="program3" class="radio-input" type="radio" name="program" value="grad">	
+											<input id="program3" class="radio-input" type="radio" name="program" value="grad">
 											<label class="prgmtype" for="program3">
 												Graduate
 											</label>
@@ -254,7 +254,7 @@ var restoredata = {{ data_js|safe }};
 									With family (little or no cost to you)
 								</label>
 							</div><!-- /get-started-radio-group -->
-			        	</fieldset>			            
+			        	</fieldset>
 			        </div><!-- /pfc-container-left -->
 			    </div><!-- /add-school /staged /stage-res-hse /step-3d3 /res-hse /step-left -->
 			    <div class="step-right">
@@ -270,7 +270,7 @@ var restoredata = {{ data_js|safe }};
 			        <div class="pfc-container-left">
 			        	<h4>Success!</h4>
 			        	<div id="success-no-data" class="success-message">
-			        		<p>You have added <span class="success-school-name"></span> to the chart below. We don’t have all the cost info for this school, but you can look up this information on <a href="" class="navigator-link" target="_blank">College Navigator</a>.</p>
+			        		<p>You have added <span class="success-school-name"></span> to the chart below. We don’t have all the cost info for this school, but you can look up this information on <a href="" class="navigator-link" target="_blank" rel="noopener noreferrer">College Navigator</a>.</p>
 			        		<p>Add another school, or continue to enter your financial aid offer below.</p>
 			       	 	</div>
 			        	<div id="success-offer-xml" class="success-message">
@@ -358,7 +358,7 @@ var restoredata = {{ data_js|safe }};
 						<td data-column="3"><div class="h6 data-total" data-nickname="firstyrcostattend">$0</div></td>
 					</tr>
 					<tr class="hide highlighted-row">
-						<td class="full" colspan="4">If you have a financial aid offer from this school, use it to enter your information here. If not, you can go to <a href="http://www.collegenavigator.gov/" target="_blank" class="exit-link">www.collegenavigator.gov</a> to look up this school’s cost of attendance info, add it to the fields below, then add more schools to see how they compare.</td>
+						<td class="full" colspan="4">If you have a financial aid offer from this school, use it to enter your information here. If not, you can go to <a href="http://www.collegenavigator.gov/" class="exit-link" target="_blank" rel="noopener noreferrer">www.collegenavigator.gov</a> to look up this school’s cost of attendance info, add it to the fields below, then add more schools to see how they compare.</td>
 					</tr>
 					<tr class="hide highlighted-row">
 						<th scope="row" data-column="0"><span class="tooltip-info" data-tooltip="Tuition &amp; Fees: Tuition and fees are what the school charges the student to participate in classes." data-tipname="tuitionfees">Tuition &amp; fees</span></th>
@@ -758,7 +758,7 @@ var restoredata = {{ data_js|safe }};
 										<td>Left to pay:</td>
 										<td data-nickname="gap" class="value">$0</td>
 									</tr>
-								</table><!-- end .bars -->		
+								</table><!-- end .bars -->
 							</div><!-- end .meter -->
 						</td>
 						<td class="bg-spacing" data-column="2">
@@ -811,7 +811,7 @@ var restoredata = {{ data_js|safe }};
 										<td>Left to pay:</td>
 										<td data-nickname="gap" class="value">$0</td>
 									</tr>
-								</table><!-- end .bars -->		
+								</table><!-- end .bars -->
 							</div><!-- end .meter -->
 						</td>
 						<td class="bg-spacing" data-column="3">
@@ -864,7 +864,7 @@ var restoredata = {{ data_js|safe }};
 										<td>Left to pay:</td>
 										<td data-nickname="gap" class="value">$0</td>
 									</tr>
-								</table><!-- end .bars -->		
+								</table><!-- end .bars -->
 							</div><!-- end .meter -->
 						</td>
 					</tr>
@@ -930,7 +930,7 @@ var restoredata = {{ data_js|safe }};
 				<tbody>
 					<tr class="bottom-border" id="indicators-row">
 						<th class="nopad-horiz" colspan="4">
-							<div class="h3 bold">School indicators (<a class="exit-link" href="http://collegecost.ed.gov/scorecard/index.aspx" target="_blank">Source</a>)</div>
+							<div class="h3 bold">School indicators (<a class="exit-link" href="http://collegecost.ed.gov/scorecard/index.aspx" target="_blank" rel="noopener noreferrer">Source</a>)</div>
 						</th>
 					</tr>
 					<tr class="school-name-row">
@@ -955,7 +955,7 @@ var restoredata = {{ data_js|safe }};
 								<div class="graduation-rate-chart">
 									<div class="gradrisk-container">
 										<span data-nickname="gradriskpercent" class="gradrisk-percent"></span><span class="gradrisk-indc cfpb_visually_hide"></span>
-										<div class="gradrisk-pointer"></div>	
+										<div class="gradrisk-pointer"></div>
 									</div>
 									<div class="gradrisk-bar">
 										<div class="low">Low</div><div class="medium">Medium</div><div class="high">High</div>
@@ -969,7 +969,7 @@ var restoredata = {{ data_js|safe }};
 								<div class="graduation-rate-chart">
 									<div class="gradrisk-container">
 										<span data-nickname="gradriskpercent" class="gradrisk-percent"></span><span class="gradrisk-indc cfpb_visually_hide"></span>
-										<div class="gradrisk-pointer"></div>	
+										<div class="gradrisk-pointer"></div>
 									</div>
 									<div class="gradrisk-bar">
 										<div class="low">Low</div><div class="medium">Medium</div><div class="high">High</div>
@@ -983,7 +983,7 @@ var restoredata = {{ data_js|safe }};
 								<div class="graduation-rate-chart">
 									<div class="gradrisk-container">
 										<span data-nickname="gradriskpercent" class="gradrisk-percent"></span><span class="gradrisk-indc cfpb_visually_hide"></span>
-										<div class="gradrisk-pointer"></div>	
+										<div class="gradrisk-pointer"></div>
 									</div>
 									<div class="gradrisk-bar">
 										<div class="low">Low</div><div class="medium">Medium</div><div class="high">High</div>
@@ -1071,7 +1071,7 @@ var restoredata = {{ data_js|safe }};
 			<h2 class="h3 vert-pad bottom-border bold">Feedback</h2>
 			<div class="feedback-container">
 				<p>What do you think about Paying for College? We're always looking to make our tools and resources better for you. Tell us how!</p>
-				<a class="feedback button school-link" target="_blank" href="/paying-for-college/compare-financial-aid-and-college-cost/feedback/">Give us Feedback</a>
+				<a class="feedback button school-link" href="/paying-for-college/compare-financial-aid-and-college-cost/feedback/" target="_blank" rel="noopener noreferrer">Give us Feedback</a>
 			</div>
 		</div><!-- end #save-footer -->
 	</div><!-- end #comparison-tool -->

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -249,7 +249,7 @@
                                 <p>
                                     <a
                                     href="/{{url_root}}/understanding-your-financial-aid-offer/about-this-tool/"
-                                    target="_blank" rel="noopener">Get details
+                                    target="_blank" rel="noopener noreferrer">Get details
                                     about how this tool works</a>
                                 </p>
                             </div>
@@ -437,8 +437,7 @@
                                                 Based on financial need,
                                                 <a
                                                 href="https://studentaid.ed.gov/sa/types/grants-scholarships/pell"
-                                                target="_blank"
-                                                rel="noopener">see how you
+                                                target="_blank" rel="noopener noreferrer">see how you
                                                 qualify</a>
                                             </p>
                                         </div>
@@ -561,8 +560,7 @@
                                                 Money for service members or
                                                 veterans that you don’t have
                                                 to pay back; <a href="https://www.vets.gov/gi-bill-comparison-tool"
-                                                target="_blank"
-                                                rel="noopener">see how much the
+                                                target="_blank" rel="noopener noreferrer">see how much the
                                                 GI Bill pays</a>
                                             </p>
                                         </div>
@@ -966,8 +964,7 @@
                                                 accumulating 9 months after you
                                                 leave school; <a
                                                 href="https://studentaid.ed.gov/sa/types/loans/perkins"
-                                                target="_blank"
-                                                rel="noopener">see
+                                                target="_blank" rel="noopener noreferrer">see
                                                 how you qualify</a>
                                             </p>
                                         </div>
@@ -2118,7 +2115,7 @@
                                             for the entire school? <a
                                             href="https://collegescorecard.ed.gov/"
                                             class="graduation-link"
-                                            target="_blank" rel="noopener">See
+                                            target="_blank" rel="noopener noreferrer">See
                                             how this school’s graduation rate
                                             compares to the national average</a>
                                         </p>
@@ -2256,7 +2253,7 @@
                                   you leave school, you are able to choose one
                                   of <a
                                   href="https://studentaid.ed.gov/sa/repay-loans/understand/plans"
-                                  target="_blank" rel="noopener">several
+                                  target="_blank" rel="noopener noreferrer">several
                                   different repayment options for your federal
                                   loans</a> that may help reduce your monthly
                                   student loan payment.
@@ -2269,7 +2266,7 @@
                                     repaying your loans, you may be able to
                                     <a
                                     href="https://www.irs.gov/uac/tax-benefits-for-education-information-center"
-                                    target="_blank" rel="noopener">reduce your
+                                    target="_blank" rel="noopener noreferrer">reduce your
                                     federal tax burden</a>. Please consult with
                                     your tax advisor.
                                 </p>
@@ -2372,7 +2369,7 @@
                                     <div>
                                         <p>
                                           <a href="https://studentaid.ed.gov/sa/repay-loans/understand/plans"
-                                          target="_blank" rel="noopener">
+                                          target="_blank" rel="noopener noreferrer">
                                             Learn about other federal repayment options
                                           </a>
                                         </p>
@@ -2399,7 +2396,7 @@
                                 <p class="content_job-placement"
                                 id="criteria_job-placement-content">
                                     Keep in mind your school has a <a
-                                    href="/{{url_root}}/understanding-your-financial-aid-offer/about-this-tool/#job-placement-rate" target="_blank" rel="noopener">job
+                                    href="/{{url_root}}/understanding-your-financial-aid-offer/about-this-tool/#job-placement-rate" target="_blank" rel="noopener noreferrer">job
                                     placement rate</a> of <span
                                     id="criteria_job-placement-rate"
                                     data-financial="jobRate"
@@ -2552,8 +2549,7 @@
                                             college)</span> in the region you
                                             plan to live (Source: <a
                                             href="http://www.bls.gov/cex/"
-                                            target="_blank"
-                                            rel="noopener">Bureau of Labor
+                                            target="_blank" rel="noopener noreferrer">Bureau of Labor
                                             Statistics</a>). Your expenses may
                                             be higher or lower.
                                         </p>
@@ -2936,7 +2932,7 @@
                                             <a
                                             href="http://nces.ed.gov/collegenavigator/"
                                             class="loan-default-link"
-                                            target="_blank" rel="noopener">See
+                                            target="_blank" rel="noopener noreferrer">See
                                             the loan default rates for the
                                             entire school</a>
                                         </p>
@@ -3049,7 +3045,7 @@
                                 </h3>
                                 <p>
                                     Consider applying for <a href="https://studentaid.ed.gov/sa/types/grants-scholarships"
-                                    target="_blank" rel="noopener">additional
+                                    target="_blank" rel="noopener noreferrer">additional
                                     scholarships and grants</a>,
                                     which provide money you don’t have to repay.
                                     By increasing the amount of this type of
@@ -3066,7 +3062,7 @@
                                     Living at home or finding cheaper off-campus
                                     housing can
                                     <a href="https://studentaid.ed.gov/sa/prepare-for-college/choosing-schools/consider/costs#lower-costs"
-                                    target="_blank" rel="noopener">reduce the
+                                    target="_blank" rel="noopener noreferrer">reduce the
                                     cost of attendance</a>, meaning you can
                                     borrow less money overall.
                                 </p>
@@ -3095,7 +3091,7 @@
                                     Make sure you don’t have to take classes twice.
                                 </h3>
                                 <p>
-                                    <a href="http://www.consumer.ftc.gov/articles/0395-choosing-college-questions-ask" target="_blank" rel="noopener">Ask if
+                                    <a href="http://www.consumer.ftc.gov/articles/0395-choosing-college-questions-ask" target="_blank" rel="noopener noreferrer">Ask if
                                         credits from your school transfer</a> to
                                         degrees earned at other schools.
                                     <span id="option_completion-rate-content">
@@ -3121,7 +3117,7 @@
                                     your educational needs.
                                     <a href="https://collegescorecard.ed.gov/"
                                     class="scorecard-link"
-                                    target="_blank" rel="noopener">
+                                    target="_blank" rel="noopener noreferrer">
                                         See all schools
                                     </a>
                                     that offer the same type of program in your
@@ -3141,8 +3137,8 @@
                                     to borrow to pay for school, resulting in
                                     long-term benefits of reducing overall debt.
                                     Check out <a
-                                    href="http://www.careeronestop.org/JobSearch/job-search.aspx" target="_blank"
-                                    rel="noopener">resources for finding a
+                                    href="http://www.careeronestop.org/JobSearch/job-search.aspx"
+                                    target="_blank" rel="noopener noreferrer">resources for finding a
                                     job</a>, including links to job search
                                     sites, tips for writing a
                                     r&eacute;sum&eacute;, and more.
@@ -3183,37 +3179,36 @@
                                     <div>
                                         <a
                                         href="https://collegescorecard.ed.gov"
-                                        target="_blank" rel="noopener">College
+                                        target="_blank" rel="noopener noreferrer">College
                                         Scorecard</a>
                                         <p>Compare <a class="scorecard-school"
-                                            href="https://collegescorecard.ed.gov" target="_blank"
-                                            rel="noopener">your
+                                            href="https://collegescorecard.ed.gov"
+                                            target="_blank" rel="noopener noreferrer">your
                                             school</a>’s annual costs,
                                             graduation rates, and post-college
                                             earnings.</p>
                                     </div>
                                     <p>
                                         <a
-                                         href="https://www.consumer.ftc.gov/articles/0395-choosing-college-questions-ask" target="_blank"
-                                         rel="noopener">Questions to ask
+                                         href="https://www.consumer.ftc.gov/articles/0395-choosing-college-questions-ask"
+                                         target="_blank" rel="noopener noreferrer">Questions to ask
                                          your college</a>
                                     </p>
                                     <div>
                                         <a href="https://fafsa.ed.gov/"
-                                        target="_blank"
-                                        rel="noopener">FAFSA&reg;</a>
+                                        target="_blank" rel="noopener noreferrer">FAFSA&reg;</a>
                                         <p>Apply for federal, state, and school
                                             financial aid.</p>
                                     </div>
                                     <div>
                                         <a href="http://www.consumerfinance.gov/paying-for-college/choose-a-student-loan/"
-                                        target="_blank" rel="noopener">Student
+                                        target="_blank" rel="noopener noreferrer">Student
                                         loan guide</a>
                                         <p>Choose a student loan that’s right
                                             for you.</p>
                                     </div>
                                     <div>
-                                        <a href="http://www.consumerfinance.gov/paying-for-college/manage-your-college-money/" target="_blank" rel="noopener">Student banking guide</a>
+                                        <a href="http://www.consumerfinance.gov/paying-for-college/manage-your-college-money/" target="_blank" rel="noopener noreferrer">Student banking guide</a>
                                         <p>Manage your college money.</p>
                                     </div>
                                 </div>
@@ -3299,7 +3294,7 @@
                     <a class="btn btn__full-small"
                     title="Give feedback on this tool"
                     href="/{{url_root}}/understanding-your-financial-aid-offer/feedback"
-                    target="_blank"
+                    target="_blank" rel="noopener noreferrer"
                     data-qa='feedback-btn'
                     data-gtm_ignore="true">
                         Tell us how

--- a/src/disclosures/js/views/links-view.js
+++ b/src/disclosures/js/views/links-view.js
@@ -38,7 +38,7 @@ var linksView = {
       var $scorecardSchool = $( '<a>', {
         'href': scorecardURL,
         'target': '_blank',
-        'rel': 'noopener',
+        'rel': 'noopener noreferrer',
         'class': this.$scorecardSchoolLink.attr( 'class' )
       } )
         .text( this.$scorecardSchoolLink.text() );
@@ -58,7 +58,7 @@ var linksView = {
       var $gradLink = $( '<a>', {
         'href': gradURL,
         'target': '_blank',
-        'rel': 'noopener',
+        'rel': 'noopener noreferrer',
         'class': this.$gradLinkText.attr( 'class' )
       } )
         .text( this.$gradLinkText.text() );
@@ -77,7 +77,7 @@ var linksView = {
       var $defaultLink = $( '<a>', {
         'href': defaultURL,
         'target': '_blank',
-        'rel': 'noopener',
+        'rel': 'noopener noreferrer',
         'class': this.$defaultLinkText.attr( 'class' )
       } )
         .text( this.$defaultLinkText.text() );
@@ -96,7 +96,7 @@ var linksView = {
       var $schoolLink = $( '<a>', {
         'href': schoolURL,
         'target': '_blank',
-        'rel': 'noopener',
+        'rel': 'noopener noreferrer',
         'class': this.$schoolLinkText.attr( 'class' )
       } )
         .text( this.$schoolLinkText.text() );


### PR DESCRIPTION
## Changes

- Adds `rel="nopener noreferrer"` to two PDF links that were missing that with `target="_blank"` (reported by @lfatty).
- Normalizes quotes to double quotes.
- Removes some extraneous whitespace.

## Testing

- Follow project installation instructions https://github.com/cfpb/college-costs#installation
