### PR TITLE
Change functional test parameters, update to jQuery3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8290,9 +8290,9 @@
       }
     },
     "jquery": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.11.3.tgz",
-      "integrity": "sha1-3Yt0J4snEC0p32Pq4oMIqM+htYM="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
     "jquery.easing": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "format-usd": "1.0.1",
     "fs": "0.0.2",
     "html5shiv": "3.7.3",
-    "jquery": "1.11.3",
+    "jquery": "^3.3.1",
     "jquery.easing": "1.3.2",
     "normalize-css": "2.3.1",
     "normalize-legacy-addon": "0.1.0",

--- a/test/functional/conf.js
+++ b/test/functional/conf.js
@@ -3,8 +3,8 @@ exports.config = {
   seleniumAddress: 'http://localhost:4444/wd/hub',
   capabilities: { 'browserName': 'chrome' },
   specs: ['dd-functional-settlement-spec.js', 'dd-settlement-only-spec.js', 'dd-feedback-spec.js', 'dd-school-data-spec.js', 'dd-interactions-spec.js' ],
-  // specs: ['dd-interactions-spec.js'],
-  // specs: ['dd-functional-settlement-spec.js'],
+  // By limiting the specs to one file, we can isolate and fix specific tests:
+  // specs: ['dd-settlement-only-spec.js'],
   onPrepare:function(){
     browser.ignoreSynchronization = true;
   }

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -720,7 +720,7 @@ it( 'should properly update when more than one private loans is modified', funct
   } );
 
   it( 'should properly describe a future based on covering more of the cost of college that is needed', function() {
-   browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=182111&pid=1412&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&tran=500&tuit=38976&unsl=2000&wkst=3000' );
+    browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=182111&pid=1412&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&tran=500&tuit=38976&unsl=2000&wkst=3000' );
     page.confirmVerification();
     waitForNumbers( page )
     .then( function() {

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -50,7 +50,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   } );
 
   it( 'should display the anticipated total direct cost section if passed in the URL', function() {
-    browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=981&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&totl=40000&tran=500&tuit=38976&unsl=2000&wkst=3000' );
+    // browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=981&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&totl=40000&tran=500&tuit=38976&unsl=2000&wkst=3000' );
     browser.wait(
       browser.actions().mouseMove( page.totalDirectCost ).perform(), 10000
     );
@@ -58,7 +58,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   } );
 
   it( 'should hide the anticipated total direct cost section if not passed in the URL', function() {
-    browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=981&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&tran=500&tuit=38976&unsl=2000&wkst=3000' );
+    browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=182111&pid=1412&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&tran=500&tuit=38976&unsl=2000&wkst=3000' );
     browser.wait(
       browser.actions().mouseMove( page.totalDirectCost ).perform(), 10000
     );
@@ -66,7 +66,7 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   } );
 
   it( 'should hide the anticipated total direct cost section if the passed URL value is 0', function() {
-    browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=981&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&totl=0&book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&tran=500&tuit=38976&unsl=2000&wkst=3000' );
+    browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=182111&pid=1412&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&totl=0&book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&tran=500&tuit=38976&unsl=2000&wkst=3000' );
     browser.wait(
       browser.actions().mouseMove( page.totalDirectCost ).perform(), 10000
     );
@@ -636,14 +636,14 @@ it( 'should properly update when more than one private loans is modified', funct
 */
 
   it( 'should display the tuition payment plan section if passed in the URL', function() {
-    browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=981&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&totl=40000&tran=500&tuit=38976&unsl=2000&wkst=3000' );
+    // browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=981&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&totl=40000&tran=500&tuit=38976&unsl=2000&wkst=3000' );
     page.confirmVerification();
     expect( page.paymentPlanAmount.isDisplayed() ).toBeTruthy();
     expect( page.totalPaymentPlans.isDisplayed() ).toBeTruthy();
   } );
 
   it( 'should hide the tuition payment plan section if not passed in the URL', function() {
-    browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=981&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&totl=40000&tran=500&tuit=38976&unsl=2000&wkst=3000' );
+    browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=182111&pid=1412&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&totl=40000&tran=500&tuit=38976&unsl=2000&wkst=3000' );
     page.confirmVerification();
     browser.wait(
       browser.actions().mouseMove( page.paymentPlanAmount ).perform(), 10000
@@ -653,7 +653,7 @@ it( 'should properly update when more than one private loans is modified', funct
   } );
 
   it( 'should hide the tuition payment plan section if the passed URL value is 0', function() {
-    browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=981&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&insi=0&insl=0&inst=0&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&totl=40000&tran=500&tuit=38976&unsl=2000&wkst=3000' );
+    browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=182111&pid=1412&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&insi=0&insl=0&inst=0&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&totl=40000&tran=500&tuit=38976&unsl=2000&wkst=3000' );
     page.confirmVerification();
     browser.wait(
       browser.actions().mouseMove( page.paymentPlanAmount ).perform(), 10000
@@ -722,7 +722,7 @@ it( 'should properly update when more than one private loans is modified', funct
   } );
 
   it( 'should properly describe a future based on covering more of the cost of college that is needed', function() {
-    browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=981&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&tran=500&tuit=38976&unsl=2000&wkst=3000' );
+   browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=182111&pid=1412&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&tran=500&tuit=38976&unsl=2000&wkst=3000' );
     page.confirmVerification();
     waitForNumbers( page )
     .then( function() {
@@ -743,7 +743,7 @@ it( 'should properly update when more than one private loans is modified', funct
   } );
 
   it( 'should properly describe a future based on covering exactly the cost of college that is needed', function() {
-    browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=981&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36&mta=3000&othg=100&othr=500&parl=0&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&tran=500&tuit=38976&unsl=2000&wkst=3000' );
+    browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=182111&pid=1412&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36&mta=3000&othg=100&othr=500&parl=0&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&tran=500&tuit=38976&unsl=2000&wkst=3000' );
     page.confirmVerification();
     waitForNumbers( page )
     .then( function() {

--- a/test/functional/dd-functional-settlement-spec.js
+++ b/test/functional/dd-functional-settlement-spec.js
@@ -50,7 +50,6 @@ fdescribe( 'A dynamic financial aid disclosure that\'s required by settlement', 
   } );
 
   it( 'should display the anticipated total direct cost section if passed in the URL', function() {
-    // browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=981&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&totl=40000&tran=500&tuit=38976&unsl=2000&wkst=3000' );
     browser.wait(
       browser.actions().mouseMove( page.totalDirectCost ).perform(), 10000
     );
@@ -636,7 +635,6 @@ it( 'should properly update when more than one private loans is modified', funct
 */
 
   it( 'should display the tuition payment plan section if passed in the URL', function() {
-    // browser.get( 'http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=408039&pid=981&oid=9e0280139f3238cbc9702c7b0d62e5c238a835a0&book=650&gib=3000&gpl=1000&hous=3000&insi=4.55&insl=3000&inst=36&mta=3000&othg=100&othr=500&parl=10000&pelg=1500&perl=3000&ppl=1000&prvl=3000&prvf=2.1&prvi=4.55&schg=2000&stag=2000&subl=3500&totl=40000&tran=500&tuit=38976&unsl=2000&wkst=3000' );
     page.confirmVerification();
     expect( page.paymentPlanAmount.isDisplayed() ).toBeTruthy();
     expect( page.totalPaymentPlans.isDisplayed() ).toBeTruthy();

--- a/test/functional/dd-settlement-only-spec.js
+++ b/test/functional/dd-settlement-only-spec.js
@@ -130,7 +130,7 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
     expect( page.defaultRateLink.getAttribute( 'href' ) ).toEqual( 'http://nces.ed.gov/collegenavigator/?id=182111#fedloans' );
   } );
 
-  fit( 'should open the link to the College Navigator cohort loan default rates in a new tab with the loan default rates section open', function() {
+  it( 'should open the link to the College Navigator cohort loan default rates in a new tab with the loan default rates section open', function() {
     page.confirmVerification();
     browser.sleep( 1000 );
     page.continueStep2();

--- a/test/functional/dd-settlement-only-spec.js
+++ b/test/functional/dd-settlement-only-spec.js
@@ -130,7 +130,7 @@ fdescribe( 'The dynamic financial aid disclosure', function() {
     expect( page.defaultRateLink.getAttribute( 'href' ) ).toEqual( 'http://nces.ed.gov/collegenavigator/?id=182111#fedloans' );
   } );
 
-  it( 'should open the link to the College Navigator cohort loan default rates in a new tab with the loan default rates section open', function() {
+  fit( 'should open the link to the College Navigator cohort loan default rates in a new tab with the loan default rates section open', function() {
     page.confirmVerification();
     browser.sleep( 1000 );
     page.continueStep2();


### PR DESCRIPTION
This code will update the functional tests to use a school from the default data (`collegedata.json`) rather than the test data (`test_program.json`) to avoid extra steps in making those functional tests work.

It also updates jQuery in the application from `1.11.3` to `3.3.1`.

## Changes
- Upgrade jquery to version 3+, fixing old vulnerabilities
- Change functional tests to use data from the 'collegedata' fixture, which is loaded automatically in standalone_setup.sh, rather than the 'test_program' fixture, which must be loaded manually

## Testing
- Run functional tests as outlined in the `README`.

## Review
- @chosak 
- @schbetsy 

## Notes
- Some functional tests are going to be changed in a future PR

## Todos
- One pending spec and a few other specs which test the opening of external sites will be changed to test only that links are properly inserted into the text.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
