### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -995,6 +995,14 @@
         }
       }
     },
+    "@snyk/composer-lockfile-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@snyk/composer-lockfile-parser/-/composer-lockfile-parser-1.0.2.tgz",
+      "integrity": "sha512-kFzMajJLgWYsRTD+j1B79RckP1nYolM3UU9wJAo6VjvaBJ1R8E6IXmz0lEJBwK2zXM4EPrgk41ZqmoQS3hselQ==",
+      "requires": {
+        "lodash": "4.17.11"
+      }
+    },
     "@snyk/dep-graph": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.4.1.tgz",
@@ -1062,6 +1070,11 @@
       "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-3.0.16.tgz",
       "integrity": "sha512-lMC2G0ItF2xv4UCiwbJGbnJlIuUixHrioOhNGHSCsYCJ8l4t9hMCUimCytvFv7qy6AfSzRxhRHoGa+UqaqwyeA==",
       "dev": true
+    },
+    "@types/sinon": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.11.tgz",
+      "integrity": "sha512-6ee09Ugx6GyEr0opUIakmxIWFNmqYPjkqa3/BuxCBokA0klsOLPgMD5K4q40lH7/yZVuJVzOfQpd7pipwjngkQ=="
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
@@ -2803,20 +2816,29 @@
       }
     },
     "cf-buttons": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cf-buttons/-/cf-buttons-8.0.1.tgz",
-      "integrity": "sha512-nB8eThHgrr4qmtUXzDff9K89NNZL7u3gsnXUUyQm1DGoumvXUS7d300KgK1pGbYehclPWeqHUD/FOhz/eaBmaw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cf-buttons/-/cf-buttons-10.1.0.tgz",
+      "integrity": "sha512-Xk4lEdXZIpBIkRdfTfWRk7O2zRAjbUJ1WhH9MXQ/rhTZLZkE8ajThF9FyGwE3e3ejMNfm1WBrUXacYaZKbDXNQ==",
       "requires": {
-        "cf-core": "^8.0.1",
-        "cf-icons": "^8.0.1"
+        "cf-core": "^10.1.0",
+        "cf-icons": "^10.1.0"
       },
       "dependencies": {
-        "cf-icons": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/cf-icons/-/cf-icons-8.0.1.tgz",
-          "integrity": "sha512-5svSF9d+zjLm58Pp2cT/72A1Sz4qFRduWYUYp+G8ZENEwX5LJZMY8wNKlp88BlpXd6DrTcCpvuRkXYJfe8H1aQ==",
+        "cf-core": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/cf-core/-/cf-core-10.1.0.tgz",
+          "integrity": "sha512-KuedDp+7G1/3gsrTvbasEoSUI+hvpgwdQcqOqF93Ne8idX3cb3kQOXpgJHEnwaogWRFKjF7AUOx4EXRUC7Mrsg==",
           "requires": {
-            "cf-core": "^8.0.1"
+            "normalize-css": "^2.0.0",
+            "normalize-legacy-addon": "0.1.0"
+          }
+        },
+        "cf-icons": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/cf-icons/-/cf-icons-10.1.0.tgz",
+          "integrity": "sha512-DEiVtp7FSoOYvQ7/GRQkdPX8BqnEYHQLFblEpcGqU/Drzstpf8KUCV/loPkjviAh1VFgANJT3jBC8pgRDlMNmw==",
+          "requires": {
+            "cf-core": "^10.1.0"
           }
         }
       }
@@ -2831,22 +2853,49 @@
       }
     },
     "cf-forms": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/cf-forms/-/cf-forms-8.0.2.tgz",
-      "integrity": "sha512-WIglT7Tt3Nv8jTY0Rwj4a/T3oeA31lEvJV4cx1am53/9nf4OJ9ngEDCE9tCfGOEcHF9jnDCgd+tuNe6kuJv7ew==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/cf-forms/-/cf-forms-10.2.0.tgz",
+      "integrity": "sha512-BVgakICmqLbZ4lJhDa+jvpDvwjZhfZtWEHrVaeaujucK3nFOkdy/VnJ5VKG4Gm0e7NAQfmjiMDHgyzJAk5iEZQ==",
       "requires": {
-        "cf-buttons": "^8.0.1",
-        "cf-core": "^8.0.1",
-        "cf-grid": "^8.0.1",
-        "cf-icons": "^8.0.1"
+        "cf-buttons": "^10.1.0",
+        "cf-core": "^10.1.0",
+        "cf-grid": "^10.0.0",
+        "cf-icons": "^10.1.0"
       },
       "dependencies": {
-        "cf-icons": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/cf-icons/-/cf-icons-8.0.1.tgz",
-          "integrity": "sha512-5svSF9d+zjLm58Pp2cT/72A1Sz4qFRduWYUYp+G8ZENEwX5LJZMY8wNKlp88BlpXd6DrTcCpvuRkXYJfe8H1aQ==",
+        "cf-buttons": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/cf-buttons/-/cf-buttons-10.1.0.tgz",
+          "integrity": "sha512-Xk4lEdXZIpBIkRdfTfWRk7O2zRAjbUJ1WhH9MXQ/rhTZLZkE8ajThF9FyGwE3e3ejMNfm1WBrUXacYaZKbDXNQ==",
           "requires": {
-            "cf-core": "^8.0.1"
+            "cf-core": "^10.1.0",
+            "cf-icons": "^10.1.0"
+          }
+        },
+        "cf-core": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/cf-core/-/cf-core-10.1.0.tgz",
+          "integrity": "sha512-KuedDp+7G1/3gsrTvbasEoSUI+hvpgwdQcqOqF93Ne8idX3cb3kQOXpgJHEnwaogWRFKjF7AUOx4EXRUC7Mrsg==",
+          "requires": {
+            "normalize-css": "^2.0.0",
+            "normalize-legacy-addon": "0.1.0"
+          }
+        },
+        "cf-grid": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/cf-grid/-/cf-grid-10.0.0.tgz",
+          "integrity": "sha512-+jIACLO3MqrPp+BhzbOI3AhSlll48EhNGFh7TDtaJmZPS4xyk3GFiJNfNOCPA58ENPqb4cBS+oIHKKpS+1iqAw==",
+          "requires": {
+            "normalize-css": "^2.0.0",
+            "normalize-legacy-addon": "0.1.0"
+          }
+        },
+        "cf-icons": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/cf-icons/-/cf-icons-10.1.0.tgz",
+          "integrity": "sha512-DEiVtp7FSoOYvQ7/GRQkdPX8BqnEYHQLFblEpcGqU/Drzstpf8KUCV/loPkjviAh1VFgANJT3jBC8pgRDlMNmw==",
+          "requires": {
+            "cf-core": "^10.1.0"
           }
         }
       }
@@ -2861,17 +2910,17 @@
       }
     },
     "cf-icons": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/cf-icons/-/cf-icons-10.0.0.tgz",
-      "integrity": "sha512-tVM5PUfaFFpnmvU+NDKn3R5QYKX8mpf0xCLDNl9Co4DTQLvsLMIVIq9Alsn+xqsdFtbafrl5l0tnuykUgMf0zw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cf-icons/-/cf-icons-10.1.0.tgz",
+      "integrity": "sha512-DEiVtp7FSoOYvQ7/GRQkdPX8BqnEYHQLFblEpcGqU/Drzstpf8KUCV/loPkjviAh1VFgANJT3jBC8pgRDlMNmw==",
       "requires": {
-        "cf-core": "^10.0.0"
+        "cf-core": "^10.1.0"
       },
       "dependencies": {
         "cf-core": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/cf-core/-/cf-core-10.0.0.tgz",
-          "integrity": "sha512-NrPhzfwWv+KRnMMLYfOzuuDBsLQ80uBOdNTsYLxEvJrItLa/aXNSBJ1T+JHCxlodKFjT8e54rWf5oRaOq5DiuA==",
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/cf-core/-/cf-core-10.1.0.tgz",
+          "integrity": "sha512-KuedDp+7G1/3gsrTvbasEoSUI+hvpgwdQcqOqF93Ne8idX3cb3kQOXpgJHEnwaogWRFKjF7AUOx4EXRUC7Mrsg==",
           "requires": {
             "normalize-css": "^2.0.0",
             "normalize-legacy-addon": "0.1.0"
@@ -2889,20 +2938,21 @@
       }
     },
     "cf-typography": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cf-typography/-/cf-typography-8.0.1.tgz",
-      "integrity": "sha512-BMTa7aEKoK+2iVSple1TICwxHQ9ukS/rx7tYGPMllXSU9TA9ImbEua3ZnzrZKRW1seqDiPa6Qkn1dkzazne2RQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cf-typography/-/cf-typography-10.1.0.tgz",
+      "integrity": "sha512-kBZ4NrNXIKXsxUPEGSpjrSWhlT0VHGm7rnXO0ZUmRteMUFjrsSNUUYWs3vT6fB7LiaNaDOpG70KX8Qqtqx6BEw==",
       "requires": {
-        "cf-core": "^8.0.1",
-        "cf-icons": "^8.0.1"
+        "cf-core": "^10.1.0",
+        "cf-icons": "^10.1.0"
       },
       "dependencies": {
-        "cf-icons": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/cf-icons/-/cf-icons-8.0.1.tgz",
-          "integrity": "sha512-5svSF9d+zjLm58Pp2cT/72A1Sz4qFRduWYUYp+G8ZENEwX5LJZMY8wNKlp88BlpXd6DrTcCpvuRkXYJfe8H1aQ==",
+        "cf-core": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/cf-core/-/cf-core-10.1.0.tgz",
+          "integrity": "sha512-KuedDp+7G1/3gsrTvbasEoSUI+hvpgwdQcqOqF93Ne8idX3cb3kQOXpgJHEnwaogWRFKjF7AUOx4EXRUC7Mrsg==",
           "requires": {
-            "cf-core": "^8.0.1"
+            "normalize-css": "^2.0.0",
+            "normalize-legacy-addon": "0.1.0"
           }
         }
       }
@@ -13695,9 +13745,9 @@
       }
     },
     "snyk": {
-      "version": "1.175.2",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.175.2.tgz",
-      "integrity": "sha512-xs47Gw3rYggOeY867kGeFRzWZQFM5mwQsTla5JgKaUiEvaiyugbwRPfy6PgIcB+mYST1PaxZhzHec2UBKaOTnw==",
+      "version": "1.180.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.180.0.tgz",
+      "integrity": "sha512-jY9qp9DkO8/Ir5JDRoZQ1N3nh/HWSJ8hbrfTWZleXAEhPfKtkC5BgDNr93oyBuQqml+WHrq0CzUHI/C84alOFg==",
       "requires": {
         "@snyk/dep-graph": "1.4.1",
         "@snyk/gemfile": "1.2.0",
@@ -13720,18 +13770,18 @@
         "semver": "^6.0.0",
         "snyk-config": "^2.2.1",
         "snyk-docker-plugin": "1.25.1",
-        "snyk-go-plugin": "1.9.0",
+        "snyk-go-plugin": "1.10.2",
         "snyk-gradle-plugin": "2.12.4",
         "snyk-module": "1.9.1",
         "snyk-mvn-plugin": "2.3.0",
         "snyk-nodejs-lockfile-parser": "1.13.0",
         "snyk-nuget-plugin": "1.10.0",
-        "snyk-php-plugin": "1.5.3",
+        "snyk-php-plugin": "1.6.2",
         "snyk-policy": "1.13.5",
         "snyk-python-plugin": "1.10.2",
         "snyk-resolve": "1.0.1",
         "snyk-resolve-deps": "4.0.3",
-        "snyk-sbt-plugin": "2.2.0",
+        "snyk-sbt-plugin": "2.4.2",
         "snyk-tree": "^1.0.0",
         "snyk-try-require": "1.3.1",
         "source-map-support": "^0.5.11",
@@ -13774,22 +13824,22 @@
       }
     },
     "snyk-go-parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/snyk-go-parser/-/snyk-go-parser-1.3.0.tgz",
-      "integrity": "sha512-qXzmvPyehnrqXMqROtM2PqkvRG7AEBPDDOAywxHdumgDgMPOwOQOZj9t94halDlqb3qVTYgNTupox9kg0tqovA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/snyk-go-parser/-/snyk-go-parser-1.3.1.tgz",
+      "integrity": "sha512-jrFRfIk6yGHFeipGD66WV9ei/A/w/lIiGqI80w1ndMbg6D6M5pVNbK7ngDTmo4GdHrZDYqx/VBGBsUm2bol3Rg==",
       "requires": {
         "toml": "^3.0.0",
         "tslib": "^1.9.3"
       }
     },
     "snyk-go-plugin": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.9.0.tgz",
-      "integrity": "sha512-8keL4KKHZUXHK2R9DSaejzs4/UPokT1LsSLBxNsqxC9PJ8JSfXIErNmUCyZbCraVt3TPUbUyAfIYoekhokMgpQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.10.2.tgz",
+      "integrity": "sha512-k+f/0XgiAfnqK36L3t3EBYyMy8/vVFAU9ctHO5BztaXZXMfkYZpRsJGbvR3c7cVE4n4ruwYQhlKLM8bCuai8SQ==",
       "requires": {
         "debug": "^4.1.1",
         "graphlib": "^2.1.1",
-        "snyk-go-parser": "1.3.0",
+        "snyk-go-parser": "1.3.1",
         "tmp": "0.0.33"
       },
       "dependencies": {
@@ -13878,12 +13928,11 @@
       }
     },
     "snyk-php-plugin": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.5.3.tgz",
-      "integrity": "sha512-iZB3UpleLbeOL1D1bNLMFfh5hSflbQnepxmtXxXSD3S+euAhqJTZz/26QrsUIAtLQ2eHl3LfAXGTp6131tWyGw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.6.2.tgz",
+      "integrity": "sha512-6QM7HCmdfhuXSNGFgNOVC+GVT1Y2UfBoO+TAeV1uM1CdRGPJziz12F79a1Qyc9YGuiAwmm5DtdatUgKraC8gdA==",
       "requires": {
-        "debug": "^3.1.0",
-        "lodash": "^4.17.5"
+        "@snyk/composer-lockfile-parser": "1.0.2"
       }
     },
     "snyk-policy": {
@@ -13949,9 +13998,14 @@
       }
     },
     "snyk-sbt-plugin": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.2.0.tgz",
-      "integrity": "sha512-me/Su5J0ZVoOag3SrbfezHD6kkFymovGhZ0eK2P3T8607iWAOeGVEIbOXAAwMLSFmv8TpihQeWmnRgrCvPLfKw=="
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.4.2.tgz",
+      "integrity": "sha512-2H49mB31cLYgZRikf0lM3c8L/0rVx5W0umTpE9kjBxCRoO1cnXDipU5Kf+/U73B1hb+g6YDUP9c4zUa/s4nX1A==",
+      "requires": {
+        "@types/sinon": "7.0.11",
+        "tree-kill": "^1.2.1",
+        "tslib": "1.9.3"
+      }
     },
     "snyk-tree": {
       "version": "1.0.0",
@@ -15403,6 +15457,11 @@
           "dev": true
         }
       }
+    },
+    "tree-kill": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
+      "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q=="
     },
     "trim-newlines": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,13 +53,13 @@
     "webpack-stream": "5.0.0"
   },
   "dependencies": {
-    "cf-buttons": "^8.0.1",
+    "cf-buttons": "^10.1.0",
     "cf-core": "^8.0.1",
-    "cf-forms": "^8.0.2",
+    "cf-forms": "10.2.0",
     "cf-grid": "^8.0.1",
-    "cf-icons": "^10.0.0",
+    "cf-icons": "^10.1.0",
     "cf-layout": "^8.0.1",
-    "cf-typography": "^8.0.1",
+    "cf-typography": "^10.1.0",
     "del": "^4.1.1",
     "format-usd": "1.0.1",
     "fs": "0.0.2",
@@ -70,7 +70,7 @@
     "normalize-legacy-addon": "0.1.0",
     "number-to-words": "^1.2.4",
     "require-dir": "^1.0.0",
-    "snyk": "^1.175.2",
+    "snyk": "^1.180.0",
     "sticky-kit": "1.1.3",
     "student-debt-calc": "^2.6.5"
   },


### PR DESCRIPTION
cf-forms, cf-typography, and cf-buttons have a dependency on an older version of cf-icons that includes references to the deprecated webfont icons. This PR bumps those versions past 10.

## Changes

- Update cf-buttons, cf-forms, and cf-typography to 10.x
- Update snyk to 1.180.0

## Testing

- `npm install && gulp build` should pass.
- With college-costs as a sibling of cfgov-refresh, run `pip install -e ../college-costs/` and the urls listed in https://github.com/cfpb/college-costs/blob/master/paying_for_college/disclosures/urls.py should work and look like production.
