### PR TITLE
Fix for missing icon files

### DIFF
--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -45,23 +45,15 @@ gulp.task( 'styles:ie', function() {
     .pipe( gulp.dest( configStyles.dest ) );
 } );
 
-gulp.task( 'styles:icons', function() {
-  let static = 'paying_for_college/static/paying_for_college/disclosures/static/';
-  return gulp.src( './node_modules/cf-icons/src/icons/*' )
-    .pipe( gulp.dest( static + 'icons/' ) );
-  
-} );
 gulp.task( 'styles:icon-fonts', function() {
   let static = 'paying_for_college/static/paying_for_college/disclosures/static/';
   return gulp.src( './node_modules/cf-icons/src/fonts/*' )
     .pipe( gulp.dest( static + 'fonts/' ) );
-  
 } );
 
 
 gulp.task( 'styles', gulp.parallel(
   'styles:modern',
   'styles:ie',
-  'styles:icons',
   'styles:icon-fonts'
 ) );

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -45,7 +45,23 @@ gulp.task( 'styles:ie', function() {
     .pipe( gulp.dest( configStyles.dest ) );
 } );
 
+gulp.task( 'styles:icons', function() {
+  let static = 'paying_for_college/static/paying_for_college/disclosures/static/';
+  return gulp.src( './node_modules/cf-icons/src/icons/*' )
+    .pipe( gulp.dest( static + 'icons/' ) );
+  
+} );
+gulp.task( 'styles:icon-fonts', function() {
+  let static = 'paying_for_college/static/paying_for_college/disclosures/static/';
+  return gulp.src( './node_modules/cf-icons/src/fonts/*' )
+    .pipe( gulp.dest( static + 'fonts/' ) );
+  
+} );
+
+
 gulp.task( 'styles', gulp.parallel(
   'styles:modern',
-  'styles:ie'
+  'styles:ie',
+  'styles:icons',
+  'styles:icon-fonts'
 ) );

--- a/src/disclosures/css/disclosures.less
+++ b/src/disclosures/css/disclosures.less
@@ -34,6 +34,10 @@
       padding-top: 0;
       padding-bottom: 0;
 
+      button.a-btn.a-btn__link {
+          border-bottom: none;
+      }
+
       // Overrides a style bleeding in from footer.css/header.css
       p:last-child {
         margin-bottom: 15px;


### PR DESCRIPTION
Due to the Capital Framework updates, icons were no longer working. Because this app is independent of `cfgov-refresh`, the necessary icon fonts are now copied during build into the static directory of this application.

## Additions
- Add gulp tasks to copy cf-icon files to static directory

## Testing
- Check out the pages locally and make sure the icons show as intended. If you have the cf-minicons font in your Font Book, be sure to disable it to test this!

## Review
- @chosak @schbetsy 

## Screenshots
Example of icons showing as intended:
<img width="579" alt="screen shot 2018-09-17 at 2 58 41 pm" src="https://user-images.githubusercontent.com/1490703/45643929-4030e700-ba8a-11e8-81be-839ed51e8a63.png">

## Checklist
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
