### PR TITLE
Pass the offer data explicitly to the feedback form

### DIFF
--- a/paying_for_college/forms.py
+++ b/paying_for_college/forms.py
@@ -5,7 +5,6 @@ from .validators import validate_uuid4
 
 class FeedbackForm(forms.Form):
     message = forms.CharField(widget=forms.Textarea)
-    referrer = forms.CharField(widget=forms.HiddenInput)
 
 
 class EmailForm(forms.Form):

--- a/paying_for_college/models.py
+++ b/paying_for_college/models.py
@@ -370,7 +370,7 @@ class DisclosureBase(models.Model):
     def parsed_url(self):
         """parses a disclosure URL and returns a field:value dict"""
         data = {}
-        if not self.url or 'feedback' in self.url or '?' not in self.url:
+        if not self.url or '?' not in self.url:
             return data
         split_fields = self.url.replace(
             '#info-right', '').split('?')[1].split('&')

--- a/paying_for_college/templates/feedback.html
+++ b/paying_for_college/templates/feedback.html
@@ -33,7 +33,6 @@
               <form method="post" id="feedback-container">
                   <label for="id_message"><span class="demi">Enter your comments here</span></label>
                                   {% csrf_token %}
-                  <input type="hidden" name="referrer" value="{{ request.META.HTTP_REFERER }}">
                   <span class="pfc-feedback">{{ form.message }}</span>
                   <p><button>Submit your feedback</button></p>
               </form>

--- a/paying_for_college/templates/worksheet.html
+++ b/paying_for_college/templates/worksheet.html
@@ -3306,7 +3306,7 @@
                     </div>
                     <a class="a-btn a-btn__full-on-xs"
                     title="Give feedback on this tool"
-                    href="/{{url_root}}/understanding-your-financial-aid-offer/feedback"
+                    href="/{{url_root}}/understanding-your-financial-aid-offer/feedback?{{request.GET.urlencode}}"
                     target="_blank" rel="noopener noreferrer"
                     data-qa='feedback-btn'
                     data-gtm_ignore="true">

--- a/paying_for_college/tests/test_models.py
+++ b/paying_for_college/tests/test_models.py
@@ -116,7 +116,7 @@ class SchoolModelsTest(TestCase):
             created=datetime.datetime.now(),
             message='Thank you, FPO',
             url=('www.cfpb.gov/paying-for-college2/'
-                 'understanding-your-financial-aid-offer/offer/'
+                 'understanding-your-financial-aid-offer/feedback/'
                  '?iped=451796&pid=2736'
                  '&oid=1234567890123456789012345678901234567890'
                  '&book=1832&gib=0&gpl=0&hous=4431&insi=3.36&insl=4339'
@@ -288,7 +288,10 @@ class SchoolModelsTest(TestCase):
         self.assertEqual(feedback.unmet_cost, 8136)
         feedback.url = feedback.url.replace('&book=1832', '&book=voodoo')
         self.assertEqual(feedback.unmet_cost, 6304)
-        feedback.url = feedback.url.replace('offer', 'feedback')
+        feedback.url = feedback.url = (
+            'www.cfpb.gov/paying-for-college2/'
+            'understanding-your-financial-aid-offer/feedback/'
+        )
         self.assertIs(feedback.unmet_cost, None)
 
     def test_feedback_cost_error_valid_values(self):

--- a/paying_for_college/views.py
+++ b/paying_for_college/views.py
@@ -224,7 +224,7 @@ class FeedbackView(TemplateView):
         if form.is_valid():
             feedback = Feedback(
                 message=form.cleaned_data['message'][:2000],
-                url=form.cleaned_data['referrer'].replace('#info-right', ''))
+                url=request.build_absolute_uri())
             feedback.save()
             return render(request, 'feedback_thanks.html', {
                 'base_template': BASE_TEMPLATE,


### PR DESCRIPTION
The feedback form had previously acquired the offer data indirectly from the referrer URL. This change passes that data directly to the form in the form of the query string so that it can be recorded along with the message. This should fix the current issues of the referrer being blank by explicitly providing the data needed.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
