### PR TITLE
Fixes for setup.sh and .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
 script:
 - npm config set package-lock false
 - tox
+- npm test
 - python2.7 setup.py bdist_wheel
 - ls dist/*
 - gulp lint --travis

--- a/README.md
+++ b/README.md
@@ -86,11 +86,17 @@ Python tests for this project can be run using
 [Tox](https://tox.readthedocs.io/en/latest/) with the `tox` command.
 
 #### Javascript Tests
-To run JavaScript unit tests and check for security vulnerabilities in
-Node packages (requires a [Snyk](https://snyk.io/) login):
+To run JavaScript unit tests:
 
 ```bash
 npm test
+```
+
+To check for security vulnerabilities in Node packages(requires a
+[Snyk](https://snyk.io/) login)
+
+```bash
+npm run snyk
 ```
 
 To run functional tests, **you need to make sure that you have version 4.0+ of Node.js**. Install/upgrade it using either `npm` or `brew`.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "college-costs"
   ],
   "scripts": {
-    "test": "mocha test/js-unit/ && snyk test",
+    "test": "mocha test/js-unit/",
+    "snyk": "snyk test",
     "snyk-protect": "snyk protect"
   },
   "devDependencies": {

--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,7 @@ clean(){
 install(){
   echo 'Installing project dependencies...'
   npm install
-  npm install --save --save-exact jquery.easing@1.3.2 normalize-css@2.3.1 jquery@1.11.3 normalize-legacy-addon@0.1.0
+  npm install --save --save-exact jquery.easing@1.3.2 normalize-css@2.3.1 normalize-legacy-addon@0.1.0
 }
 
 # Run tasks to build the project for distribution.

--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,6 @@ clean(){
 install(){
   echo 'Installing project dependencies...'
   npm install
-  npm install --save --save-exact jquery.easing@1.3.2 normalize-css@2.3.1 normalize-legacy-addon@0.1.0
 }
 
 # Run tasks to build the project for distribution.

--- a/src/disclosures/js/index.js
+++ b/src/disclosures/js/index.js
@@ -75,10 +75,10 @@ const app = {
 $( document ).ready( function() {
   app.init();
 
-  // The following line allows for functional testing by exposing
-  // the getFinancial method.
-  // $( '#financial-offer' ).data( 'getFinancial', getFinancial );
-  // console.log( $( '#financial-offer' ).data() );
+  /* The following line allows for functional testing by exposing
+     the getFinancial method.
+     $( '#financial-offer' ).data( 'getFinancial', getFinancial );
+     console.log( $( '#financial-offer' ).data() ); */
   window.getFinancial = getFinancial;
   window.getExpenses = getExpenses;
 } );

--- a/src/disclosures/js/views/financial-view.js
+++ b/src/disclosures/js/views/financial-view.js
@@ -813,7 +813,6 @@ const financialView = {
     if ( $win.width() >= 600 && $stickyOffers.data( 'sticky_kit' ) !== true ) {
       // Attach event handler
       $stickyOffers.trigger( 'sticky_kit:detach' );
-      console.log( 'Adding', $stickyOffers.data( 'sticky_kit' ) );
       $stickyOffers.stick_in_parent()
         .on( 'sticky_kit:bottom', function( evt ) {
           $( evt.target ).addClass( 'is_bottomed' );
@@ -823,15 +822,14 @@ const financialView = {
         } );
     } else if ( $win.width() < 600 ) {
       $stickyOffers.trigger( 'sticky_kit:detach' );
-      console.log( 'detaching:', $stickyOffers.stick_in_parent );
     }
 
     // On resize, check if event handler should be attached
     $win.on( 'resize', function( evt ) {
       clearTimeout( financialView.resizeTimer );
-        financialView.resizeTimer = setTimeout(function() {
-          financialView.stickySummariesListener();            
-        }, 250);
+      financialView.resizeTimer = setTimeout( function() {
+        financialView.stickySummariesListener();
+      }, 250 );
     } );
   },
 
@@ -869,7 +867,7 @@ const financialView = {
    */
   financialInputChangeListener: function() {
     $( '[data-financial]' ).one( 'change', function() {
-      const dataFinancial = $( this ).data( 'financial' ); 
+      const dataFinancial = $( this ).data( 'financial' );
       if ( dataFinancial ) {
         Analytics.sendEvent( getDataLayerOptions( 'Value Edited', dataFinancial ) );
       }

--- a/src/disclosures/js/views/links-view.js
+++ b/src/disclosures/js/views/links-view.js
@@ -90,7 +90,7 @@ const linksView = {
    * Creates a link in Step 3 to the school's website if the school has provided
    * a URL in the College Scorecard data
    * @param {object} values Financial model values
-   */ 
+   */
   setSchoolLink: function( values ) {
     const schoolURL = formatURL( values.url );
     if ( schoolURL ) {

--- a/src/disclosures/js/views/question-view.js
+++ b/src/disclosures/js/views/question-view.js
@@ -75,8 +75,6 @@ const questionView = {
       $answerButtons.removeClass( 'active' );
       $( this ).addClass( 'active' );
 
-console.log( 'ID! --- ' + $(this).attr( 'id' ) );
-
       if ( isSettlementStatus === true ) {
         questionView.$followupYes.hide();
         questionView.$followupNoNotSure.hide();

--- a/test/functional/conf.js
+++ b/test/functional/conf.js
@@ -4,7 +4,7 @@ exports.config = {
   capabilities: { 'browserName': 'chrome' },
   specs: ['dd-functional-settlement-spec.js', 'dd-settlement-only-spec.js', 'dd-feedback-spec.js', 'dd-school-data-spec.js', 'dd-interactions-spec.js' ],
   // By limiting the specs to one file, we can isolate and fix specific tests:
-  // specs: ['dd-settlement-only-spec.js'],
+  // specs: ['dd-interactions-spec.js'],
   onPrepare:function(){
     browser.ignoreSynchronization = true;
   }


### PR DESCRIPTION
A line in `setup.sh` was forcing a version of jQuery and overwriting the new version. This line was removed, and `npm test` was changed and added to `.travis.yml`

## Changes
- Remove the installation of specific pinned npm packages from
setup.sh. These packages are already in package.json, and should
simply be installed from there.
- Change npm test to remove snyk
- Add "npm snyk" script to run snyk
- Add "npm test" to ".travis.yml"

## Review
- @chosak 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
