### PR TITLE
Fix migration for stand-alone usage.

### DIFF
--- a/paying_for_college/migrations/0014_migrate_url_field_to_notifications.py
+++ b/paying_for_college/migrations/0014_migrate_url_field_to_notifications.py
@@ -31,6 +31,8 @@ def forward(apps, schema_editor):
                 db_alias).get(oid=parse_url(feedback).get('oid'))
             notification.url = feedback.url
             notification.save()
+        except IndexError:
+            continue
         except ObjectDoesNotExist:
             continue
         except MultipleObjectsReturned:


### PR DESCRIPTION
This just allows local data migrations to sidestep an error that can crop up
while setting up a standalone version. It shouldn't affect any other operations.
