### PR TITLE
Remove legacy cfpb-icon-font CSS references

### DIFF
--- a/paying_for_college/templates/choose_a_loan.html
+++ b/paying_for_college/templates/choose_a_loan.html
@@ -22,9 +22,6 @@
 {% block page_css %}
     <link href="{% static "paying_for_college/choosealoan/css/guides.css" %}" rel="stylesheet" media="screen">
     <link href="{% static "paying_for_college/choosealoan/css/print.css" %}" rel="stylesheet" media="print">
-    <!--[if IE 7]>
-    <link rel="stylesheet" id="cfpb_icon_font_ie7-css"  href="/wp-content/themes/cfpb_nemo/_/cfpb-icon-font/css/icons-ie7.css?ver=all" type="text/css" media="all" />
-    <![endif]-->
 {% endblock %}
 
 {% block body_class %}page paying-for-college{% endblock %}

--- a/paying_for_college/templates/landing.html
+++ b/paying_for_college/templates/landing.html
@@ -23,9 +23,6 @@
 
 {% block page_css %}
     <link rel="stylesheet" href="{% static "paying_for_college/landing/css/landing.css" %}">
-    <!--[if IE 7]>
-    <link rel="stylesheet" id="cfpb_icon_font_ie7-css"  href="/wp-content/themes/cfpb_nemo/_/cfpb-icon-font/css/icons-ie7.css?ver=all" type="text/css" media="all" />
-    <![endif]-->
 {% endblock %}
 
 {% block content %}

--- a/paying_for_college/templates/manage_your_money.html
+++ b/paying_for_college/templates/manage_your_money.html
@@ -19,10 +19,6 @@
 {% block page_css %}
     <link href="{% static "paying_for_college/choosealoan/css/guides.css" %}" rel="stylesheet" media="screen">
     <link href="{% static "paying_for_college/choosealoan/css/print.css" %}" rel="stylesheet" media="print">
-    <link rel="stylesheet" id="cfpb_icon_font-css"  href="/wp-content/themes/cfpb_nemo/_/cfpb-icon-font/css/icons.css?ver=all" type="text/css" media="all">
-    <!--[if IE 7]>
-    <link rel="stylesheet" id="cfpb_icon_font_ie7-css"  href="/wp-content/themes/cfpb_nemo/_/cfpb-icon-font/css/icons-ie7.css?ver=all" type="text/css" media="all" />
-    <![endif]-->
 {% endblock %}
 
 {% block body_class %}page paying-for-college{% endblock %}

--- a/paying_for_college/templates/repay_student_debt.html
+++ b/paying_for_college/templates/repay_student_debt.html
@@ -22,10 +22,6 @@
 
 {% block page_css %}
     <link href="{% static "paying_for_college/repaystudentdebt/css/repay.css" %}" rel="stylesheet">
-    <link rel='stylesheet' id='cfpb_icon_font-css'  href="/wp-content/themes/cfpb_nemo/_/cfpb-icon-font/css/icons.css?ver=all" type="text/css" media="all">
-    <!--[if IE 7]>
-    <link rel="stylesheet" id="cfpb_icon_font_ie7-css"  href="/wp-content/themes/cfpb_nemo/_/cfpb-icon-font/css/icons-ie7.css?ver=all" type="text/css" media="all" />
-    <![endif]-->
 {% endblock %}
 
 {% block analytics_js %}


### PR DESCRIPTION
Icons should be using SVGs per https://github.com/cfpb/college-costs/pull/348, so any references to webfont icons can be removed.

## Removals

- Remove legacy cfpb-icon-font CSS references
