### PR TITLE
Include cf-icons SVGs as static assets in build

### DIFF
--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -51,9 +51,16 @@ gulp.task( 'styles:icon-fonts', function() {
     .pipe( gulp.dest( static + 'fonts/' ) );
 } );
 
+gulp.task( 'styles:icons', function() {
+  let static = 'paying_for_college/static/paying_for_college/disclosures/static/';
+  return gulp.src( './node_modules/cf-icons/src/icons/*' )
+    .pipe( gulp.dest( static + 'icons/' ) );
+} );
+
 
 gulp.task( 'styles', gulp.parallel(
   'styles:modern',
   'styles:ie',
-  'styles:icon-fonts'
+  'styles:icon-fonts',
+  'styles:icons'
 ) );

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
                    'static/paying_for_college/disclosures/static/fonts/*.svg',
                    'static/paying_for_college/disclosures/static/fonts/*.woff',
                    'static/paying_for_college/disclosures/static/fonts/*.ttf',
+                   'static/paying_for_college/disclosures/static/icons/*.svg',
                    'static/paying_for_college/disclosures/static/js/*.htc',
                    'static/paying_for_college/disclosures/static/js/*.js',
                    'static/paying_for_college/disclosures/static/js/*.map',


### PR DESCRIPTION
The use of Capital Framework cf-forms in this project requires inclusion of the cf-icons icon SVG files. This change adds a gulp copy step to copy these to the right static output folder and also includes them in the Python wheel build.

See https://github.com/cfpb/capital-framework/issues/864.