### PR TITLE
Add deprecation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 # Paying for College
 Tools to help students make informed financial decisions about college.
 
+## ⚠️ DEPRECATION NOTE ⚠️
+This repository is being retired, and its code has been ported to the [cfgov-refresh](https://github.com/cfpb/cfgov-refresh) repo. Code on this site will no longer be maintained, with the exception of our published documentation of [specifications for using the tool](https://cfpb.github.io/college-costs/). 
+
 ![](compare_hero.png)
 
 - **Status**:  Beta


### PR DESCRIPTION
The college-costs code now lives as part of the cfgov-refresh repo, but
we need to maintain, at least for now, the published documentation for schools
that use the settlement version of the tool.
