### PR TITLE
Stop the Travis from giving our wheels a dirty name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,11 @@ python:
 install:
 - pip install tox-travis
 - npm install -g gulp-cli
-- npm config set package-lock false
 - pip install coveralls tox
 script:
+- npm config set package-lock false
 - tox
 - python2.7 setup.py bdist_wheel --universal
-- npm config set package-lock false
 - npm test
 - gulp lint --travis
 - ls dist/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 install:
 - pip install tox-travis
 - npm install -g gulp-cli
+- npm config set package-lock false
 - pip install coveralls tox
 script:
 - tox


### PR DESCRIPTION
Package-lock changes during Travis builds can result in wheels with polluted names, such as:

college_costs-2.6.1.dev0+3f1ded0-py2.py3-none-any.whl

Since this repo is likely to move soon into cfgov-refresh, with its yarn build setup, it makes sense to me to let Travis sidestep package-lock.json for the time being.
