### PR TITLE
Update Library Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,29 @@ apache-jmeter-3.0/bin/jmeter.sh -t college-costs/test/load_testing/Offer.jmx -Js
 
 The corresponding `Offer.csv` in `test/load_testing` specified the parameters being used for testing.  The order and name of each column is specified in the JMX file under CSV Offer.
 
+## API Docs
+
+[Documentation](https://cfpb.github.io/college-costs/) for this repository is rendered via GitHub pages and [Swagger](https://swagger.io/docs/). They can be edited in the `docs/` directory, but to view or deploy them, you'll need to install the docs dependencies listed in the `setup.py`:
+
+```
+pip install -e '.[docs]'
+```
+
+You can then preview your changes locally by running `mkdocs serve` and then reviewing <http://127.0.0.1:8000/>
+
+When your changes are ready, you can submit them as a normal pull request. After that, you can use this command to publish them:
+
+```
+mkdocs gh-deploy --clean
+```
+
+That pushes the necessary files to the `gh-pages` branch.
+
+### Notes
+
+- The `mkdocs gh-deploy` command will push any edits you've made locally to the `gh-pages` branch of the repository, whether you've committed them or not.
+- Mkdocs will create a "site" directory locally when you use either `build`, `serve` or `gh-deploy`. This is used to assemble assets to be pushed to the gh-pages branch, but the `site/` directory itself doesn't need to be under version control. It can be deleted after a deploy.
+
 ## Getting involved
 
 If you find a bug or see a way to improve the project, we'd love to hear from you. Add an issue, or fork the project and send us a pull request with your suggested changes.

--- a/paying_for_college/tests/test_models.py
+++ b/paying_for_college/tests/test_models.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf8 -*-
 import datetime
-import dateutil.parser
 import smtplib
 
 import mock
@@ -9,6 +8,7 @@ from mock import mock_open, patch
 import requests
 
 from django.test import TestCase
+from django.utils import timezone
 from paying_for_college.models import (
     School, Contact, Program, Alias, Nickname, Feedback)
 from paying_for_college.models import ConstantCap, ConstantRate, Disclosure
@@ -97,12 +97,11 @@ class SchoolModelsTest(TestCase):
     def create_notification(
             self,
             school,
-            oid='f38283b5b7c939a058889f997949efa566c616c5',
-            time='2016-01-13T20:06:18.913112+00:00'):
+            oid='f38283b5b7c939a058889f997949efa566c616c5'):
         return Notification.objects.create(
             institution=school,
             oid=oid,
-            timestamp=dateutil.parser.parse(time),
+            timestamp=timezone.now(),
             errors='none')
 
     def create_feedback(self):
@@ -338,17 +337,16 @@ class SchoolModelsTest(TestCase):
         self.assertEqual(feedback.tuition_plan, None)
 
 
-class NonSettlementNotificaion(TestCase):
+class NonSettlementNotification(TestCase):
     fixtures = ['test_fixture.json']
 
     def create_notification(self,
                             school,
-                            oid='f38283b5b7c939a058889f997949efa566c616c5',
-                            time='2016-01-13T20:06:18.913112+00:00'):
+                            oid='f38283b5b7c939a058889f997949efa566c616c5'):
         return Notification.objects.create(
             institution=school,
             oid=oid,
-            timestamp=dateutil.parser.parse(time),
+            timestamp=timezone.now(),
             errors='none')
 
     def test_nonsettlement_notification(self):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ install_requires = [
     'djangorestframework==3.6.4',
     'elasticsearch>=2.4.1,<3',
     'PyYAML>=3.11,<3.14',
-    'python-dateutil>=2.2,<3',
     'requests>=2.18,<3',
     'Unipath>=1.1,<2',
 ]

--- a/setup.py
+++ b/setup.py
@@ -10,26 +10,26 @@ setup_requires=[
 
 install_requires = [
     'Django>=1.8,<1.12',
-    'django-haystack==2.7.0',
+    'django-haystack==2.7.0',  # Latest version that supports both Django 1.8 and 1.11
     'djangorestframework==3.6.4',
-    'elasticsearch==2.4.1',
-    'PyYAML==3.11',
-    'python-dateutil==2.2',
-    'requests==2.7.0',
-    'Unipath==1.1',
+    'elasticsearch>=2.4.1,<3',
+    'PyYAML>=3.11,<3.14',
+    'python-dateutil>=2.2,<3',
+    'requests>=2.18,<3',
+    'Unipath>=1.1,<2',
 ]
 
 
 docs_extras = [
-    'Markdown==2.3.1',
+    'Markdown==2.6.9',
     'PyYAML==3.10',
     'backports-abc==0.4',
     'certifi==2016.8.2',
     'click==3.3',
     'django-livereload==1.2',
     'livereload==2.3.2',
-    'mkDOCter==1.0.3',
-    'mkdocs==0.15.3',
+    'mkDOCter==1.0.5',
+    'mkdocs==0.16.3',
     'mkdocs-bootstrap==0.1.1',
     'mkdocs-bootswatch==0.1.0',
     'singledispatch==3.4.0.3',
@@ -39,8 +39,8 @@ docs_extras = [
 
 
 testing_extras = [
-    'coverage==4.2',
-    'dj-database-url==0.4.2',
+    'coverage>=4.5.1,<5',
+    'dj-database-url>=0.4.2,<1',
     'mock==2.0.0',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-setup_requires=[
+setup_requires = [
     'cfgov-setup==1.2',
     'setuptools-git-version==1.0.3',
 ]
@@ -21,20 +21,8 @@ install_requires = [
 
 
 docs_extras = [
-    'Markdown==2.6.9',
-    'PyYAML==3.10',
-    'backports-abc==0.4',
-    'certifi==2016.8.2',
-    'click==3.3',
-    'django-livereload==1.2',
-    'livereload==2.3.2',
     'mkDOCter==1.0.5',
-    'mkdocs==0.16.3',
-    'mkdocs-bootstrap==0.1.1',
-    'mkdocs-bootswatch==0.1.0',
-    'singledispatch==3.4.0.3',
-    'six==1.9.0',
-    'tornado==4.1',
+    'mkdocs==0.17.5',
 ]
 
 


### PR DESCRIPTION
Ensure that the set of allowed versions contains the actual version that cfgov-refresh is currently on, so when we import and install this repo in cfgov, it doesn't cause version conflicts.

For most libraries, allow any revision within a major version. There are a few exceptions, especially for libraries that drop compatibility with django 1.8 without a major version bump.

## Testing

`tox -r` will run the tests on Django 1.8 and 1.11 with upgraded versions of all affected libraries.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
