### PR TITLE
Post-Django 1.11 Upgrade Cleanup

### DIFF
--- a/paying_for_college/config/wsgi.py
+++ b/paying_for_college/config/wsgi.py
@@ -4,7 +4,7 @@ WSGI config for disclosures project.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
 """
 
 import os

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ setup_requires = [
 
 
 install_requires = [
-    'Django>=1.8,<1.12',
     'django-haystack==2.7.0',  # Latest version that supports both Django 1.8 and 1.11
     'djangorestframework==3.6.4',
+    'Django>=1.11,<1.12',
     'elasticsearch>=2.4.1,<3',
     'PyYAML>=3.11,<3.14',
     'requests>=2.18,<3',

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ setup_requires = [
 
 
 install_requires = [
-    'django-haystack==2.7.0',  # Latest version that supports both Django 1.8 and 1.11
-    'djangorestframework==3.6.4',
     'Django>=1.11,<1.12',
+    'django-haystack>=2.7,<2.9',
+    'djangorestframework>=3.6,<3.9',
     'elasticsearch>=2.4.1,<3',
     'PyYAML>=3.11,<3.14',
     'requests>=2.18,<3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=dj{18,111}
+envlist=dj{111}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -10,5 +10,4 @@ commands=
     coverage report --show-missing --skip-covered
 
 deps=
-    dj18: Django>=1.8,<1.9
     dj111: Django>=1.11,<1.12


### PR DESCRIPTION
- Update `setup.py` and `tox.ini` to reflect that we don't support Django 1.8
- Update links to Django documentation to point to current version
- Allow flexible version of djangorestframework and django-haystack

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
